### PR TITLE
[CORE-327] Adding Request ID filter module

### DIFF
--- a/scg-system/src/main/java/io/telicent/core/FMod_RequestIDFilter.java
+++ b/scg-system/src/main/java/io/telicent/core/FMod_RequestIDFilter.java
@@ -1,0 +1,101 @@
+package io.telicent.core;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jena.atlas.lib.Version;
+import org.apache.jena.atlas.logging.FmtLog;
+import org.apache.jena.fuseki.Fuseki;
+import org.apache.jena.fuseki.main.FusekiServer;
+import org.apache.jena.fuseki.main.sys.FusekiModule;
+import org.apache.jena.rdf.model.Model;
+import org.slf4j.MDC;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * FMod responsible for obtaining the Request ID from the incoming request.
+ * Creating a new ID if it is missing.
+ */
+public class FMod_RequestIDFilter implements FusekiModule {
+    private static final String VERSION = Version.versionForClass(FMod_RequestIDFilter.class).orElse("<development>");
+
+    /**
+     * HTTP Header, and Logger {@link MDC} key, used to specify the Request ID associated with an HTTP Request
+     */
+    public static final String REQUEST_ID = "Request-ID";
+
+    /**
+     * The maximum possible length of a client supplied Request ID, a Request ID above this length will be truncated to
+     * this maximum.
+     */
+    public static final int MAX_CLIENT_REQUEST_ID_LENGTH = UUID.randomUUID().toString().length();
+
+    /**
+     * Use a unique starting point each time the server starts up so even if Clients are providing custom Request IDs
+     * the server will continue to append unique suffixes to them
+     */
+    private static final AtomicLong CLIENT_ID_SUFFIX = new AtomicLong(System.currentTimeMillis());
+
+    @Override
+    public String name() {
+        return "Request ID Capture ";
+    }
+
+    @Override
+    public void prepare(FusekiServer.Builder serverBuilder, Set<String> datasetNames, Model configModel) {
+        FmtLog.info(Fuseki.configLog, "Telicent Request ID Filter Module (%s)", VERSION);
+        serverBuilder.addFilter("/*", new FusekiRequestIDFilter());
+    }
+
+    private static final class FusekiRequestIDFilter implements Filter {
+
+        @Override
+        public void init(FilterConfig filterConfig) {
+            // Do nothing
+            // We explicitly configure the filter at the server setup level so no need to use the default filter
+            // behaviour of trying to automatically configure itself from init parameters
+            FmtLog.debug(Fuseki.configLog, "Initiating Telicent Request ID Filter Module");
+        }
+
+        @Override
+        public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain chain) throws
+                IOException, ServletException {
+            HttpServletRequest request = (HttpServletRequest) servletRequest;
+            HttpServletResponse response = (HttpServletResponse) servletResponse;
+
+            String requestId = request.getHeader(REQUEST_ID);
+            if (StringUtils.isNotBlank(requestId)) {
+                // If the Client provided their own Request ID we append a unique suffix each time.  This allows each
+                // request to be uniquely identified while also allowing clients to use the same Request ID for a sequence
+                // of related requests.  We impose a maximum length on the client provided ID to avoid them supplying
+                // something ridiculous and effectively allowing them to DDoS the logging.
+                if (requestId.length() > MAX_CLIENT_REQUEST_ID_LENGTH) {
+                    requestId = requestId.substring(0, MAX_CLIENT_REQUEST_ID_LENGTH);
+                }
+                requestId = requestId + "/" + CLIENT_ID_SUFFIX.incrementAndGet();
+            } else {
+                requestId = UUID.randomUUID().toString();
+            }
+            response.addHeader(REQUEST_ID, requestId);
+
+            // Place into the Logging MDC so logging patterns can include this if desired
+            MDC.put(REQUEST_ID, requestId);
+            try {
+                chain.doFilter(servletRequest, servletResponse);
+            } finally {
+                MDC.remove(REQUEST_ID);
+            }
+        }
+
+        @Override
+        public void destroy() {
+            // Do nothing
+            FmtLog.debug(Fuseki.configLog, "Destroying Telicent Request ID Filter Module");
+        }
+    }
+}

--- a/scg-system/src/main/java/io/telicent/core/SmartCacheGraph.java
+++ b/scg-system/src/main/java/io/telicent/core/SmartCacheGraph.java
@@ -84,6 +84,7 @@ public class SmartCacheGraph {
                   , new FMod_JwtServletAuth()
                   , new FMod_OpenTelemetry()
                   , new FMod_TelicentGraphQL()
+                  , new FMod_RequestIDFilter()
                   ));
         return FusekiModules.create(mods);
     }

--- a/scg-system/src/test/java/io/telicent/TestRequestIDFilter.java
+++ b/scg-system/src/test/java/io/telicent/TestRequestIDFilter.java
@@ -1,0 +1,139 @@
+package io.telicent;
+
+import io.telicent.core.SmartCacheGraph;
+import io.telicent.smart.cache.configuration.Configurator;
+import io.telicent.smart.cache.configuration.sources.PropertiesSource;
+import io.telicent.smart.caches.configuration.auth.AuthConstants;
+import org.apache.jena.fuseki.main.FusekiServer;
+import org.apache.jena.http.HttpEnv;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestRequestIDFilter {
+
+    private static final Properties AUTH_DISABLED_PROPERTIES = new Properties();
+    private static final PropertiesSource AUTH_DISABLED_SOURCE = new PropertiesSource(AUTH_DISABLED_PROPERTIES);
+
+    private static final String DATASET_NAME = "/ds";
+    private static final String REQUEST_ID = "Request-ID";
+    private static final String EXPECTED_REQUEST_ID = UUID.randomUUID().toString();
+
+    private static FusekiServer server;
+    private static URI uri;
+
+    @BeforeAll
+    static void createAndSetupFusekiServer(){
+        AUTH_DISABLED_PROPERTIES.put(AuthConstants.ENV_JWKS_URL, AuthConstants.AUTH_DISABLED);
+        Configurator.setSingleSource(AUTH_DISABLED_SOURCE);
+        server = SmartCacheGraph.smartCacheGraphBuilder()
+                                             .port(0)
+                                             .add(DATASET_NAME, DatasetGraphFactory.empty())
+                                             .build()
+                                             .start();
+
+        uri = URI.create(server.datasetURL(DATASET_NAME));
+    }
+
+    @AfterAll
+    static void stopFusekiServer(){
+        if (null != server)
+            server.stop();
+    }
+
+    @Test
+    void make_request_with_existing_id() throws IOException, InterruptedException {
+        // given
+        HttpRequest request = HttpRequest.newBuilder()
+                                         .uri(uri)
+                                         .headers(REQUEST_ID, EXPECTED_REQUEST_ID)
+                                         .GET()
+                                         .build();
+        // when
+        HttpResponse<Void> response = HttpEnv.getDftHttpClient().send(request, HttpResponse.BodyHandlers.discarding());
+        // then
+        assertEquals(200, response.statusCode());
+        Optional<String> optionalHeader =  response.headers().firstValue(REQUEST_ID);
+        assertTrue(optionalHeader.isPresent());
+        assertTrue(optionalHeader.get().startsWith(EXPECTED_REQUEST_ID));
+    }
+
+    @Test
+    void make_identical_requests_with_existing_id() throws IOException, InterruptedException {
+        // given
+        HttpRequest request = HttpRequest.newBuilder()
+                                         .uri(uri)
+                                         .headers(REQUEST_ID, EXPECTED_REQUEST_ID)
+                                         .GET()
+                                         .build();
+        // when
+        HttpResponse<Void> response = HttpEnv.getDftHttpClient().send(request, HttpResponse.BodyHandlers.discarding());
+        HttpResponse<Void> nextResponse = HttpEnv.getDftHttpClient().send(request, HttpResponse.BodyHandlers.discarding());
+        // then
+        assertEquals(200, response.statusCode());
+        Optional<String> optionalHeader =  response.headers().firstValue(REQUEST_ID);
+        assertTrue(optionalHeader.isPresent());
+        String firstResponseRequestId = optionalHeader.get();
+        assertTrue(firstResponseRequestId.startsWith(EXPECTED_REQUEST_ID));
+
+
+        assertEquals(200, response.statusCode());
+        Optional<String> nextOptionalHeader =  nextResponse.headers().firstValue(REQUEST_ID);
+        assertTrue(nextOptionalHeader.isPresent());
+        String secondResponseRequestId = nextOptionalHeader.get();
+        assertTrue(secondResponseRequestId.startsWith(EXPECTED_REQUEST_ID));
+
+        assertNotEquals(firstResponseRequestId, secondResponseRequestId);
+
+    }
+
+    @Test
+    void make_request_without_id() throws IOException, InterruptedException {
+        // given
+        HttpRequest request = HttpRequest.newBuilder()
+                                         .uri(uri)
+                                         .GET()
+                                         .build();
+        // when
+        HttpResponse<Void> response = HttpEnv.getDftHttpClient().send(request, HttpResponse.BodyHandlers.discarding());
+        // then
+        assertEquals(200, response.statusCode());
+        Optional<String> optionalHeader =  response.headers().firstValue(REQUEST_ID);
+        assertTrue(optionalHeader.isPresent());
+        String responseRequestId = optionalHeader.get();
+        assertFalse(responseRequestId.startsWith(EXPECTED_REQUEST_ID)); // It'll be randomly created
+    }
+
+    @Test
+    void make_request_with_existing_id_too_long() throws IOException, InterruptedException {
+        // given
+        String randomID = UUID.randomUUID().toString();
+        String longRequestId = randomID + EXPECTED_REQUEST_ID;
+
+        HttpRequest request = HttpRequest.newBuilder()
+                                         .uri(uri)
+                                         .headers(REQUEST_ID, longRequestId)
+                                         .GET()
+                                         .build();
+        // when
+        HttpResponse<Void> response = HttpEnv.getDftHttpClient().send(request, HttpResponse.BodyHandlers.discarding());
+        // then
+        assertEquals(200, response.statusCode());
+        Optional<String> optionalHeader =  response.headers().firstValue(REQUEST_ID);
+        assertTrue(optionalHeader.isPresent());
+        String responseRequestId = optionalHeader.get();
+        assertFalse(responseRequestId.contains(EXPECTED_REQUEST_ID));
+        assertTrue(responseRequestId.startsWith(randomID));
+    }
+}


### PR DESCRIPTION
Adding Request ID filter module to acquire the Request ID, if provided, on incoming requests and make available for logging purposes. If it's not available we create a new UUID and use that.

The code is nearly identical to SC Core's Request ID Filter ([here](https://github.com/telicent-oss/smart-caches-core/blob/main/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/filters/RequestIdFilter.java)) for obvious reasons.

Replacing the incorrectly name PR #5 