### PR TITLE
Upgrade to GraphQL 0.7.0 (CORE-355)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <ver.fuseki-kafka>1.3.2</ver.fuseki-kafka>
     <ver.jena>5.0.0</ver.jena>
     <ver.fuseki-server>${ver.jena}</ver.fuseki-server>
-    <ver.graphql>0.6.0</ver.graphql>
+    <ver.graphql>0.7.0</ver.graphql>
     <ver.testcontainers>1.19.8</ver.testcontainers>
 
     <!-- These must be in-step. -->
@@ -72,7 +72,7 @@
 
     <ver.kotlin>2.0.0</ver.kotlin>
     <ver.jwt-servlet-auth>0.15.1</ver.jwt-servlet-auth>
-    <ver.smart-caches-core>0.21.0</ver.smart-caches-core>
+    <ver.smart-caches-core>0.21.1</ver.smart-caches-core>
     <ver.slf4j>2.0.13</ver.slf4j>
     <ver.log4j2>2.23.1</ver.log4j2>
     <ver.logback>1.5.6</ver.logback>


### PR DESCRIPTION
This makes new limit and offset arguments available on the search query within the Telicent Graph Schema.

Also simplifies some of the GraphQL related implementation around auth token passing to take advantage of newer features in JWT Servlet Auth tht makes the users JWT available to us more cleanly.

# Related Issues and PRs

- Adopts the new feature from telicent-oss/graphql-jena#10
- Progress on CORE-355