### PR TITLE
Remove jackson-databind exclusion (CORE-370)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,10 +166,6 @@
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
           </exclusion>
-          <exclusion>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-          </exclusion>
         </exclusions>
       </dependency>
       <dependency>


### PR DESCRIPTION
A previous change to add dependency exclusions to minimise build warning noise had the unintentional side effect of excluding a runtime only dependency that is dynamically loaded so only shows up in the actual container and not in tests.

Removes that exclusion so the necessary dependency is now present in the container and should resolve the initialisation failure that was seen.

Deployed into System Integration and verified successful authentication, I'm seeing other errors in the Graph app but I think that's a separate configuration issue in that the Graph app appears to be adding a duplicate `/graphql` segment into the request path:

```
2024-07-29 09:21:28,867 [Server] [rob.vesse+system-integration.telicent-sandbox.admin@telicent.io] INFO  JwtAuthenticationEngine - Request to /ontology/query successfully authenticated as rob.vesse+system-integration.telicent-sandbox.admin@telicent.io
2024-07-29 09:21:28,867 [Server] [rob.vesse+system-integration.telicent-sandbox.admin@telicent.io] INFO  JwtAuthenticationEngine - Request to /knowledge/graphql/graphql successfully authenticated as rob.vesse+system-integration.telicent-sandbox.admin@telicent.io
```

# Related Issues and PRs

- This resolves CORE-370