### PR TITLE
[CORE-390] Add initial load compaction module

### DIFF
--- a/scg-system/src/main/java/io/telicent/core/FMod_InitialCompaction.java
+++ b/scg-system/src/main/java/io/telicent/core/FMod_InitialCompaction.java
@@ -1,0 +1,91 @@
+package io.telicent.core;
+
+import org.apache.jena.atlas.lib.Timer;
+import org.apache.jena.atlas.lib.Version;
+import org.apache.jena.atlas.logging.FmtLog;
+import org.apache.jena.fuseki.Fuseki;
+import org.apache.jena.fuseki.kafka.FKS;
+import org.apache.jena.fuseki.main.FusekiServer;
+import org.apache.jena.fuseki.main.sys.FusekiAutoModule;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.DatasetGraphWrapper;
+import org.apache.jena.tdb2.DatabaseMgr;
+import org.apache.jena.tdb2.sys.TDBInternal;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import static java.lang.String.format;
+
+public class FMod_InitialCompaction implements FusekiAutoModule {
+
+    public static final Logger LOG = LoggerFactory.getLogger("io.telicent.core.FMod_InitialCompaction");
+    final Set<String> datasets = new HashSet<>();
+    final boolean DELETE_OLD = true;
+    public static final String DISABLE_INITIAL_COMPACTION = "DISABLE_INITIAL_COMPACTION";
+    private static final String VERSION = Version.versionForClass(FMod_InitialCompaction.class).orElse("<development>");
+
+    @Override
+    public String name() {
+        return "Initial Compaction";
+    }
+
+    @Override
+    public void prepare(FusekiServer.Builder builder, Set<String> names, Model configModel) {
+        FmtLog.info(Fuseki.configLog, "%s Fuseki Module (%s)", name(), VERSION);
+        this.datasets.addAll(names);
+    }
+
+    /**
+     * Compact the existing TDB2 after initial data-load
+     * @param server underlying Fuseki server
+     * Note: We will only run this module at server start-up.
+     */
+    @Override
+    public void serverBeforeStarting(FusekiServer server) {
+        for (String name : datasets) {
+            Optional<DatasetGraph> optionalDatasetGraph = FKS.findDataset(server, name);
+            if (optionalDatasetGraph.isPresent()) {
+                DatasetGraph dsg = getTDB2(optionalDatasetGraph.get());
+                if (dsg != null) {
+                    FmtLog.info(LOG, format("[Initial] >>>> Start compact %s", name));
+                    Timer timer = new Timer();
+                    timer.startTimer();
+                    DatabaseMgr.compact(dsg, DELETE_OLD);
+                    FmtLog.info(LOG, format("[Initial] <<<< Finish compact %s. Took %s seconds", name, Timer.timeStr(timer.endTimer())));
+                } else {
+                    FmtLog.debug(LOG, format("Compaction not required for %s as not TDB2",name));
+                }
+            } else {
+                FmtLog.debug(LOG, format("Compaction not required for %s as no graph",name));
+            }
+        }
+
+    }
+
+    /**
+     * Check the given Graph and, if possible, return the underlying TDB2 instance
+     * @param dsg Graph
+     * @return TDB2 compatible DSG or null
+     */
+    public static DatasetGraph getTDB2(DatasetGraph dsg) {
+        for (; ;) {
+            if (IS_NOT_TDB_2.test(dsg))
+                return null;
+            if (IS_TDB_2.test(dsg))
+                return dsg;
+            if (!(dsg instanceof DatasetGraphWrapper dsgw))
+                return null;
+            dsg = dsgw.getWrapped();
+        }
+    }
+
+    private static final Predicate<DatasetGraph> IS_NOT_TDB_2 =
+            org.apache.jena.tdb1.sys.TDBInternal::isTDB1;
+    private static final Predicate<DatasetGraph> IS_TDB_2 = TDBInternal::isTDB2;
+}

--- a/scg-system/src/main/java/io/telicent/core/FMod_InitialCompaction.java
+++ b/scg-system/src/main/java/io/telicent/core/FMod_InitialCompaction.java
@@ -75,8 +75,6 @@ public class FMod_InitialCompaction implements FusekiAutoModule {
      */
     public static DatasetGraph getTDB2(DatasetGraph dsg) {
         for (; ;) {
-            if (IS_NOT_TDB_2.test(dsg))
-                return null;
             if (IS_TDB_2.test(dsg))
                 return dsg;
             if (!(dsg instanceof DatasetGraphWrapper dsgw))
@@ -85,7 +83,5 @@ public class FMod_InitialCompaction implements FusekiAutoModule {
         }
     }
 
-    private static final Predicate<DatasetGraph> IS_NOT_TDB_2 =
-            org.apache.jena.tdb1.sys.TDBInternal::isTDB1;
     private static final Predicate<DatasetGraph> IS_TDB_2 = TDBInternal::isTDB2;
 }

--- a/scg-system/src/main/java/io/telicent/core/FMod_RequestIDFilter.java
+++ b/scg-system/src/main/java/io/telicent/core/FMod_RequestIDFilter.java
@@ -3,7 +3,6 @@ package io.telicent.core;
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.atlas.lib.Version;
 import org.apache.jena.atlas.logging.FmtLog;
 import org.apache.jena.fuseki.Fuseki;
@@ -69,7 +68,7 @@ public class FMod_RequestIDFilter implements FusekiModule {
             HttpServletResponse response = (HttpServletResponse) servletResponse;
 
             String requestId = request.getHeader(REQUEST_ID);
-            if (StringUtils.isNotBlank(requestId)) {
+            if (isNotBlank(requestId)) {
                 // If the Client provided their own Request ID we append a unique suffix each time.  This allows each
                 // request to be uniquely identified while also allowing clients to use the same Request ID for a sequence
                 // of related requests.  We impose a maximum length on the client provided ID to avoid them supplying
@@ -97,5 +96,9 @@ public class FMod_RequestIDFilter implements FusekiModule {
             // Do nothing
             FmtLog.debug(Fuseki.configLog, "Destroying Telicent Request ID Filter Module");
         }
+    }
+
+    public static boolean isNotBlank(String str) {
+        return str != null && !str.trim().isEmpty();
     }
 }

--- a/scg-system/src/main/java/io/telicent/graphql/ActionTelicentGraphQL.java
+++ b/scg-system/src/main/java/io/telicent/graphql/ActionTelicentGraphQL.java
@@ -16,10 +16,6 @@
 
 package io.telicent.graphql;
 
-import java.util.Enumeration;
-import java.util.Objects;
-import java.util.function.Function;
-
 import io.telicent.jena.abac.ABAC;
 import io.telicent.jena.abac.fuseki.ABAC_Processor;
 import io.telicent.jena.abac.fuseki.ABAC_Request;
@@ -27,13 +23,12 @@ import io.telicent.jena.graphql.execution.GraphQLOverDatasetExecutor;
 import io.telicent.jena.graphql.fuseki.ActionGraphQL;
 import io.telicent.jena.graphql.schemas.telicent.graph.TelicentGraphSchema;
 import io.telicent.jena.graphql.server.model.GraphQLRequest;
-import io.telicent.servlet.auth.jwt.JwtHttpConstants;
 import io.telicent.servlet.auth.jwt.JwtServletConstants;
-import io.telicent.servlet.auth.jwt.verifier.aws.AwsConstants;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.fuseki.servlets.HttpAction;
-import org.apache.jena.riot.web.HttpNames;
 import org.apache.jena.sparql.core.DatasetGraph;
+
+import java.util.Objects;
+import java.util.function.Function;
 
 /**
  * A Fuseki action that evaluates GraphQL Requests that use the Telicent Graph schema

--- a/scg-system/src/test/java/io/telicent/AbstractBearerAuthTests.java
+++ b/scg-system/src/test/java/io/telicent/AbstractBearerAuthTests.java
@@ -30,6 +30,7 @@ public abstract class AbstractBearerAuthTests {
         FileOps.ensureDir(DIR);
         FileOps.clearAll(DIR);
         FusekiLogging.setLogging();
+        LibTestsSCG.disableInitialCompaction();
         server = launchServer("config-simple-auth.ttl");
         URL = "http://localhost:" + server.getHttpPort() + "/ds";
     }

--- a/scg-system/src/test/java/io/telicent/LibTestsSCG.java
+++ b/scg-system/src/test/java/io/telicent/LibTestsSCG.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.Jwts;
+import io.telicent.core.FMod_InitialCompaction;
 import io.telicent.servlet.auth.jwt.JwtHttpConstants;
 import io.telicent.servlet.auth.jwt.verifier.aws.AwsConstants;
 import io.telicent.servlet.auth.jwt.verifier.aws.AwsElbKeyUrlRegistry;
@@ -174,5 +175,11 @@ public class LibTestsSCG {
     /** Execute with a given logging level. */
     public static void withLevel(Logger logger, String execLevel, Runnable action) {
         CtlLogback.withLevel(logger, execLevel, action);
+    }
+
+    public static void disableInitialCompaction() {
+        Properties properties = new Properties();
+        properties.put(FMod_InitialCompaction.DISABLE_INITIAL_COMPACTION, "true");
+        Configurator.addSource(new PropertiesSource(properties));
     }
 }

--- a/scg-system/src/test/java/io/telicent/TestInitialCompaction.java
+++ b/scg-system/src/test/java/io/telicent/TestInitialCompaction.java
@@ -1,0 +1,125 @@
+package io.telicent;
+
+import io.telicent.core.FMod_InitialCompaction;
+import io.telicent.core.SmartCacheGraph;
+import io.telicent.jena.abac.core.Attributes;
+import org.apache.jena.fuseki.main.FusekiServer;
+import org.apache.jena.fuseki.system.FusekiLogging;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.tdb1.TDB1Factory;
+import org.apache.jena.tdb1.base.file.Location;
+import org.apache.jena.tdb2.DatabaseMgr;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.Set;
+
+import static io.telicent.TestSmartCacheGraphIntegration.launchServer;
+import static org.apache.jena.graph.Graph.emptyGraph;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.*;
+
+public class TestInitialCompaction {
+    private static final MockedStatic<DatabaseMgr> mockDatabaseMgr  = mockStatic(DatabaseMgr.class, Mockito.CALLS_REAL_METHODS);
+    private static FusekiServer server;
+
+    @BeforeAll
+    static void createAndSetupServerDetails() throws Exception {
+        LibTestsSCG.setupAuthentication();
+        FusekiLogging.setLogging();
+        Attributes.buildStore(emptyGraph);
+    }
+
+    @AfterEach
+    void clearDown() {
+       mockDatabaseMgr.clearInvocations();
+    }
+
+    @AfterAll
+    static void stopServer() throws Exception {
+        if (server != null) {
+            server.stop();
+        }
+        LibTestsSCG.teardownAuthentication();
+        mockDatabaseMgr.close();
+    }
+
+    @Test
+    public void test_emptyGraph() {
+        // given, when
+        server = SmartCacheGraph.construct("--port=0", "--empty").start();
+        // then
+        assertNotNull(server.serverURL());
+        mockDatabaseMgr.verify(() -> DatabaseMgr.compact(any(), anyBoolean()), times(0));
+    }
+
+    @Test
+    public void test_authMemoryDataset() {
+        // given
+        String configFile = "config-no-hierarchies.ttl";
+        // when
+        server = launchServer(configFile);
+        // then
+        assertNotNull(server.serverURL());
+        mockDatabaseMgr.verify(() -> DatabaseMgr.compact(any(), anyBoolean()), times(0));
+    }
+
+    @Test
+    public void test_persistentDataset() {
+        // given
+        String configFile = "config-persistent.ttl";
+        // when
+        server = launchServer(configFile);
+        // then
+        assertNotNull(server.serverURL());
+        mockDatabaseMgr.verify(() -> DatabaseMgr.compact(any(), anyBoolean()));
+    }
+
+    @Test
+    public void test_name() {
+        // given
+        FMod_InitialCompaction fModInitialCompaction = new FMod_InitialCompaction();
+        // when
+        String name = fModInitialCompaction.name();
+        // then
+        assertNotNull(name);
+    }
+
+    @Test
+    public void test_TDB1_DSG() {
+        // given
+        DatasetGraph tdb1_DG = TDB1Factory.createDatasetGraph(Location.mem());
+        // when
+        DatasetGraph actualDSG = FMod_InitialCompaction.getTDB2(tdb1_DG);
+        // then
+        assertNull(actualDSG);
+    }
+
+    @Test
+    public void test_noServices() {
+        // given
+        server = SmartCacheGraph.construct("--port=0", "--empty").start();
+        FMod_InitialCompaction fModInitialCompaction = new FMod_InitialCompaction();
+        // when
+        fModInitialCompaction.serverBeforeStarting(server);
+        // then
+        mockDatabaseMgr.verify(() -> DatabaseMgr.compact(any(), anyBoolean()), times(0));
+    }
+
+    @Test
+    public void test_wrongServices() {
+        // given
+        server = SmartCacheGraph.construct("--port=0", "--empty").start();
+        FMod_InitialCompaction fModInitialCompaction = new FMod_InitialCompaction();
+        fModInitialCompaction.prepare(null, Set.of("Missing", "NotThere"), null);
+        // when
+        fModInitialCompaction.serverBeforeStarting(server);
+        // then
+        mockDatabaseMgr.verify(() -> DatabaseMgr.compact(any(), anyBoolean()), times(0));
+    }
+}

--- a/scg-system/src/test/java/io/telicent/TestInitialCompaction.java
+++ b/scg-system/src/test/java/io/telicent/TestInitialCompaction.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.mockito.stubbing.Answer;
 
 import java.util.Set;
 
@@ -73,14 +72,12 @@ public class TestInitialCompaction {
     @Test
     public void test_persistentDataset() {
         // given
-        mockDatabaseMgr.when(() -> DatabaseMgr.compact(any(),anyBoolean()))
-                .thenAnswer((Answer<Void>) invocation -> null);
         String configFile = "config-persistent.ttl";
         // when
         server = launchServer(configFile);
         // then
         assertNotNull(server.serverURL());
-        mockDatabaseMgr.verify(() -> DatabaseMgr.compact(any(), anyBoolean()), times(2));
+        mockDatabaseMgr.verify(() -> DatabaseMgr.compact(any(), anyBoolean()), times(1));
     }
 
     @Test

--- a/scg-system/src/test/java/io/telicent/TestInitialCompaction.java
+++ b/scg-system/src/test/java/io/telicent/TestInitialCompaction.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
 
 import java.util.Set;
 
@@ -72,12 +73,14 @@ public class TestInitialCompaction {
     @Test
     public void test_persistentDataset() {
         // given
+        mockDatabaseMgr.when(() -> DatabaseMgr.compact(any(),anyBoolean()))
+                .thenAnswer((Answer<Void>) invocation -> null);
         String configFile = "config-persistent.ttl";
         // when
         server = launchServer(configFile);
         // then
         assertNotNull(server.serverURL());
-        mockDatabaseMgr.verify(() -> DatabaseMgr.compact(any(), anyBoolean()));
+        mockDatabaseMgr.verify(() -> DatabaseMgr.compact(any(), anyBoolean()), times(2));
     }
 
     @Test

--- a/scg-system/src/test/java/io/telicent/TestMainSmartCacheGraph.java
+++ b/scg-system/src/test/java/io/telicent/TestMainSmartCacheGraph.java
@@ -46,6 +46,7 @@ class TestMainSmartCacheGraph {
         FusekiLogging.setLogging();
         SysFusekiABAC.init();
         LibTestsSCG.teardownAuthentication();
+        LibTestsSCG.disableInitialCompaction();
     }
 
     @AfterEach

--- a/scg-system/src/test/java/io/telicent/TestPersistentSetup.java
+++ b/scg-system/src/test/java/io/telicent/TestPersistentSetup.java
@@ -61,6 +61,7 @@ public class TestPersistentSetup {
 
     @BeforeAll public static void beforeAll() throws Exception {
         LibTestsSCG.setupAuthentication();
+        LibTestsSCG.disableInitialCompaction();
         FusekiLogging.setLogging();
         FileOps.ensureDir(testArea);
     }

--- a/scg-system/src/test/java/io/telicent/otel/MetricsCollector.java
+++ b/scg-system/src/test/java/io/telicent/otel/MetricsCollector.java
@@ -23,7 +23,6 @@ import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.data.*;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.atlas.lib.NotImplemented;
 
 import java.util.Collection;
@@ -65,7 +64,7 @@ public class MetricsCollector implements MetricExporter {
         Map<AttributeKey<?>, Object> map = attributes.asMap();
         AttributesBuilder builder = Attributes.builder();
         for (Map.Entry<AttributeKey<?>, Object> entry : map.entrySet()) {
-            if (StringUtils.equals(entry.getKey().getKey(), AttributeNames.INSTANCE_ID)) {
+            if (AttributeNames.INSTANCE_ID.equals(entry.getKey().getKey())) {
                 continue;
             }
             builder.put(entry.getKey().getKey(), (String) entry.getValue());

--- a/scg-system/src/test/java/io/telicent/platform/play/MessageRequest.java
+++ b/scg-system/src/test/java/io/telicent/platform/play/MessageRequest.java
@@ -16,6 +16,10 @@
 
 package io.telicent.platform.play;
 
+import org.apache.jena.atlas.io.IO;
+import org.apache.jena.atlas.io.IOX;
+import org.apache.jena.atlas.lib.Bytes;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -24,11 +28,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
-
-import org.apache.commons.io.IOUtils;
-import org.apache.jena.atlas.io.IO;
-import org.apache.jena.atlas.io.IOX;
-import org.apache.jena.atlas.lib.Bytes;
 
 /**
  * A message is a set of headers then a body.
@@ -67,7 +66,7 @@ public class MessageRequest {
         // Consume the body to give simple interface.
         byte[] bytes;
         try {
-            bytes = IOUtils.toByteArray(input);
+            bytes = input.readAllBytes();
             return new MessageRequest(headers, bytes);
         } catch (IOException ex) {
             throw IOX.exception(ex);
@@ -123,7 +122,7 @@ public class MessageRequest {
     */
     public byte[] getBodyBytes() {
         try {
-            return IOUtils.toByteArray(bodySource);
+            return bodySource.readAllBytes();
         } catch (IOException e) {
             throw IOX.exception(e);
         }


### PR DESCRIPTION
This will ensure that the on-disk TDB2 will be compacted at server start-up. It can be disabled via environment variable should we wish to. 

Also, some minor code tidy-up. Removing some unused imports and some Commons Collection code that can be easily replaced with core code. 