### PR TITLE
fix: dumb-init add verbose to allow logging info msg

### DIFF
--- a/scg-docker/Dockerfile
+++ b/scg-docker/Dockerfile
@@ -55,4 +55,4 @@ USER fuseki
 EXPOSE 3030
 
 ENTRYPOINT [ "/usr/bin/dumb-init", "--", "./entrypoint.sh" ]
-CMD []
+CMD ["-v"]


### PR DESCRIPTION
Add -v flag to allow for info level messages to the console