### PR TITLE
bug: docker build multi-arch

### DIFF
--- a/scg-docker/Dockerfile
+++ b/scg-docker/Dockerfile
@@ -5,7 +5,7 @@
 ARG JAVA_VERSION=21
 
 ##FROM openjdk:${JAVA_VERSION}
-FROM --platform=${BUILDPLATFORM} eclipse-temurin:${JAVA_VERSION} AS smart-cache-graph
+FROM eclipse-temurin:${JAVA_VERSION} AS smart-cache-graph
 
 ARG FUSEKI_DIR=/fuseki
 


### PR DESCRIPTION
$BUILDPLATFORM — matches the current machine. (e.g. linux/amd64) only.

Causing the 'linux/arm64'  image to be reported as  `x86_64 (uname -m) ` and using the emulator as seen in `ps auxww` `/usr/bin/qemu-x86_64 /opt/java/openjdk/bin/java java ...`

it now defaults back to  `--platform=$TARGETPLATFORM`  (default value for all build stages) 