### PR TITLE
Final preparation for a 0.82.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Smart Cache Graph
 
+## 0.82.0
+
+- Upgraded GraphQL implementation to pick up a fix for intermittent "Not in a Transaction" errors during GraphQL query
+  execution
+- Upgraded JWT Servlet Auth to reduce noise level of authentication exclusion warnings about health check paths i.e.
+  `/$/ping`
+- Fuseki Kafka Connections are started after the HTTP Server is up to avoid crash restart loops when signficantly behind
+  the Kafka topic(s)
+- Database compaction happens both before the server startup and after the Kafka Connector startup to maximise
+  opportunities for compacting the databases
+- Build improvements:
+    - JWT Servlet Auth upgraded to 0.17.0
+    - GraphQL Jena upgraded to 0.9.0
+    - Protobuf upgraded to 4.28.2
+    - Smart Caches Core upgraded to 0.23.0
+    - Various build and test dependencies upgraded to latest available
+
 ## 0.81.8
 - Build improvements:
   - Upgrading RDF ABAC to 0.71.9
@@ -19,7 +36,6 @@
     - Log4j upgraded to 2.24.0
     - Logback upgraded to 1.5.8
     - Smart Caches Core upgraded to 0.22.0
-    - Various build and test dependencies upgraded to latest available
 
 ## 0.81.1
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,10 +60,10 @@
     <java.version>21</java.version>
 
     <ver.rdf-abac>0.71.9</ver.rdf-abac>
-    <ver.fuseki-kafka>1.3.5</ver.fuseki-kafka>
+    <ver.fuseki-kafka>1.4.0</ver.fuseki-kafka>
     <ver.jena>5.1.0</ver.jena>
     <ver.fuseki-server>${ver.jena}</ver.fuseki-server>
-    <ver.graphql>0.8.2</ver.graphql>
+    <ver.graphql>0.9.0</ver.graphql>
     <ver.testcontainers>1.20.1</ver.testcontainers>
 
     <!-- These must be in-step. -->
@@ -71,8 +71,8 @@
     <ver.otel-semconv>1.30.1-alpha</ver.otel-semconv>
 
     <ver.kotlin>2.0.20</ver.kotlin>
-    <ver.jwt-servlet-auth>0.16.0</ver.jwt-servlet-auth>
-    <ver.smart-caches-core>0.22.0</ver.smart-caches-core>
+    <ver.jwt-servlet-auth>0.17.0</ver.jwt-servlet-auth>
+    <ver.smart-caches-core>0.23.0</ver.smart-caches-core>
     <ver.slf4j>2.0.13</ver.slf4j>
     <ver.log4j2>2.24.0</ver.log4j2>
     <ver.logback>1.5.8</ver.logback>
@@ -81,7 +81,7 @@
     <ver.junit5-platform>1.11.0</ver.junit5-platform>
     <ver.mockito>5.13.0</ver.mockito>
 
-    <ver.protobuf>4.27.5</ver.protobuf> <!-- CVE-2024-7254 -->
+    <ver.protobuf>4.28.2</ver.protobuf> <!-- CVE-2024-7254 -->
 
     <ver.plugin.owasp-dependency-check>10.0.4</ver.plugin.owasp-dependency-check>
     <ver.plugin.compiler>3.13.0</ver.plugin.compiler>

--- a/scg-system/src/main/java/io/telicent/core/FMod_JwtServletAuth.java
+++ b/scg-system/src/main/java/io/telicent/core/FMod_JwtServletAuth.java
@@ -46,7 +46,7 @@ public class FMod_JwtServletAuth implements FusekiModule {
 
         if (jwtVerifier == null) {
             FmtLog.error(Fuseki.configLog,
-                         "Failed to configure JWT Authentication, {} environment variable was missing or contained invalid value",
+                         "Failed to configure JWT Authentication, %s environment variable was missing or contained invalid value",
                          AuthConstants.ENV_JWKS_URL);
             throw new RuntimeException("Failed to configure JWT Authentication");
         } else {

--- a/scg-system/src/main/java/io/telicent/core/MainSmartCacheGraph.java
+++ b/scg-system/src/main/java/io/telicent/core/MainSmartCacheGraph.java
@@ -62,14 +62,14 @@ public class MainSmartCacheGraph {
     public static FusekiServer build(String... args) {
         JenaSystem.init();
         FusekiLogging.markInitialized(true);
-        LOG.info(format("Smart Cache Graph: Args: %s", List.of(args)));
-        LOG.info(format("Smart Cache Graph (%s)", SmartCacheGraph.VERSION));
-        LOG.info(format("Apache Jena Fuseki (%s)", Fuseki.VERSION));
+        LOG.info("Smart Cache Graph: Args: {}", List.of(args));
+        LOG.info("Smart Cache Graph ({})", SmartCacheGraph.VERSION);
+        LOG.info("Apache Jena Fuseki ({})", Fuseki.VERSION);
         String userAttributeStore = urlUserAttributeStore();
         if ( userAttributeStore == null )
             LOG.info("No ENV_USER_ATTRIBUTES_URL setting");
         else
-            LOG.info(format("User attribute store: %s", userAttributeStore));
+            LOG.info("User attribute store: {}", userAttributeStore);
 
         // SmartCacheGraph.construct does the work of building a configured server.
         FusekiServer server = SmartCacheGraph.construct(args);


### PR DESCRIPTION
- Upgrade to latest dependencies
- Fix some logging statements that had incorrect/incomplete placeholders and/or unnecessary double `String.format()` calls
- Kafka Connectors are started after server startup to avoid crash restart loops (CORE-443)
- Initial compaction can now happen both before and after server startup to account for potential database bloat caused by initial Kafka load post startup, if a database is already maximally compacted it isn't compacted again after startup