### PR TITLE
Further improved Initial Compaction (CORE-443)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Smart Cache Graph
 
+## 0.82.1
+
+- Database compaction moved to happen potentially twice, but both after HTTP Server is up to avoid crash restart loops
+  when time consuming compactions are needed
+
 ## 0.82.0
 
 - Upgraded GraphQL implementation to pick up a fix for intermittent "Not in a Transaction" errors during GraphQL query


### PR DESCRIPTION
Further fixes to Initial Compaction logic based on observed Crash Restart loop behaviour in our dev clusters.  There are still two opportunities for compaction but both now happen after the HTTP Server is up to avoid failing readiness probes.