### PR TITLE
[CORE-441] Addressing potential security issue

### DIFF
--- a/scg-docker/Dockerfile.alpine
+++ b/scg-docker/Dockerfile.alpine
@@ -1,22 +1,20 @@
 ## Dockerfile for Smart Cache Graph
+## Specific for an Alpine deployment
 
 # syntax=docker/dockerfile:1.7
 
-
 ARG JAVA_VERSION=21
 
-FROM eclipse-temurin:${JAVA_VERSION} AS smart-cache-graph
+FROM eclipse-temurin:${JAVA_VERSION}-alpine AS smart-cache-graph
 
 ARG FUSEKI_DIR=/fuseki
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends dumb-init && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk update && \
+    apk add dumb-init
 
 WORKDIR $FUSEKI_DIR
 
-RUN useradd fuseki
+RUN addgroup -S fusekigroup && adduser -S fuseki -G fusekigroup
 
 ARG LOGS=${FUSEKI_DIR}/logs
 ARG DATA=${FUSEKI_DIR}/databases
@@ -50,7 +48,7 @@ ENV \
     JAVA_OPTIONS="-Xmx2048m -Xms2048m"  \
     FUSEKI_JAR="${FUSEKI_JAR}"          \
     FUSEKI_DIR="${FUSEKI_DIR}"          \
-    ROCKSDB_MUSL_LIBC="false"            \
+    ROCKSDB_MUSL_LIBC="true"            \
     LOG_CONFIG_FILE="/fuseki/logback.xml"
 
 USER fuseki


### PR DESCRIPTION
By setting ROCKSDB_MUSL_LIBC flag to false. 

This tells RocksDB not to check to see what C Library exists on the image in question - by checking ldd, a unix process for listing what libraries to load for file. The flag essentially says "there is no MUSL on this machine" which is RocksDB's preferred lib (for performance reasons) and forces it to use GLIBC.

Note: if we use an Alpine image, which doesn't have GLBIC and uses MUSL instead, we would obviously set this flag to true.

I have also added a specific Dockerfile for Alpine builds (Dockerfile.alpine) should we wish to use it. The image generated is about ~150Mb smaller and could be more performant - testing is required to confirm. I have updated the docker-run.sh script so that it can take an "alpine" parameter that creates an alpine image (so "0.82.4-SNAPSHOT-alpine" instead of "0.82.4-SNAPSHOT")

