### PR TITLE
[CORE-537] Addressing dumb-init warnings

### DIFF
--- a/scg-docker/Dockerfile
+++ b/scg-docker/Dockerfile
@@ -57,5 +57,5 @@ USER fuseki
 
 EXPOSE 3030
 
-ENTRYPOINT [ "/usr/bin/dumb-init", "-v", "--", "./entrypoint.sh" ]
+ENTRYPOINT [ "/usr/bin/dumb-init", "-v", "--single-child", "--", "./entrypoint.sh" ]
 CMD []

--- a/scg-docker/Dockerfile.alpine
+++ b/scg-docker/Dockerfile.alpine
@@ -55,5 +55,5 @@ USER fuseki
 
 EXPOSE 3030
 
-ENTRYPOINT [ "/usr/bin/dumb-init", "-v", "--", "./entrypoint.sh" ]
+ENTRYPOINT [ "/usr/bin/dumb-init", "-v", "--single-child", "--", "./entrypoint.sh" ]
 CMD []


### PR DESCRIPTION
Addressing dumb-init warnings by running in single-child mode.

[dumb-init] Unable to detach from controlling tty (errno=25 Inappropriate ioctl for device).
[dumb-init] Child spawned with PID 7.
[dumb-init] Unable to attach to controlling tty (errno=25 Inappropriate ioctl for device).
[dumb-init] setsid complete.