### PR TITLE
Fix missing producer config (CORE-550)

### DIFF
--- a/scg-system/src/main/java/io/telicent/core/CQRS.java
+++ b/scg-system/src/main/java/io/telicent/core/CQRS.java
@@ -77,7 +77,7 @@ public class CQRS {
     public static ActionService updateAction(String topic, Properties producerProperties) {
         Producer<String, byte[]> producer = (producerProperties == null)
                 ? null
-                : new KafkaProducer<String,byte[]>(producerProperties, new StringSerializer(), new ByteArraySerializer());
+                : new KafkaProducer<>(producerProperties, new StringSerializer(), new ByteArraySerializer());
         return new SPARQL_Update_CQRS(topic, producer, onBegin, onCommit, onAbort);
     }
 


### PR DESCRIPTION
The CQRS module created `KafkaProducer`'s only with the bootstrap.servers from the Kafka Connector meaning that if additional configuration was necessary, e.g. for a secure cluster, this was ignored and the producers would get stuck in a fail loop spamming the log with `WARN` messages about failures to connect to Kafka.  This is fixed to now simply pass the configuration across as a producer will ignore the consumer specific configuration it doesn't use but does need to share generic configuratio, like AuthN.

# Related Issues and Fixes

- Discovered while working on Kafka AuthN validation for CORE-469
- This fixes CORE-550