### PR TITLE
update fuseki-yaml-parser to 1.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
     <dependency.mockito>5.14.2</dependency.mockito>
     <dependency.testcontainers>1.20.3</dependency.testcontainers>
 
-    <dependency.yaml-config>1.0.3</dependency.yaml-config>
+    <dependency.yaml-config>1.0.4</dependency.yaml-config>
 
   </properties>
 


### PR DESCRIPTION
I just changed the yaml parser version because I want to make a new release of SCG to be able to test it. I have been unsuccessful with mounting the new fuseki-yaml-config jar in the sys-int cluster (even if I delete the statefulset I get the same permissions issues when I try to re-apply it), and testing using Rancher Desktop and k8s-desktop is insufficient because the config has to be modified to work locally. So I'm resorting to releasing SCG with the new parser version. If this is a bad idea or bad timing for a release please let me know.