### PR TITLE
[CORE-649]  Safeguard Restore operation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
 
     <!-- Logging dependencies -->
     <dependency.log4j2>2.24.3</dependency.log4j2>
-    <dependency.logback>1.5.12</dependency.logback>
+    <dependency.logback>1.5.13</dependency.logback>
     <dependency.slf4j>2.0.13</dependency.slf4j>
 
     <!-- Test dependencies -->

--- a/scg-system/src/main/java/io/telicent/backup/services/DatasetBackupService.java
+++ b/scg-system/src/main/java/io/telicent/backup/services/DatasetBackupService.java
@@ -256,12 +256,20 @@ public class DatasetBackupService {
         ObjectNode response = MAPPER.createObjectNode();
         response.put("dataset-id", datasetName);
         DataAccessPoint dataAccessPoint = dapRegistry.get("/" + datasetName);
-        if (dataAccessPoint == null) {
+        if (dataAccessPoint == null || dataAccessPoint.getDataService() == null) {
             response.put("reason", datasetName + " does not exist");
             response.put("success", false);
             return response;
         }
-        applyRestoreMethods(response, dataAccessPoint, restorePath + "/" + datasetName);
+        DatasetGraph dsg = dataAccessPoint.getDataService().getDataset();
+        try {
+            Txn.executeWrite(dsg, () -> {
+                applyRestoreMethods(response, dataAccessPoint, restorePath + "/" + datasetName);
+            });
+        } catch (RuntimeException ex) {
+            response.put("reason", ex.getMessage());
+            response.put("success", false);
+        }
         return response;
     }
 

--- a/scg-system/src/main/java/io/telicent/core/TelicentKafka.java
+++ b/scg-system/src/main/java/io/telicent/core/TelicentKafka.java
@@ -26,6 +26,7 @@ import org.apache.jena.riot.web.HttpNames;
  */
 public class TelicentKafka {
 
+    private TelicentKafka(){}
     /**
      * Request-Id : Unique ID for the request (UUID).
      */

--- a/scg-system/src/test/java/io/telicent/TestRequestIDFilter.java
+++ b/scg-system/src/test/java/io/telicent/TestRequestIDFilter.java
@@ -1,5 +1,6 @@
 package io.telicent;
 
+import io.telicent.core.FMod_RequestIDFilter;
 import io.telicent.core.SmartCacheGraph;
 import io.telicent.smart.cache.configuration.Configurator;
 import io.telicent.smart.cache.configuration.sources.PropertiesSource;
@@ -7,6 +8,7 @@ import io.telicent.smart.caches.configuration.auth.AuthConstants;
 import org.apache.jena.fuseki.main.FusekiServer;
 import org.apache.jena.http.HttpEnv;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
+import org.junit.Assert;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -137,5 +139,24 @@ public class TestRequestIDFilter {
         String responseRequestId = optionalHeader.get();
         assertFalse(responseRequestId.contains(EXPECTED_REQUEST_ID));
         assertTrue(responseRequestId.startsWith(randomID));
+    }
+
+    @Test
+    void name_happyPath() {
+        // given
+        String expected = "Request ID Capture ";
+        FMod_RequestIDFilter fModRequestIDFilter = new FMod_RequestIDFilter();
+        // when
+        String actual = fModRequestIDFilter.name();
+        // then
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    void test_isBlank() {
+        // given
+        // when
+        // then
+        assertFalse(FMod_RequestIDFilter.isNotBlank("  "));
     }
 }

--- a/scg-system/src/test/java/io/telicent/backup/services/TestDatasetBackupService.java
+++ b/scg-system/src/test/java/io/telicent/backup/services/TestDatasetBackupService.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.telicent.backup.utils.BackupUtils;
 import io.telicent.jena.abac.ABAC;
 import io.telicent.jena.abac.core.DatasetGraphABAC;
+import io.telicent.jena.abac.labels.LabelsStoreMem;
 import io.telicent.jena.abac.labels.LabelsStoreRocksDB;
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.HttpServletRequest;
@@ -579,9 +580,13 @@ public class TestDatasetBackupService {
         assertTrue(labelsDir.mkdir());
         labelsDir.deleteOnExit();
 
+        LabelsStoreRocksDB mockRocksDbLabelStore = mock(LabelsStoreRocksDB.class);
+        when(mockRocksDbLabelStore.getTransactional()).thenReturn(DatasetGraphFactory.createTxnMem());
+
+
         DatasetGraphABAC dsgABAC = ABAC.authzDataset(DatasetGraphFactory.createTxnMem(),
                 null,
-                mock(LabelsStoreRocksDB.class),
+                mockRocksDbLabelStore,
                 null,
                 null);
         DataAccessPoint dap = new DataAccessPoint("dataset-name", DataService.newBuilder().dataset(dsgABAC).build());
@@ -634,7 +639,7 @@ public class TestDatasetBackupService {
         assertTrue(tdbFile.createNewFile());
         tdbFile.deleteOnExit();
 
-        DataAccessPoint dap = new DataAccessPoint("dataset-name", DataService.newBuilder().build());
+        DataAccessPoint dap = new DataAccessPoint("dataset-name", DataService.newBuilder().dataset(DatasetGraphFactory.createTxnMem()).build());
 
         when(mockRegistry.get("/dataset-name")).thenReturn(dap);
 
@@ -668,6 +673,111 @@ public class TestDatasetBackupService {
 
 
     @Test
+    public void test_restoreDatasets_exception() throws IOException {
+        // given
+        String restoreID = "restore";
+        File newDir = new File(baseDir.toString() + "/" + restoreID);
+        assertTrue(newDir.mkdir());
+        newDir.deleteOnExit();
+
+        String datasetName = "dataset-name";
+        File newDataset = new File(newDir + "/" + datasetName);
+        assertTrue(newDataset.mkdir());
+        newDataset.deleteOnExit();
+
+        File tdbDir = new File(newDataset + "/tdb/");
+        assertTrue(tdbDir.mkdir());
+        tdbDir.deleteOnExit();
+
+        File tdbFile = new File(newDataset + "/tdb/" + datasetName + "_backup.nq.gz");
+        assertTrue(tdbFile.createNewFile());
+        tdbFile.deleteOnExit();
+
+        File labelsDir = new File(newDataset + "/labels/");
+        assertTrue(labelsDir.mkdir());
+        labelsDir.deleteOnExit();
+
+        LabelsStoreRocksDB mockRocksDbLabelStore = mock(LabelsStoreRocksDB.class);
+        when(mockRocksDbLabelStore.getTransactional()).thenReturn(DatasetGraphFactory.createTxnMem());
+
+        DatasetGraphABAC dsgABAC = ABAC.authzDataset(DatasetGraphFactory.createTxnMem(),
+                null,
+                mockRocksDbLabelStore,
+                null,
+                null);
+        DataAccessPoint dap = new DataAccessPoint("dataset-name", DataService.newBuilder().build());
+
+        when(mockRegistry.get("/dataset-name")).thenReturn(dap);
+
+        DatasetBackupService_Test.setupExceptionForMethod(RESTORE_TDB, "Failure");
+        DatasetBackupService_Test.setupExceptionForMethod(RESTORE_LABELS, "Failure");
+
+        // when
+        ObjectNode result = cut.restoreDatasets(restoreID);
+
+        // then
+        assertTrue(result.has("restorePath"));
+        assertFalse(result.has("success"));
+        assertTrue(result.has(datasetName));
+        JsonNode dataset = result.get(datasetName);
+        assertTrue(dataset.has("dataset-id"));
+        assertEquals(dataset.get("dataset-id").asText(), datasetName);
+
+        assertEquals(0, DatasetBackupService_Test.getCallCount(RESTORE_TDB));
+        assertEquals(0, DatasetBackupService_Test.getCallCount(RESTORE_LABELS));
+    }
+
+    @Test
+    public void test_restoreDatasets_invalidDataAccessPoint() throws IOException {
+        // given
+        String restoreID = "restore";
+        File newDir = new File(baseDir.toString() + "/" + restoreID);
+        assertTrue(newDir.mkdir());
+        newDir.deleteOnExit();
+
+        String datasetName = "dataset-name";
+        File newDataset = new File(newDir + "/" + datasetName);
+        assertTrue(newDataset.mkdir());
+        newDataset.deleteOnExit();
+
+        File tdbDir = new File(newDataset + "/tdb/");
+        assertTrue(tdbDir.mkdir());
+        tdbDir.deleteOnExit();
+
+        File tdbFile = new File(newDataset + "/tdb/" + datasetName + "_backup.nq.gz");
+        assertTrue(tdbFile.createNewFile());
+        tdbFile.deleteOnExit();
+
+        File labelsDir = new File(newDataset + "/labels/");
+        assertTrue(labelsDir.mkdir());
+        labelsDir.deleteOnExit();
+
+        LabelsStoreRocksDB mockRocksDbLabelStore = mock(LabelsStoreRocksDB.class);
+        when(mockRocksDbLabelStore.getTransactional()).thenReturn(DatasetGraphFactory.createTxnMem());
+
+        DataAccessPoint mockDAP = mock(DataAccessPoint.class);
+
+        when(mockRegistry.get("/dataset-name")).thenReturn(mockDAP);
+
+        DatasetBackupService_Test.setupExceptionForMethod(RESTORE_TDB, "Failure");
+        DatasetBackupService_Test.setupExceptionForMethod(RESTORE_LABELS, "Failure");
+
+        // when
+        ObjectNode result = cut.restoreDatasets(restoreID);
+
+        // then
+        assertTrue(result.has("restorePath"));
+        assertFalse(result.has("success"));
+        assertTrue(result.has(datasetName));
+        JsonNode dataset = result.get(datasetName);
+        assertTrue(dataset.has("dataset-id"));
+        assertEquals(dataset.get("dataset-id").asText(), datasetName);
+
+        assertEquals(0, DatasetBackupService_Test.getCallCount(RESTORE_TDB));
+        assertEquals(0, DatasetBackupService_Test.getCallCount(RESTORE_LABELS));
+    }
+
+    @Test
     public void test_restoreDatasets_abac_dsg_not_rocksdb() throws IOException {
         // given
         String restoreID = "restore";
@@ -690,7 +800,7 @@ public class TestDatasetBackupService {
 
         DatasetGraphABAC dsgABAC = ABAC.authzDataset(DatasetGraphFactory.createTxnMem(),
                 null,
-                null,
+                LabelsStoreMem.create(),
                 null,
                 null);
         DataAccessPoint dap = new DataAccessPoint("dataset-name", DataService.newBuilder().dataset(dsgABAC).build());
@@ -750,9 +860,12 @@ public class TestDatasetBackupService {
         assertTrue(labelsDir.mkdir());
         labelsDir.deleteOnExit();
 
+        LabelsStoreRocksDB mockRocksDbLabelStore = mock(LabelsStoreRocksDB.class);
+        when(mockRocksDbLabelStore.getTransactional()).thenReturn(DatasetGraphFactory.createTxnMem());
+
         DatasetGraphABAC dsgABAC = ABAC.authzDataset(DatasetGraphFactory.createTxnMem(),
                 null,
-                mock(LabelsStoreRocksDB.class),
+                mockRocksDbLabelStore,
                 null,
                 null);
         DataAccessPoint dap = new DataAccessPoint("dataset-name", DataService.newBuilder().dataset(dsgABAC).build());
@@ -800,9 +913,12 @@ public class TestDatasetBackupService {
         assertTrue(newDataset.mkdir());
         newDataset.deleteOnExit();
 
+        LabelsStoreRocksDB mockRocksDbLabelStore = mock(LabelsStoreRocksDB.class);
+        when(mockRocksDbLabelStore.getTransactional()).thenReturn(DatasetGraphFactory.createTxnMem());
+
         DatasetGraphABAC dsgABAC = ABAC.authzDataset(DatasetGraphFactory.createTxnMem(),
                 null,
-                mock(LabelsStoreRocksDB.class),
+                mockRocksDbLabelStore,
                 null,
                 null);
         DataAccessPoint dap = new DataAccessPoint("dataset-name", DataService.newBuilder().dataset(dsgABAC).build());
@@ -1051,6 +1167,22 @@ public class TestDatasetBackupService {
             executorService.awaitTermination(1, TimeUnit.SECONDS);
         }
         verify(response, times(1)).setStatus(409);
+    }
+
+    @Test
+    public void test_process_exception() throws IOException {
+        // given
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        ServletOutputStream outputStream = mock(ServletOutputStream.class);
+        when(response.getOutputStream()).thenReturn(outputStream);
+        doThrow(new RuntimeException("Test")).when(request).getPathInfo();
+
+        // when
+        cut.process(request, response, true);
+
+        // then
+        verify(response, times(1)).setStatus(500);
     }
 
     public void doNothing(DataAccessPoint dataAccessPoint, String path, ObjectNode resultNode) {

--- a/scg-system/src/test/java/io/telicent/otel/TestJenaMetrics.java
+++ b/scg-system/src/test/java/io/telicent/otel/TestJenaMetrics.java
@@ -55,6 +55,7 @@ import org.apache.jena.fuseki.system.FusekiLogging;
 import org.apache.jena.http.HttpEnv;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.apache.jena.sys.JenaSystem;
+import org.junit.Assert;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -335,5 +336,16 @@ class TestJenaMetrics {
             HttpResponse<Void> response = HttpEnv.getDftHttpClient().send(request, HttpResponse.BodyHandlers.discarding());
 //            server.join();
         } finally { server.stop(); }
+    }
+
+    @Test
+    void name_happyPath() {
+        // given
+        String expected = "FMod_OpenTelemetry";
+        FMod_OpenTelemetry fModOpenTelemetry = new FMod_OpenTelemetry();
+        // when
+        String actual = fModOpenTelemetry.name();
+        // then
+        Assert.assertEquals(expected, actual);
     }
 }


### PR DESCRIPTION
Wrap restore operation in transaction lock to ensure that we do not invalidate the underlying data stores by processing updates. In particular, we are at risk of the kafka batch processing exposing the Rocks DB during it's transition and corrupting it.  This addresses that. 

I've tested it as best I can and am confident it works i.e. I cannot break it locally.  

I've also shored up some test coverage. 