### PR TITLE
[CORE-679] Sanitise the dataset names 

### DIFF
--- a/scg-system/src/main/java/io/telicent/core/FMod_FusekiKafkaSCG.java
+++ b/scg-system/src/main/java/io/telicent/core/FMod_FusekiKafkaSCG.java
@@ -40,6 +40,7 @@ import org.apache.jena.kafka.common.PersistentState;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.sparql.core.DatasetGraph;
 
+import static io.telicent.backup.services.DatasetBackupService.sanitiseName;
 import static org.apache.jena.kafka.FusekiKafka.LOG;
 
 /**
@@ -117,7 +118,8 @@ public class FMod_FusekiKafkaSCG extends FMod_FusekiKafka {
         String dataset = dataAccessPoint.getName();
         KConnectorDesc conn = connectors.get(dataset);
         if (conn != null) {
-            String filename = path + "/" + dataset + ".json";
+            String sanitizedDataset = sanitiseName(dataset);
+            String filename = path + "/" + sanitizedDataset + ".json";
             IOX.copy(conn.getStateFile(), filename);
             resultNode.put("source", conn.getStateFile());
             resultNode.put("destination", filename);
@@ -133,7 +135,8 @@ public class FMod_FusekiKafkaSCG extends FMod_FusekiKafka {
     public void restoreKafka(DataAccessPoint dataAccessPoint, String path, ObjectNode resultNode) {
         String dataset = dataAccessPoint.getName();
         if (connectors.get(dataset) != null) {
-            String filename = path + "/" + dataset + ".json";
+            String sanitizedDataset = sanitiseName(dataset);
+            String filename = path + "/" + sanitizedDataset + ".json";
             PersistentState persistentState = new PersistentState(filename);
             if ( persistentState.getBytes().length == 0 ) {
                 String errorMessage = String.format("Unable to restore Kafka for dataset (%s) as restore file (%s) not suitable. ", dataset, filename);

--- a/scg-system/src/main/java/io/telicent/otel/FMod_OpenTelemetry.java
+++ b/scg-system/src/main/java/io/telicent/otel/FMod_OpenTelemetry.java
@@ -119,7 +119,12 @@ public class FMod_OpenTelemetry implements FusekiModule {
         }
     }
 
-    private static String fixupName(String name) {
+    /**
+     * Take a filename string and replace any troublesome characters
+     * @param name to be cleaned
+     * @return a cleaned filename
+     */
+    public static String fixupName(String name) {
         name = name.replace(' ', '_');
         name = name.replace('/', '_');
         name = name.replace('(', '-');

--- a/scg-system/src/test/java/io/telicent/backup/services/TestDatasetBackupService.java
+++ b/scg-system/src/test/java/io/telicent/backup/services/TestDatasetBackupService.java
@@ -48,7 +48,6 @@ import static io.telicent.backup.services.DatasetBackupService_Test.*;
 import static io.telicent.backup.utils.BackupUtils.MAPPER;
 import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 public class TestDatasetBackupService {
@@ -183,7 +182,7 @@ public class TestDatasetBackupService {
     @Test
     public void test_backup_happyPath_abac_rocksDB_labels() {
         // given
-        String datasetName = "/dataset-name";
+        String datasetName = "dataset-name";
         DatasetGraphABAC dsgABAC = ABAC.authzDataset(DatasetGraphFactory.createTxnMem(),
                 null,
                 mock(LabelsStoreRocksDB.class),
@@ -225,8 +224,8 @@ public class TestDatasetBackupService {
     @Test
     public void test_backup_happyPath_abac_rocksDB_labels_noID() {
         // given
-        String datasetName = "/dataset-name";
-        String datasetName2 = "/dataset-include";
+        String datasetName = "dataset-name";
+        String datasetName2 = "dataset-include";
         DatasetGraphABAC dsgABAC = ABAC.authzDataset(DatasetGraphFactory.createTxnMem(),
                 null,
                 mock(LabelsStoreRocksDB.class),
@@ -284,7 +283,7 @@ public class TestDatasetBackupService {
     @Test
     public void test_backup_happyPath_tdb_only() {
         // given
-        String datasetName = "/dataset-name";
+        String datasetName = "dataset-name";
         DataAccessPoint dap = new DataAccessPoint("dataset-name", DataService.newBuilder().build());
         when(mockRegistry.accessPoints()).thenReturn(List.of(dap));
 
@@ -320,7 +319,7 @@ public class TestDatasetBackupService {
     @Test
     public void test_backup_happyPath_abac_not_rocksDB() {
         // given
-        String datasetName = "/dataset-name";
+        String datasetName = "dataset-name";
         DatasetGraphABAC dsgABAC = ABAC.authzDataset(DatasetGraphFactory.createTxnMem(),
                 null,
                 null,
@@ -362,7 +361,7 @@ public class TestDatasetBackupService {
     @Test
     public void test_backup_happyPath_tdb_exception() {
         // given
-        String datasetName = "/dataset-name";
+        String datasetName = "dataset-name";
         DataAccessPoint dap = new DataAccessPoint("dataset-name", DataService.newBuilder().build());
         when(mockRegistry.accessPoints()).thenReturn(List.of(dap));
 
@@ -401,7 +400,7 @@ public class TestDatasetBackupService {
     @Test
     public void test_backup_abac_rocksDB_exceptions() {
         // given
-        String datasetName = "/dataset-name";
+        String datasetName = "dataset-name";
         DatasetGraphABAC dsgABAC = ABAC.authzDataset(DatasetGraphFactory.createTxnMem(),
                 null,
                 mock(LabelsStoreRocksDB.class),
@@ -592,7 +591,7 @@ public class TestDatasetBackupService {
                 null);
         DataAccessPoint dap = new DataAccessPoint("dataset-name", DataService.newBuilder().dataset(dsgABAC).build());
 
-        when(mockRegistry.get("/dataset-name")).thenReturn(dap);
+        when(mockRegistry.get("dataset-name")).thenReturn(dap);
 
         // when
         ObjectNode result = cut.restoreDatasets(restoreID);
@@ -642,7 +641,7 @@ public class TestDatasetBackupService {
 
         DataAccessPoint dap = new DataAccessPoint("dataset-name", DataService.newBuilder().dataset(DatasetGraphFactory.createTxnMem()).build());
 
-        when(mockRegistry.get("/dataset-name")).thenReturn(dap);
+        when(mockRegistry.get("dataset-name")).thenReturn(dap);
 
         // when
         ObjectNode result = cut.restoreDatasets(restoreID);
@@ -708,7 +707,7 @@ public class TestDatasetBackupService {
                 null);
         DataAccessPoint dap = new DataAccessPoint("dataset-name", DataService.newBuilder().build());
 
-        when(mockRegistry.get("/dataset-name")).thenReturn(dap);
+        when(mockRegistry.get("dataset-name")).thenReturn(dap);
 
         DatasetBackupService_Test.setupExceptionForMethod(RESTORE_TDB, "Failure");
         DatasetBackupService_Test.setupExceptionForMethod(RESTORE_LABELS, "Failure");
@@ -758,7 +757,7 @@ public class TestDatasetBackupService {
 
         DataAccessPoint mockDAP = mock(DataAccessPoint.class);
 
-        when(mockRegistry.get("/dataset-name")).thenReturn(mockDAP);
+        when(mockRegistry.get("dataset-name")).thenReturn(mockDAP);
 
         DatasetBackupService_Test.setupExceptionForMethod(RESTORE_TDB, "Failure");
         DatasetBackupService_Test.setupExceptionForMethod(RESTORE_LABELS, "Failure");
@@ -806,7 +805,7 @@ public class TestDatasetBackupService {
                 null);
         DataAccessPoint dap = new DataAccessPoint("dataset-name", DataService.newBuilder().dataset(dsgABAC).build());
 
-        when(mockRegistry.get("/dataset-name")).thenReturn(dap);
+        when(mockRegistry.get("dataset-name")).thenReturn(dap);
 
         // when
         ObjectNode result = cut.restoreDatasets(restoreID);
@@ -871,7 +870,7 @@ public class TestDatasetBackupService {
                 null);
         DataAccessPoint dap = new DataAccessPoint("dataset-name", DataService.newBuilder().dataset(dsgABAC).build());
 
-        when(mockRegistry.get("/dataset-name")).thenReturn(dap);
+        when(mockRegistry.get("dataset-name")).thenReturn(dap);
 
         DatasetBackupService_Test.setupExceptionForMethod(RESTORE_TDB, "Failure");
         DatasetBackupService_Test.setupExceptionForMethod(RESTORE_LABELS, "Failure");
@@ -924,7 +923,7 @@ public class TestDatasetBackupService {
                 null);
         DataAccessPoint dap = new DataAccessPoint("dataset-name", DataService.newBuilder().dataset(dsgABAC).build());
 
-        when(mockRegistry.get("/dataset-name")).thenReturn(dap);
+        when(mockRegistry.get("dataset-name")).thenReturn(dap);
 
         // when
         ObjectNode result = cut.restoreDatasets(restoreID);
@@ -1334,9 +1333,7 @@ public class TestDatasetBackupService {
             // Submit 5 concurrent tasks simulating individual requests
             for (int i = 0; i < 2; i++) {
                 final boolean flag = (i == 0);
-                executorService.submit(() -> {
-                    cut.process(request, response, flag);
-                });
+                executorService.submit(() -> cut.process(request, response, flag));
             }
             // Wait for threads to complete
             executorService.shutdown();


### PR DESCRIPTION
To avoid any complications when creating/loading the backup files.

Data set names can be in the following forms "/knowledge" or "/knowledge/upload" which can cause trouble when creating files. We remove the first '/' and replace the other (or any other troublesome characters) with more suitable variants. 