### PR TITLE
CORE-412: add admin endpoint for triple label queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ The URL value is a template including `{user}`. Example: `http://some-host/users
 This specifies the JSON Web Key Set (JWKS) URL to use to obtain the public keys for verifying JSON Web Tokens (JWTs).
 The value "disabled" turns off token verification.
 
+### `ENABLE_LABELS_QUERY`
+
+Setting this to `true` will enable the security label query endpoint at `http://{hostname}/$/labels/query`. More information
+about this endpoint can be found in the [API docs](docs/labels-api.yaml). You can also run a Docker container with the
+endpoint enabled which can be accessed from the API docs by running:
+```commandline
+scg-docker/docker-run.sh --config config/config-labels-query-test.ttl
+```
+To populate this instance with sample security labelled data you can run:
+```commandline
+curl --location 'http://localhost:3030/securedDataset/upload' --header 'Security-Label: !' --header 'Content-Type: application/trig' --data-binary '@scg-system/src/test/files/sample-data-labelled.trig'
+```
 ## Build
 
 Building Smart Cache Graph is a two-step process.

--- a/docs/labels-api.yaml
+++ b/docs/labels-api.yaml
@@ -1,0 +1,62 @@
+openapi: 3.0.3
+info:
+  title: Security Labels Query API
+  description: API for querying security labels.
+  version: 0.82.8
+servers:
+  - url: http://localhost:3030/
+    description: Base path for query operations.
+paths:
+  /$/labels/query:
+    post:
+      summary: Find security labels for a given triple
+      description: Retrieves a list of the security labels for a given triple.
+      requestBody:
+        description: The subject, predicate and object of the triple to retrieve security labels for.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                subject:
+                  type: string
+                predicate:
+                  type: string
+                object:
+                  type: string
+            examples:
+              London_Population:
+                value:
+                  subject: http://dbpedia.org/resource/London
+                  predicate: http://dbpedia.org/ontology/populationTotal
+                  object: 8799800
+              London_Country:
+                value:
+                  subject: http://dbpedia.org/resource/London
+                  predicate: http://dbpedia.org/ontology/country
+                  object: "http://dbpedia.org/resource/United_Kingdom"
+      responses:
+        '200':
+          description: Request processed successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  labels:
+                    type: array
+                    items:
+                      type: string
+                    description: List of the labels.
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error message.
+

--- a/scg-docker/Dockerfile
+++ b/scg-docker/Dockerfile
@@ -19,6 +19,7 @@ WORKDIR $FUSEKI_DIR
 ARG LOGS=${FUSEKI_DIR}/logs
 ARG DATA=${FUSEKI_DIR}/databases
 ARG BACKUPS=${FUSEKI_DIR}/backups
+ARG LABELS=${FUSEKI_DIR}/labels
 ARG CONFIGS=${FUSEKI_DIR}/config
 ARG LIB=${FUSEKI_DIR}/lib
 ARG AGENTS=${FUSEKI_DIR}/agents
@@ -28,10 +29,10 @@ COPY scg-docker/entrypoint.sh .
 COPY scg-docker/logback.xml .
 
 
-RUN mkdir -p $LOGS $DATA $CONFIGS $LIB $AGENTS $SBOMS $BACKUPS && \
+RUN mkdir -p $LOGS $DATA $CONFIGS $LIB $AGENTS $SBOMS $BACKUPS $LABELS && \
     groupadd -r fuseki && \
     useradd -r -g fuseki -d ${FUSEKI_DIR} fuseki && \
-    chown -R fuseki:fuseki $LOGS $DATA $CONFIGS $LIB $AGENTS $SBOMS $BACKUPS && \
+    chown -R fuseki:fuseki $LOGS $DATA $CONFIGS $LIB $AGENTS $SBOMS $BACKUPS $LABELS && \
     chmod 777 $BACKUPS && \
     chmod a+x entrypoint.sh
 

--- a/scg-docker/docker-run.sh
+++ b/scg-docker/docker-run.sh
@@ -72,6 +72,7 @@ MNT_DIR=$(pwd)/${CURRENT_DIR}/mnt
 docker run -d \
     -e JAVA_OPTIONS="-Xmx2048m -Xms2048m" \
     -e JWKS_URL="disabled" \
+    -e ENABLE_LABELS_QUERY="true" \
     -p 3030:3030 \
     -v "$MNT_DIR/logs:/fuseki/logs"      \
     -v "$MNT_DIR/databases:/fuseki/databases" \

--- a/scg-docker/mnt/config/config-labels-query-test.ttl
+++ b/scg-docker/mnt/config/config-labels-query-test.ttl
@@ -1,0 +1,22 @@
+PREFIX :        <#>
+PREFIX fuseki:  <http://jena.apache.org/fuseki#>
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
+PREFIX authz:   <http://telicent.io/security#>
+
+:secureService rdf:type fuseki:Service ;
+    fuseki:name "securedDataset" ;
+    fuseki:endpoint [ fuseki:operation fuseki:query ; fuseki:name "query" ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:gsp-r ; fuseki:name "read" ] ;
+    fuseki:endpoint [ fuseki:operation authz:upload ; fuseki:name "upload" ] ;
+    fuseki:dataset :dataset ;
+    .
+
+:dataset rdf:type authz:DatasetAuthz ;
+         authz:dataset :inMemoryDatabase;
+         authz:labelsStore  [ authz:labelsStorePath "labels" ];
+         authz:attributes <file:labels-query-test-attribute-store.ttl> ;
+         authz:tripleDefaultAttributes "!";
+         .
+
+:inMemoryDatabase rdf:type ja:MemoryDataset .

--- a/scg-docker/mnt/config/labels-query-test-attribute-store.ttl
+++ b/scg-docker/mnt/config/labels-query-test-attribute-store.ttl
@@ -1,0 +1,10 @@
+PREFIX security: <http://telicent.io/security#>
+
+[] security:user "User1" ;
+    security:userAttribute "everyone";
+    .
+    
+[] security:user "User2" ;
+    security:userAttribute "admin";
+    security:userAttribute "census";
+    .

--- a/scg-system/pom.xml
+++ b/scg-system/pom.xml
@@ -201,6 +201,12 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>uk.org.webcompere</groupId>
+      <artifactId>system-stubs-jupiter</artifactId>
+      <version>2.1.7</version>
+      <scope>test</scope>
+    </dependency>
 
     <!-- Open Telemetry - testing -->
     <dependency>

--- a/scg-system/src/main/java/io/telicent/core/SmartCacheGraph.java
+++ b/scg-system/src/main/java/io/telicent/core/SmartCacheGraph.java
@@ -19,6 +19,7 @@ package io.telicent.core;
 import io.telicent.backup.FMod_BackupData;
 import io.telicent.graphql.FMod_TelicentGraphQL;
 import io.telicent.jena.abac.fuseki.FMod_ABAC;
+import io.telicent.labels.FMod_LabelsQuery;
 import io.telicent.otel.FMod_OpenTelemetry;
 import io.telicent.smart.cache.configuration.Configurator;
 import io.telicent.smart.caches.configuration.auth.AuthConstants;
@@ -120,6 +121,7 @@ public class SmartCacheGraph {
                 , new FMod_TelicentGraphQL()
                 , new FMod_RequestIDFilter()
                 , new FMod_BackupData()
+                , new FMod_LabelsQuery()
         ));
 
         // Initial compaction gets added again per the earlier comments

--- a/scg-system/src/main/java/io/telicent/labels/FMod_LabelsQuery.java
+++ b/scg-system/src/main/java/io/telicent/labels/FMod_LabelsQuery.java
@@ -1,0 +1,53 @@
+package io.telicent.labels;
+
+import io.telicent.jena.abac.core.DatasetGraphABAC;
+import io.telicent.jena.abac.labels.LabelsStore;
+import io.telicent.labels.services.LabelsQueryService;
+import io.telicent.labels.servlets.LabelsQueryServlet;
+import io.telicent.smart.cache.configuration.Configurator;
+import org.apache.jena.fuseki.main.FusekiServer;
+import org.apache.jena.fuseki.main.sys.FusekiAutoModule;
+import org.apache.jena.fuseki.server.DataAccessPoint;
+import org.apache.jena.fuseki.server.DataAccessPointRegistry;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.sparql.core.DatasetGraph;
+
+public class FMod_LabelsQuery implements FusekiAutoModule {
+
+    /**
+     * Configuration flag to enable/disable functionality.
+     */
+    public static final String ENABLE_LABELS_QUERY = "ENABLE_LABELS_QUERY";
+
+    private LabelsQueryService getLabelsQueryService(DataAccessPointRegistry dapRegistry) {
+        LabelsQueryService labelsQueryService = null;
+        for (DataAccessPoint dap : dapRegistry.accessPoints()) {
+            final DatasetGraph dsg = dap.getDataService().getDataset();
+            if (dsg instanceof DatasetGraphABAC abac) {
+                final LabelsStore labelsStore = abac.labelsStore();
+                labelsQueryService = new LabelsQueryService(labelsStore);
+            }
+        }
+        return labelsQueryService;
+    }
+
+    @Override
+    public String name() {
+        return "Labels Query Module";
+    }
+
+    @Override
+    public void configured(FusekiServer.Builder serverBuilder, DataAccessPointRegistry dapRegistry, Model configModel) {
+        if (isLabelsQueryEnabled()) {
+            final LabelsQueryService queryService = getLabelsQueryService(dapRegistry);
+            if(queryService != null) {
+                serverBuilder.addServlet("/$/labels/query", new LabelsQueryServlet(queryService));
+            }
+        }
+    }
+
+    private static boolean isLabelsQueryEnabled() {
+        return Configurator.get(ENABLE_LABELS_QUERY, Boolean::parseBoolean, false);
+    }
+
+}

--- a/scg-system/src/main/java/io/telicent/labels/LabelsQuery.java
+++ b/scg-system/src/main/java/io/telicent/labels/LabelsQuery.java
@@ -1,0 +1,7 @@
+package io.telicent.labels;
+
+public class LabelsQuery {
+    public String subject;
+    public String predicate;
+    public String object;
+}

--- a/scg-system/src/main/java/io/telicent/labels/TripleLabels.java
+++ b/scg-system/src/main/java/io/telicent/labels/TripleLabels.java
@@ -1,0 +1,12 @@
+package io.telicent.labels;
+
+import java.util.List;
+
+public class TripleLabels {
+
+    public TripleLabels(List<String> labels){
+        this.labels = labels;
+    }
+
+    public List<String> labels;
+}

--- a/scg-system/src/main/java/io/telicent/labels/services/LabelsQueryService.java
+++ b/scg-system/src/main/java/io/telicent/labels/services/LabelsQueryService.java
@@ -1,0 +1,22 @@
+package io.telicent.labels.services;
+
+import io.telicent.jena.abac.labels.LabelsStore;
+import io.telicent.labels.TripleLabels;
+import org.apache.jena.graph.Triple;
+
+import java.util.List;
+
+public class LabelsQueryService {
+
+
+    private final LabelsStore labelStore;
+
+    public LabelsQueryService(LabelsStore labelStore) {
+        this.labelStore = labelStore;
+    }
+
+    public TripleLabels queryLabelStore(Triple triple) {
+        final List<String> labels = labelStore.labelsForTriples(triple);
+        return new TripleLabels(labels);
+    }
+}

--- a/scg-system/src/main/java/io/telicent/labels/servlets/LabelsQueryServlet.java
+++ b/scg-system/src/main/java/io/telicent/labels/servlets/LabelsQueryServlet.java
@@ -1,0 +1,67 @@
+package io.telicent.labels.servlets;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.telicent.labels.TripleLabels;
+import io.telicent.labels.LabelsQuery;
+import io.telicent.labels.services.LabelsQueryService;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.riot.WebContent;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class LabelsQueryServlet extends HttpServlet {
+
+    private final LabelsQueryService queryService;
+
+    public static ObjectMapper MAPPER = new ObjectMapper();
+
+    public LabelsQueryServlet(LabelsQueryService queryService) {
+        this.queryService = queryService;
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        try (final InputStream inputStream = request.getInputStream()) {
+            final LabelsQuery json = MAPPER.readValue(inputStream, LabelsQuery.class);
+            final Triple triple = getTriple(json);
+            final TripleLabels labels = queryService.queryLabelStore(triple);
+            processResponse(response, labels);
+        }
+    }
+
+    private static void processResponse(HttpServletResponse response, TripleLabels labels) {
+        String jsonOutput;
+        try (ServletOutputStream out = response.getOutputStream()) {
+            jsonOutput = MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(labels);
+            response.setContentLength(jsonOutput.length());
+            response.setContentType(WebContent.contentTypeJSON);
+            response.setCharacterEncoding(WebContent.charsetUTF8);
+            out.print(jsonOutput);
+        } catch (IOException ex) {
+            response.setStatus(HttpServletResponse.SC_UNPROCESSABLE_CONTENT);
+        }
+    }
+
+    private Triple getTriple(LabelsQuery tripleQuery) {
+        final Node s = NodeFactory.createURI(tripleQuery.subject);
+        final Node p = NodeFactory.createURI(tripleQuery.predicate);
+        final Node o = getObjectNode(tripleQuery.object);
+        return Triple.create(s,p,o);
+    }
+
+    private Node getObjectNode(String object) {
+        if(object.startsWith("http://")||object.startsWith("https://") ){
+            return NodeFactory.createURI(object);
+        } else {
+            return NodeFactory.createLiteralByValue(object);
+        }
+    }
+
+}

--- a/scg-system/src/test/files/sample-data-labelled.trig
+++ b/scg-system/src/test/files/sample-data-labelled.trig
@@ -1,0 +1,28 @@
+PREFIX dbr: <http://dbpedia.org/resource/>
+PREFIX dbo: <http://dbpedia.org/ontology/>
+PREFIX security: <http://telicent.io/security#>
+
+## Basic data on 3 cities
+dbr:London dbo:populationTotal 8799800 .
+dbr:London dbo:country dbr:United_Kingdom .
+
+dbr:Paris dbo:populationTotal 2165423 .
+dbr:Paris dbo:country dbr:France .
+
+dbr:Berlin dbo:populationTotal 3677472 .
+dbr:Berlin dbo:country dbr:Germany  .
+
+## ABAC Security labels to apply
+GRAPH security:labels {
+
+    ## Something everyone can see
+    [ security:pattern 'dbr:London dbo:country dbr:United_Kingdom'  ; security:label "everyone" ] .
+    [ security:pattern 'dbr:Paris dbo:country dbr:France'  ; security:label "everyone" ] .
+    [ security:pattern 'dbr:Berlin dbo:country dbr:Germany'  ; security:label "everyone" ] .
+
+    ## Multiple labels.
+    [ security:pattern 'dbr:London dbo:populationTotal 8799800'  ; security:label "admin", "census" ] .
+    [ security:pattern 'dbr:Paris dbo:populationTotal 2165423'  ; security:label "admin", "census" ] .
+    [ security:pattern 'dbr:Berlin dbo:populationTotal 3677472'  ; security:label "admin", "census" ] .
+
+}

--- a/scg-system/src/test/java/io/telicent/labels/services/ITLabelsQueryService.java
+++ b/scg-system/src/test/java/io/telicent/labels/services/ITLabelsQueryService.java
@@ -1,0 +1,61 @@
+package io.telicent.labels.services;
+
+import io.telicent.jena.abac.labels.Labels;
+import io.telicent.jena.abac.labels.LabelsStore;
+import io.telicent.jena.abac.labels.LabelsStoreRocksDB;
+import io.telicent.jena.abac.labels.StoreFmtByString;
+import io.telicent.labels.TripleLabels;
+import org.apache.commons.io.FileUtils;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.junit.jupiter.api.*;
+import org.rocksdb.RocksDBException;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+public class ITLabelsQueryService {
+
+    private static File dbDir;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        dbDir = Files.createTempDirectory("tmpDir").toFile();
+    }
+
+    @Test
+    public void testLabelQuery() throws IOException, RocksDBException {
+        final Triple triple = Triple.create(
+                NodeFactory.createURI("http://example.org/subject"),
+                NodeFactory.createURI("http://example.org/predicate"),
+                NodeFactory.createURI("http://example.org/object")
+        );
+        final LabelsStore rocksDbLabelsStore = Labels.createLabelsStoreRocksDB(
+                dbDir, LabelsStoreRocksDB.LabelMode.Overwrite, null, new StoreFmtByString());
+        rocksDbLabelsStore.add(triple, "example");
+        final LabelsQueryService queryService = new LabelsQueryService(rocksDbLabelsStore);
+        final TripleLabels labels = queryService.queryLabelStore(triple);
+        Assertions.assertEquals(1, labels.labels.size());
+    }
+
+    @Test
+    public void testLabelQueryLiteral() throws IOException, RocksDBException {
+        final Triple triple = Triple.create(
+                NodeFactory.createURI("http://example.org/subject"),
+                NodeFactory.createURI("http://example.org/predicate"),
+                NodeFactory.createLiteralByValue("test")
+        );
+        final LabelsStore rocksDbLabelsStore = Labels.createLabelsStoreRocksDB(
+                dbDir, LabelsStoreRocksDB.LabelMode.Overwrite, null, new StoreFmtByString());
+        rocksDbLabelsStore.add(triple, "example");
+        final LabelsQueryService queryService = new LabelsQueryService(rocksDbLabelsStore);
+        final TripleLabels labels = queryService.queryLabelStore(triple);
+        Assertions.assertEquals(1, labels.labels.size());
+    }
+
+    @AfterEach
+    public void tearDown() throws IOException {
+        FileUtils.deleteDirectory(dbDir);
+    }
+}

--- a/scg-system/src/test/java/io/telicent/labels/services/LabelsQueryIntegrationTest.java
+++ b/scg-system/src/test/java/io/telicent/labels/services/LabelsQueryIntegrationTest.java
@@ -1,0 +1,131 @@
+package io.telicent.labels.services;
+
+import io.telicent.core.MainSmartCacheGraph;
+import io.telicent.smart.cache.configuration.Configurator;
+import org.apache.jena.fuseki.main.FusekiServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.shaded.org.apache.commons.io.FileUtils;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(SystemStubsExtension.class)
+public class LabelsQueryIntegrationTest {
+
+    @SystemStub
+    private static EnvironmentVariables env;
+
+    private static FusekiServer server;
+
+    private static String baseUri;
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        Configurator.reset();
+        final URL backupUrl = LabelsQueryIntegrationTest.class.getClassLoader().getResource("config-labels-query-test.ttl");
+        assert backupUrl != null;
+        env.set("JWKS_URL", "disabled");
+        env.set("ENABLE_LABELS_QUERY", true);
+        System.out.println("ENABLE var=" + System.getenv("ENABLE_LABELS_QUERY"));
+        assertEquals(System.getenv("ENABLE_LABELS_QUERY"), "true");
+        server = MainSmartCacheGraph.buildAndRun("--config", backupUrl.getPath());
+        baseUri = "http://localhost:" + server.getHttpPort();
+        uploadData();
+    }
+
+    @Test
+    public void test_one_label() throws Exception {
+        final String jsonRequestBody = """
+                {
+                  "subject": "http://dbpedia.org/resource/London",
+                  "predicate": "http://dbpedia.org/ontology/country",
+                  "object": "http://dbpedia.org/resource/United_Kingdom"
+                }""";
+        final String expectedJsonResponse = """
+                {
+                  "labels" : [ "everyone" ]
+                }""";
+        final HttpRequest request = HttpRequest.newBuilder(new URI(baseUri + "/$/labels/query"))
+                .headers("accept", "application/json", "Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(jsonRequestBody)).build();
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            final HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            assertEquals(expectedJsonResponse, response.body());
+        }
+    }
+
+    @Test
+    public void test_two_labels() throws Exception {
+        final String jsonRequestBody = """
+                {
+                  "subject": "http://dbpedia.org/resource/London",
+                  "predicate": "http://dbpedia.org/ontology/populationTotal",
+                  "object": 8799800
+                }""";
+        final String expectedJsonResponse = """
+                {
+                  "labels" : [ "census", "admin" ]
+                }""";
+        final HttpRequest request = HttpRequest.newBuilder(new URI(baseUri + "/$/labels/query"))
+                .headers("accept", "application/json", "Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(jsonRequestBody)).build();
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            final HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            assertEquals(expectedJsonResponse, response.body());
+        }
+    }
+
+    @Test
+    public void test_no_labels() throws Exception {
+        final String jsonRequestBody = """
+                {
+                  "subject": "http://dbpedia.org/resource/Rome",
+                  "predicate": "http://dbpedia.org/ontology/country",
+                  "object": "http://dbpedia.org/resource/Italy"
+                }""";
+        final String expectedJsonResponse = """
+                {
+                  "labels" : [ ]
+                }""";
+        final HttpRequest request = HttpRequest.newBuilder(new URI(baseUri + "/$/labels/query"))
+                .headers("accept", "application/json", "Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(jsonRequestBody)).build();
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            final HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            assertEquals(expectedJsonResponse, response.body());
+        }
+    }
+
+    private static void uploadData() throws Exception {
+        final URL dataUrl = LabelsQueryIntegrationTest.class.getClassLoader().getResource("test-data-labelled.trig");
+        assert dataUrl != null;
+        final HttpRequest request = HttpRequest.newBuilder(new URI(baseUri + "/securedDataset/upload"))
+                .headers("Security-Label", "!", "Content-Type", "application/trig")
+                .POST(HttpRequest.BodyPublishers.ofFile(Paths.get(dataUrl.toURI()))).build();
+        try (final HttpClient client = HttpClient.newHttpClient()) {
+            final HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            assertEquals(200, response.statusCode());
+        }
+    }
+
+    @AfterAll
+    public static void afterAll() throws IOException {
+        server.stop();
+        FileUtils.deleteDirectory(new File("labels"));
+    }
+
+}

--- a/scg-system/src/test/java/io/telicent/labels/services/TestLabelsQuery.java
+++ b/scg-system/src/test/java/io/telicent/labels/services/TestLabelsQuery.java
@@ -24,7 +24,7 @@ import java.nio.file.Paths;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(SystemStubsExtension.class)
-public class LabelsQueryIntegrationTest {
+public class TestLabelsQuery {
 
     @SystemStub
     private static EnvironmentVariables env;
@@ -36,7 +36,7 @@ public class LabelsQueryIntegrationTest {
     @BeforeAll
     public static void beforeAll() throws Exception {
         Configurator.reset();
-        final URL backupUrl = LabelsQueryIntegrationTest.class.getClassLoader().getResource("config-labels-query-test.ttl");
+        final URL backupUrl = TestLabelsQuery.class.getClassLoader().getResource("config-labels-query-test.ttl");
         assert backupUrl != null;
         env.set("JWKS_URL", "disabled");
         env.set("ENABLE_LABELS_QUERY", true);
@@ -111,7 +111,7 @@ public class LabelsQueryIntegrationTest {
     }
 
     private static void uploadData() throws Exception {
-        final URL dataUrl = LabelsQueryIntegrationTest.class.getClassLoader().getResource("test-data-labelled.trig");
+        final URL dataUrl = TestLabelsQuery.class.getClassLoader().getResource("test-data-labelled.trig");
         assert dataUrl != null;
         final HttpRequest request = HttpRequest.newBuilder(new URI(baseUri + "/securedDataset/upload"))
                 .headers("Security-Label", "!", "Content-Type", "application/trig")

--- a/scg-system/src/test/java/io/telicent/labels/services/TestLabelsQueryService.java
+++ b/scg-system/src/test/java/io/telicent/labels/services/TestLabelsQueryService.java
@@ -1,0 +1,31 @@
+package io.telicent.labels.services;
+
+import io.telicent.jena.abac.labels.LabelsStore;
+import io.telicent.labels.TripleLabels;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TestLabelsQueryService {
+
+    @Test
+    public void testLabelQuery() {
+        final LabelsStore mockLabelsStore = mock(LabelsStore.class);
+        final LabelsQueryService queryService = new LabelsQueryService(mockLabelsStore);
+        when(mockLabelsStore.labelsForTriples(any(Triple.class))).thenReturn(List.of("example"));
+        final Triple triple = Triple.create(
+                NodeFactory.createURI("http://example.org/subject"),
+                NodeFactory.createURI("http://example.org/predicate"),
+                NodeFactory.createURI("http://example.org/object")
+        );
+        final TripleLabels labels = queryService.queryLabelStore(triple);
+        Assertions.assertEquals(1, labels.labels.size());
+    }
+}

--- a/scg-system/src/test/java/io/telicent/labels/services/TestLabelsQueryServiceRocksDB.java
+++ b/scg-system/src/test/java/io/telicent/labels/services/TestLabelsQueryServiceRocksDB.java
@@ -8,14 +8,16 @@ import io.telicent.labels.TripleLabels;
 import org.apache.commons.io.FileUtils;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.graph.Triple;
-import org.junit.jupiter.api.*;
-import org.rocksdb.RocksDBException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 
-public class ITLabelsQueryService {
+public class TestLabelsQueryServiceRocksDB {
 
     private static File dbDir;
 
@@ -25,7 +27,7 @@ public class ITLabelsQueryService {
     }
 
     @Test
-    public void testLabelQuery() throws IOException, RocksDBException {
+    public void testLabelQuery() throws Exception {
         final Triple triple = Triple.create(
                 NodeFactory.createURI("http://example.org/subject"),
                 NodeFactory.createURI("http://example.org/predicate"),
@@ -40,7 +42,8 @@ public class ITLabelsQueryService {
     }
 
     @Test
-    public void testLabelQueryLiteral() throws IOException, RocksDBException {
+    public void testLabelQueryLiteral() throws Exception
+    {
         final Triple triple = Triple.create(
                 NodeFactory.createURI("http://example.org/subject"),
                 NodeFactory.createURI("http://example.org/predicate"),

--- a/scg-system/src/test/resources/config-labels-query-test.ttl
+++ b/scg-system/src/test/resources/config-labels-query-test.ttl
@@ -1,0 +1,22 @@
+PREFIX :        <#>
+PREFIX fuseki:  <http://jena.apache.org/fuseki#>
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
+PREFIX authz:   <http://telicent.io/security#>
+
+:secureService rdf:type fuseki:Service ;
+    fuseki:name "securedDataset" ;
+    fuseki:endpoint [ fuseki:operation fuseki:query ; fuseki:name "query" ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:gsp-r ; fuseki:name "read" ] ;
+    fuseki:endpoint [ fuseki:operation authz:upload ; fuseki:name "upload" ] ;
+    fuseki:dataset :dataset ;
+    .
+
+:dataset rdf:type authz:DatasetAuthz ;
+         authz:dataset :inMemoryDatabase;
+         authz:labelsStore  [ authz:labelsStorePath "labels" ];
+         authz:attributes <file:labels-query-test-attribute-store.ttl> ;
+         authz:tripleDefaultAttributes "!";
+         .
+
+:inMemoryDatabase rdf:type ja:MemoryDataset .

--- a/scg-system/src/test/resources/labels-query-test-attribute-store.ttl
+++ b/scg-system/src/test/resources/labels-query-test-attribute-store.ttl
@@ -1,0 +1,10 @@
+PREFIX security: <http://telicent.io/security#>
+
+[] security:user "User1" ;
+    security:userAttribute "everyone";
+    .
+    
+[] security:user "User2" ;
+    security:userAttribute "admin";
+    security:userAttribute "census";
+    .

--- a/scg-system/src/test/resources/test-data-labelled.trig
+++ b/scg-system/src/test/resources/test-data-labelled.trig
@@ -1,0 +1,28 @@
+PREFIX dbr: <http://dbpedia.org/resource/>
+PREFIX dbo: <http://dbpedia.org/ontology/>
+PREFIX security: <http://telicent.io/security#>
+
+## Basic data on 3 cities
+dbr:London dbo:populationTotal 8799800 .
+dbr:London dbo:country dbr:United_Kingdom .
+
+dbr:Paris dbo:populationTotal 2165423 .
+dbr:Paris dbo:country dbr:France .
+
+dbr:Berlin dbo:populationTotal 3677472 .
+dbr:Berlin dbo:country dbr:Germany  .
+
+## ABAC Security labels to apply
+GRAPH security:labels {
+
+    ## Something everyone can see
+    [ security:pattern 'dbr:London dbo:country dbr:United_Kingdom'  ; security:label "everyone" ] .
+    [ security:pattern 'dbr:Paris dbo:country dbr:France'  ; security:label "everyone" ] .
+    [ security:pattern 'dbr:Berlin dbo:country dbr:Germany'  ; security:label "everyone" ] .
+
+    ## Multiple labels.
+    [ security:pattern 'dbr:London dbo:populationTotal 8799800'  ; security:label "admin", "census" ] .
+    [ security:pattern 'dbr:Paris dbo:populationTotal 2165423'  ; security:label "admin", "census" ] .
+    [ security:pattern 'dbr:Berlin dbo:populationTotal 3677472'  ; security:label "admin", "census" ] .
+
+}


### PR DESCRIPTION
This PR adds a new admin endpoint to SCG which allows a user to retrieve the security labels for an RDF triple supplied in the request. This functionality needs to be enabled using the `ENABLE_LABELS_QUERY` environment variable. 

The PR includes API documentation and sample labelled data which can be run within a Docker container and tested locally using an OpenAPI viewer such as https://editor-next.swagger.io/.