### PR TITLE
[CORE-693] Extend Label Querying 

### DIFF
--- a/scg-system/pom.xml
+++ b/scg-system/pom.xml
@@ -167,7 +167,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <scope>test</scope>
     </dependency>
 
     <!-- OpenTelemetry dependencies -->
@@ -269,6 +268,12 @@
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-compress</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- JUnit 5 -->

--- a/scg-system/src/main/java/io/telicent/labels/FMod_LabelsQuery.java
+++ b/scg-system/src/main/java/io/telicent/labels/FMod_LabelsQuery.java
@@ -25,7 +25,7 @@ public class FMod_LabelsQuery implements FusekiAutoModule {
             final DatasetGraph dsg = dap.getDataService().getDataset();
             if (dsg instanceof DatasetGraphABAC abac) {
                 final LabelsStore labelsStore = abac.labelsStore();
-                labelsQueryService = new LabelsQueryService(labelsStore);
+                labelsQueryService = new LabelsQueryService(labelsStore, abac);
             }
         }
         return labelsQueryService;

--- a/scg-system/src/main/java/io/telicent/labels/LabelsQueryRequest.java
+++ b/scg-system/src/main/java/io/telicent/labels/LabelsQueryRequest.java
@@ -1,0 +1,7 @@
+package io.telicent.labels;
+
+import java.util.List;
+
+public class LabelsQueryRequest {
+    public List<LabelsQuery> triples;
+}

--- a/scg-system/src/main/java/io/telicent/labels/TripleLabels.java
+++ b/scg-system/src/main/java/io/telicent/labels/TripleLabels.java
@@ -1,12 +1,32 @@
 package io.telicent.labels;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.jena.graph.Triple;
+
 import java.util.List;
 
 public class TripleLabels {
 
-    public TripleLabels(List<String> labels){
+    public static ObjectMapper MAPPER = new ObjectMapper();
+
+    public TripleLabels(Triple triple, List<String> labels){
+        this.triple = triple;
         this.labels = labels;
     }
 
     public List<String> labels;
+    public Triple triple;
+
+    public ObjectNode toJSONNode() {
+        ObjectNode node = MAPPER.createObjectNode();
+        node.put("subject", triple.getSubject().toString());
+        node.put("predicate", triple.getPredicate().toString());
+        node.put("object", triple.getObject().toString());
+        ArrayNode labelNode = MAPPER.createArrayNode();
+        labels.forEach(labelNode::add);
+        node.set("labels", labelNode);
+        return node;
+    }
 }

--- a/scg-system/src/main/java/io/telicent/labels/services/LabelsQueryService.java
+++ b/scg-system/src/main/java/io/telicent/labels/services/LabelsQueryService.java
@@ -3,20 +3,37 @@ package io.telicent.labels.services;
 import io.telicent.jena.abac.labels.LabelsStore;
 import io.telicent.labels.TripleLabels;
 import org.apache.jena.graph.Triple;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.system.Txn;
+import org.apache.jena.util.iterator.ExtendedIterator;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class LabelsQueryService {
 
 
     private final LabelsStore labelStore;
+    private final DatasetGraph datasetGraph;
 
-    public LabelsQueryService(LabelsStore labelStore) {
+    public LabelsQueryService(LabelsStore labelStore, DatasetGraph datasetGraph) {
         this.labelStore = labelStore;
+        this.datasetGraph = datasetGraph;
     }
 
-    public TripleLabels queryLabelStore(Triple triple) {
-        final List<String> labels = labelStore.labelsForTriples(triple);
-        return new TripleLabels(labels);
+    public List<TripleLabels> queryOnlyLabelStore(Triple triple) {
+        return List.of(new TripleLabels(triple, labelStore.labelsForTriples(triple)));
+    }
+
+    public List<TripleLabels> queryDSGAndLabelStore(Triple triple) {
+        return Txn.calculateRead(datasetGraph, () -> {
+            List<TripleLabels> tripleLabels = new ArrayList<>();
+            ExtendedIterator<Triple> iter = datasetGraph.getDefaultGraph().find(triple);
+            while (iter.hasNext()) {
+                Triple t = iter.next();
+                tripleLabels.add(new TripleLabels(t, labelStore.labelsForTriples(t)));
+            }
+            return tripleLabels;
+        });
     }
 }

--- a/scg-system/src/main/java/io/telicent/labels/servlets/LabelsQueryServlet.java
+++ b/scg-system/src/main/java/io/telicent/labels/servlets/LabelsQueryServlet.java
@@ -52,7 +52,7 @@ public class LabelsQueryServlet extends HttpServlet {
         ArrayNode resultNodeList = MAPPER.createArrayNode();
         tripleQueryList.forEach(triple -> {
             List<TripleLabels> results = processTriple(triple);
-            resultNodeList.add(populateNodeWithResults(results));
+            results.forEach(tripleLabel -> resultNodeList.add(tripleLabel.toJSONNode()));
         });
 
         return resultNodeList;
@@ -66,13 +66,6 @@ public class LabelsQueryServlet extends HttpServlet {
         }
     }
 
-    ArrayNode populateNodeWithResults(List<TripleLabels> tripleLabels) {
-        ArrayNode resultNode = MAPPER.createArrayNode();
-        tripleLabels.forEach(tripleLabel -> {
-            resultNode.add(tripleLabel.toJSONNode());
-        });
-        return resultNode;
-    }
 
     public static boolean isWildcardTriple(Triple triple) {
         if (Node.ANY.equals(triple.getSubject())) {

--- a/scg-system/src/main/java/io/telicent/labels/servlets/LabelsQueryServlet.java
+++ b/scg-system/src/main/java/io/telicent/labels/servlets/LabelsQueryServlet.java
@@ -1,22 +1,32 @@
 package io.telicent.labels.servlets;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.telicent.labels.TripleLabels;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.telicent.labels.LabelsQuery;
+import io.telicent.labels.TripleLabels;
 import io.telicent.labels.services.LabelsQueryService;
-import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.graph.Triple;
-import org.apache.jena.riot.WebContent;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.telicent.backup.utils.BackupUtils.processResponse;
 
 public class LabelsQueryServlet extends HttpServlet {
+
+    private final static String HTTP = "http://";
+    private final static String HTTPS = "https://";
+    private final static String WILDCARD = "*";
 
     private final LabelsQueryService queryService;
 
@@ -27,37 +37,120 @@ public class LabelsQueryServlet extends HttpServlet {
     }
 
     @Override
-    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        try (final InputStream inputStream = request.getInputStream()) {
-            final LabelsQuery json = MAPPER.readValue(inputStream, LabelsQuery.class);
-            final Triple triple = getTriple(json);
-            final TripleLabels labels = queryService.queryLabelStore(triple);
-            processResponse(response, labels);
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) {
+        List<Triple> tripleQueryList = obtainTripleQueries(request);
+        ObjectNode resultNode = MAPPER.createObjectNode();
+        resultNode.set("results", processQueryList(tripleQueryList));
+        processResponse(response, resultNode);
+    }
+
+    ArrayNode processQueryList(List<Triple> tripleQueryList) {
+        ArrayNode resultNodeList = MAPPER.createArrayNode();
+        tripleQueryList.forEach(triple -> {
+            List<TripleLabels> results = processTriple(triple);
+            resultNodeList.add(populateNodeWithResults(results));
+        });
+
+        return resultNodeList;
+    }
+
+    List<TripleLabels> processTriple(Triple triple) {
+        if (isWildcardTriple(triple)) {
+            return queryService.queryDSGAndLabelStore(triple);
+        } else {
+            return queryService.queryOnlyLabelStore(triple);
         }
     }
 
-    private static void processResponse(HttpServletResponse response, TripleLabels labels) {
-        String jsonOutput;
-        try (ServletOutputStream out = response.getOutputStream()) {
-            jsonOutput = MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(labels);
-            response.setContentLength(jsonOutput.length());
-            response.setContentType(WebContent.contentTypeJSON);
-            response.setCharacterEncoding(WebContent.charsetUTF8);
-            out.print(jsonOutput);
-        } catch (IOException ex) {
-            response.setStatus(HttpServletResponse.SC_UNPROCESSABLE_CONTENT);
+    ArrayNode populateNodeWithResults(List<TripleLabels> tripleLabels) {
+        ArrayNode resultNode = MAPPER.createArrayNode();
+        tripleLabels.forEach(tripleLabel -> {
+            resultNode.add(tripleLabel.toJSONNode());
+        });
+        return resultNode;
+    }
+
+    public static boolean isWildcardTriple(Triple triple) {
+        if (Node.ANY.equals(triple.getSubject())) {
+            return true;
+        } else if (Node.ANY.equals(triple.getPredicate())) {
+            return true;
+        } else return Node.ANY.equals(triple.getObject());
+    }
+
+    List<Triple> obtainTripleQueries(HttpServletRequest request) {
+        List<Triple> tripleList = new ArrayList<>();
+        try (final InputStream inputStream = request.getInputStream()) {
+                JsonNode rootNode = MAPPER.readTree(inputStream); // Read into a JsonNode
+                if (rootNode.isArray()) {
+                    for (JsonNode node : rootNode) {
+                        LabelsQuery query = MAPPER.convertValue(node, LabelsQuery.class); // Convert each node
+                        tripleList.add(getTriple(query));
+                    }
+                } else if (rootNode.isObject()) {
+                    LabelsQuery query = MAPPER.convertValue(rootNode, LabelsQuery.class); // Convert the root node
+                    tripleList.add(getTriple(query));
+                } else {
+                    // IGNORE?
+                    System.err.println("Invalid JSON format: Must be an object or an array.");
+                }
+
+            } catch (IOException exception) {
+                // Handle I/O errors
+                exception.printStackTrace(); // Replace with proper logging
+                // ... appropriate error handling ...
+            }
+        return tripleList;
+    }
+
+    List<Triple> obtainTripleQueries2(HttpServletRequest request) {
+        List<Triple> tripleList = new ArrayList<>();
+        try (final InputStream inputStream = request.getInputStream()) {
+            try {
+                LabelsQuery json = MAPPER.readValue(inputStream, LabelsQuery.class);
+                tripleList.add(getTriple(json));
+            } catch (MismatchedInputException exception) {
+                LabelsQuery[] queryArray = MAPPER.readValue(inputStream, LabelsQuery[].class);
+                for (LabelsQuery query : queryArray) {
+                    tripleList.add(getTriple(query));
+                }
+            }
+        } catch (IOException exception) {
+            // do nothing
         }
+        return tripleList;
+    }
+
+    private static void processResponseTriple(HttpServletResponse response, Triple incomingTriple, TripleLabels labels) {
+        ObjectNode resultNode = MAPPER.createObjectNode();
+        resultNode.put("asString", incomingTriple.toString());
+        resultNode.put("querySubject", incomingTriple.getSubject().toString());
+        resultNode.put("queryPredicate", incomingTriple.getPredicate().toString());
+        resultNode.put("queryObject", incomingTriple.getObject().toString());
+        ArrayNode labelNode = MAPPER.createArrayNode();
+        labels.labels.forEach(labelNode::add);
+        resultNode.set("labels", labelNode);
+        processResponse(response, resultNode);
     }
 
     private Triple getTriple(LabelsQuery tripleQuery) {
-        final Node s = NodeFactory.createURI(tripleQuery.subject);
-        final Node p = NodeFactory.createURI(tripleQuery.predicate);
+        final Node s = getWildcardOrURI(tripleQuery.subject);
+        final Node p = getWildcardOrURI(tripleQuery.predicate);
         final Node o = getObjectNode(tripleQuery.object);
-        return Triple.create(s,p,o);
+        return Triple.create(s, p, o);
+    }
+
+    private Node getWildcardOrURI(String object) {
+        if (WILDCARD.equals(object)) {
+            return Node.ANY;
+        }
+        return NodeFactory.createURI(object);
     }
 
     private Node getObjectNode(String object) {
-        if(object.startsWith("http://")||object.startsWith("https://") ){
+        if (WILDCARD.equals(object)) {
+            return Node.ANY;
+        } else if (object.startsWith(HTTP) || object.startsWith(HTTPS)) {
             return NodeFactory.createURI(object);
         } else {
             return NodeFactory.createLiteralByValue(object);

--- a/scg-system/src/test/java/io/telicent/labels/services/TestLabelsQuery.java
+++ b/scg-system/src/test/java/io/telicent/labels/services/TestLabelsQuery.java
@@ -65,12 +65,12 @@ public class TestLabelsQuery {
                 }""";
         final String expectedJsonResponse = """
                 {
-                  "results" : [ [ {
+                  "results" : [ {
                     "subject" : "http://dbpedia.org/resource/London",
                     "predicate" : "http://dbpedia.org/ontology/country",
                     "object" : "http://dbpedia.org/resource/United_Kingdom",
                     "labels" : [ "everyone" ]
-                  } ] ]
+                  } ]
                 }""";
         callAndAssert(jsonRequestBody, expectedJsonResponse);
     }
@@ -89,12 +89,12 @@ public class TestLabelsQuery {
                 }""";
         final String expectedJsonResponse = """
                 {
-                  "results" : [ [ {
+                  "results" : [ {
                     "subject" : "http://dbpedia.org/resource/London",
                     "predicate" : "http://dbpedia.org/ontology/populationTotal",
                     "object" : "\\"8799800\\"",
                     "labels" : [ "census", "admin" ]
-                  } ] ]
+                  } ]
                 }""";
         callAndAssert(jsonRequestBody, expectedJsonResponse);
     }
@@ -113,12 +113,12 @@ public class TestLabelsQuery {
                 }""";
         final String expectedJsonResponse = """
                 {
-                  "results" : [ [ {
+                  "results" : [ {
                     "subject" : "http://dbpedia.org/resource/Rome",
                     "predicate" : "http://dbpedia.org/ontology/country",
                     "object" : "http://dbpedia.org/resource/Italy",
                     "labels" : [ ]
-                  } ] ]
+                  } ]
                 }""";
         callAndAssert(jsonRequestBody, expectedJsonResponse);
     }
@@ -142,17 +142,17 @@ public class TestLabelsQuery {
                 }""";
         final String expectedJsonResponse = """
                 {
-                  "results" : [ [ {
+                  "results" : [ {
                     "subject" : "http://dbpedia.org/resource/Rome",
                     "predicate" : "http://dbpedia.org/ontology/country",
                     "object" : "http://dbpedia.org/resource/Italy",
                     "labels" : [ ]
-                  } ], [ {
+                  }, {
                     "subject" : "http://dbpedia.org/resource/Paris",
                     "predicate" : "http://dbpedia.org/ontology/country",
                     "object" : "http://dbpedia.org/resource/France",
                     "labels" : [ "everyone" ]
-                  } ] ]
+                  } ]
                 }""";
         callAndAssert(jsonRequestBody, expectedJsonResponse);
     }

--- a/scg-system/src/test/java/io/telicent/labels/services/TestLabelsQuery.java
+++ b/scg-system/src/test/java/io/telicent/labels/services/TestLabelsQuery.java
@@ -55,9 +55,13 @@ public class TestLabelsQuery {
     public void test_one_label() throws Exception {
         final String jsonRequestBody = """
                 {
-                  "subject": "http://dbpedia.org/resource/London",
-                  "predicate": "http://dbpedia.org/ontology/country",
-                  "object": "http://dbpedia.org/resource/United_Kingdom"
+                    "triples": [
+                    {
+                        "subject": "http://dbpedia.org/resource/London",
+                        "predicate": "http://dbpedia.org/ontology/country",
+                        "object": "http://dbpedia.org/resource/United_Kingdom"
+                    }
+                  ]
                 }""";
         final String expectedJsonResponse = """
                 {
@@ -75,9 +79,13 @@ public class TestLabelsQuery {
     public void test_two_labels() throws Exception {
         final String jsonRequestBody = """
                 {
-                  "subject": "http://dbpedia.org/resource/London",
-                  "predicate": "http://dbpedia.org/ontology/populationTotal",
-                  "object": 8799800
+                    "triples": [
+                        {
+                            "subject": "http://dbpedia.org/resource/London",
+                            "predicate": "http://dbpedia.org/ontology/populationTotal",
+                            "object": 8799800
+                        }
+                    ]
                 }""";
         final String expectedJsonResponse = """
                 {
@@ -95,9 +103,13 @@ public class TestLabelsQuery {
     public void test_no_labels() throws Exception {
         final String jsonRequestBody = """
                 {
-                  "subject": "http://dbpedia.org/resource/Rome",
-                  "predicate": "http://dbpedia.org/ontology/country",
-                  "object": "http://dbpedia.org/resource/Italy"
+                    "triples": [
+                        {
+                            "subject": "http://dbpedia.org/resource/Rome",
+                            "predicate": "http://dbpedia.org/ontology/country",
+                            "object": "http://dbpedia.org/resource/Italy"
+                        }
+                    ]
                 }""";
         final String expectedJsonResponse = """
                 {
@@ -114,18 +126,20 @@ public class TestLabelsQuery {
     @Test
     public void test_list_of_labels() throws Exception {
         final String jsonRequestBody = """
-                [
-                    {
-                      "subject": "http://dbpedia.org/resource/Rome",
-                      "predicate": "http://dbpedia.org/ontology/country",
-                      "object": "http://dbpedia.org/resource/Italy"
-                    },
-                    {
-                      "subject": "http://dbpedia.org/resource/Paris",
-                      "predicate": "http://dbpedia.org/ontology/country",
-                      "object": "http://dbpedia.org/resource/France"
-                    }
-                ]""";
+                {
+                    "triples": [
+                        {
+                          "subject": "http://dbpedia.org/resource/Rome",
+                          "predicate": "http://dbpedia.org/ontology/country",
+                          "object": "http://dbpedia.org/resource/Italy"
+                        },
+                        {
+                          "subject": "http://dbpedia.org/resource/Paris",
+                          "predicate": "http://dbpedia.org/ontology/country",
+                          "object": "http://dbpedia.org/resource/France"
+                        }
+                    ]
+                }""";
         final String expectedJsonResponse = """
                 {
                   "results" : [ [ {
@@ -139,6 +153,33 @@ public class TestLabelsQuery {
                     "object" : "http://dbpedia.org/resource/France",
                     "labels" : [ "everyone" ]
                   } ] ]
+                }""";
+        callAndAssert(jsonRequestBody, expectedJsonResponse);
+    }
+
+    @Test
+    public void test_invalidInput() throws Exception {
+        final String jsonRequestBody = """
+                {
+                  "wrong" : {
+                    "subject": "http://dbpedia.org/resource/Rome",
+                  }
+                }""";
+        final String expectedJsonResponse = """
+                {
+                  "results" : [ ]
+                }""";
+        callAndAssert(jsonRequestBody, expectedJsonResponse);
+    }
+
+    @Test
+    public void test_invalidInputJSON() throws Exception {
+        final String jsonRequestBody = """
+                erroneous
+                }""";
+        final String expectedJsonResponse = """
+                {
+                  "results" : [ ]
                 }""";
         callAndAssert(jsonRequestBody, expectedJsonResponse);
     }

--- a/scg-system/src/test/java/io/telicent/labels/services/TestLabelsQuery.java
+++ b/scg-system/src/test/java/io/telicent/labels/services/TestLabelsQuery.java
@@ -112,6 +112,38 @@ public class TestLabelsQuery {
     }
 
     @Test
+    public void test_list_of_labels() throws Exception {
+        final String jsonRequestBody = """
+                [
+                    {
+                      "subject": "http://dbpedia.org/resource/Rome",
+                      "predicate": "http://dbpedia.org/ontology/country",
+                      "object": "http://dbpedia.org/resource/Italy"
+                    },
+                    {
+                      "subject": "http://dbpedia.org/resource/Paris",
+                      "predicate": "http://dbpedia.org/ontology/country",
+                      "object": "http://dbpedia.org/resource/France"
+                    }
+                ]""";
+        final String expectedJsonResponse = """
+                {
+                  "results" : [ [ {
+                    "subject" : "http://dbpedia.org/resource/Rome",
+                    "predicate" : "http://dbpedia.org/ontology/country",
+                    "object" : "http://dbpedia.org/resource/Italy",
+                    "labels" : [ ]
+                  } ], [ {
+                    "subject" : "http://dbpedia.org/resource/Paris",
+                    "predicate" : "http://dbpedia.org/ontology/country",
+                    "object" : "http://dbpedia.org/resource/France",
+                    "labels" : [ "everyone" ]
+                  } ] ]
+                }""";
+        callAndAssert(jsonRequestBody, expectedJsonResponse);
+    }
+
+    @Test
     public void test_notConfigured() throws Exception {
         SERVER.stop();
         ENV.set("ENABLE_LABELS_QUERY", false);
@@ -152,7 +184,7 @@ public class TestLabelsQuery {
                 .POST(HttpRequest.BodyPublishers.ofString(jsonRequestBody)).build();
         try (HttpClient client = HttpClient.newHttpClient()) {
             final HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-            assertEquals(expectedJsonResponse, response.body());
+            assertEquals(expectedJsonResponse, response.body(), "Response:\n" + response.body() + "\ndoes not match expected result:\n" + expectedJsonResponse);
         }
     }
 

--- a/scg-system/src/test/java/io/telicent/labels/services/TestLabelsQueryService.java
+++ b/scg-system/src/test/java/io/telicent/labels/services/TestLabelsQueryService.java
@@ -2,9 +2,14 @@ package io.telicent.labels.services;
 
 import io.telicent.jena.abac.labels.LabelsStore;
 import io.telicent.labels.TripleLabels;
+import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.graph.Triple;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -13,19 +18,127 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class TestLabelsQueryService {
+class TestLabelsQueryService {
+
+    private static final LabelsStore mockLabelsStore = mock(LabelsStore.class);
+    private static final DatasetGraph emptyDsg = DatasetGraphFactory.create();
+    private static final LabelsQueryService queryService = new LabelsQueryService(mockLabelsStore, emptyDsg);
+
+    private static final Triple TRIPLE = Triple.create(
+            NodeFactory.createURI("http://example.org/subject"),
+            NodeFactory.createURI("http://example.org/predicate"),
+            NodeFactory.createURI("http://example.org/object")
+    );
+
+    private static final Triple TRIPLE_2 = Triple.create(
+            NodeFactory.createURI("http://example.org/subject2"),
+            NodeFactory.createURI("http://example.org/predicate2"),
+            NodeFactory.createURI("http://example.org/object2")
+    );
+
+    @BeforeAll
+    public static void beforeAll() {
+        when(mockLabelsStore.labelsForTriples(any(Triple.class))).thenReturn(List.of("example"));
+    }
+
+    @AfterEach
+    public void after() {
+        emptyDsg.clear();
+    }
 
     @Test
-    public void testLabelQuery() {
-        final LabelsStore mockLabelsStore = mock(LabelsStore.class);
-        final LabelsQueryService queryService = new LabelsQueryService(mockLabelsStore);
-        when(mockLabelsStore.labelsForTriples(any(Triple.class))).thenReturn(List.of("example"));
-        final Triple triple = Triple.create(
+    public void testLabelQuery_queryOnlyLabelStore() {
+        // given, when
+        List<TripleLabels> labels = queryService.queryOnlyLabelStore(TRIPLE);
+        // then
+        Assertions.assertEquals(1, labels.size());
+        Assertions.assertEquals(1, labels.getFirst().labels.size());
+    }
+
+    @Test
+    public void testLabelQuery_queryDSGAndLabelStore() {
+        // given
+        emptyDsg.getDefaultGraph().add(TRIPLE);
+        // when
+        List<TripleLabels> labels = queryService.queryDSGAndLabelStore(TRIPLE);
+        // then
+        Assertions.assertEquals(1, labels.size());
+        Assertions.assertEquals(1, labels.getFirst().labels.size());
+    }
+
+    @Test
+    public void testLabelQuery_queryDSGAndLabelStore_empty() {
+        // given, when
+        List<TripleLabels> labels = queryService.queryDSGAndLabelStore(TRIPLE);
+        // then
+        Assertions.assertEquals(0, labels.size());
+    }
+
+    @Test
+    public void testLabelQuery_queryDSGAndLabelStore_all_wildcards() {
+        // given
+        emptyDsg.getDefaultGraph().add(TRIPLE);
+
+        final Triple queryTriple = Triple.create(
+                Node.ANY,
+                Node.ANY,
+                Node.ANY
+        );
+        // when
+        List<TripleLabels> labels = queryService.queryDSGAndLabelStore(queryTriple);
+        // then
+        Assertions.assertEquals(1, labels.size());
+        Assertions.assertEquals(1, labels.getFirst().labels.size());
+    }
+
+    @Test
+    public void testLabelQuery_queryDSGAndLabelStore_predicate_wildcard() {
+        // given
+        emptyDsg.getDefaultGraph().add(TRIPLE);
+        emptyDsg.getDefaultGraph().add(TRIPLE_2);
+        final Triple queryTriple = Triple.create(
                 NodeFactory.createURI("http://example.org/subject"),
+                Node.ANY,
+                NodeFactory.createURI("http://example.org/object")
+        );
+        // when
+        List<TripleLabels> labels = queryService.queryDSGAndLabelStore(queryTriple);
+        // then
+        Assertions.assertEquals(1, labels.size());
+        Assertions.assertEquals(1, labels.getFirst().labels.size());
+    }
+
+    @Test
+    public void testLabelQuery_queryDSGAndLabelStore_subject_wildcard() {
+        // given
+        emptyDsg.getDefaultGraph().add(TRIPLE);
+        emptyDsg.getDefaultGraph().add(TRIPLE_2);
+        Triple queryTriple = Triple.create(
+                Node.ANY,
                 NodeFactory.createURI("http://example.org/predicate"),
                 NodeFactory.createURI("http://example.org/object")
         );
-        final TripleLabels labels = queryService.queryLabelStore(triple);
-        Assertions.assertEquals(1, labels.labels.size());
+        // when
+        List<TripleLabels> labels = queryService.queryDSGAndLabelStore(queryTriple);
+        // then
+        Assertions.assertEquals(1, labels.size());
+        Assertions.assertEquals(1, labels.getFirst().labels.size());
+    }
+
+    @Test
+    public void testLabelQuery_queryDSGAndLabelStore_object_wildcard() {
+        // given
+        emptyDsg.getDefaultGraph().add(TRIPLE);
+        emptyDsg.getDefaultGraph().add(TRIPLE_2);
+        Triple queryTriple = Triple.create(
+                NodeFactory.createURI("http://example.org/subject"),
+                NodeFactory.createURI("http://example.org/predicate"),
+                Node.ANY
+                );
+        // when
+        List<TripleLabels> labels = queryService.queryDSGAndLabelStore(queryTriple);
+        // then
+        Assertions.assertEquals(1, labels.size());
+        Assertions.assertEquals(1, labels.getFirst().labels.size());
     }
 }

--- a/scg-system/src/test/java/io/telicent/labels/services/TestLabelsQueryServiceRocksDB.java
+++ b/scg-system/src/test/java/io/telicent/labels/services/TestLabelsQueryServiceRocksDB.java
@@ -8,6 +8,8 @@ import io.telicent.labels.TripleLabels;
 import org.apache.commons.io.FileUtils;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.graph.Triple;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.List;
 
 public class TestLabelsQueryServiceRocksDB {
 
@@ -36,9 +39,11 @@ public class TestLabelsQueryServiceRocksDB {
         final LabelsStore rocksDbLabelsStore = Labels.createLabelsStoreRocksDB(
                 dbDir, LabelsStoreRocksDB.LabelMode.Overwrite, null, new StoreFmtByString());
         rocksDbLabelsStore.add(triple, "example");
-        final LabelsQueryService queryService = new LabelsQueryService(rocksDbLabelsStore);
-        final TripleLabels labels = queryService.queryLabelStore(triple);
-        Assertions.assertEquals(1, labels.labels.size());
+        final DatasetGraph emptyDsg = DatasetGraphFactory.create();
+        final LabelsQueryService queryService = new LabelsQueryService(rocksDbLabelsStore, emptyDsg);
+        final List<TripleLabels> labels = queryService.queryOnlyLabelStore(triple);
+        Assertions.assertEquals(1, labels.size());
+        Assertions.assertEquals(1, labels.getFirst().labels.size());
     }
 
     @Test
@@ -52,9 +57,11 @@ public class TestLabelsQueryServiceRocksDB {
         final LabelsStore rocksDbLabelsStore = Labels.createLabelsStoreRocksDB(
                 dbDir, LabelsStoreRocksDB.LabelMode.Overwrite, null, new StoreFmtByString());
         rocksDbLabelsStore.add(triple, "example");
-        final LabelsQueryService queryService = new LabelsQueryService(rocksDbLabelsStore);
-        final TripleLabels labels = queryService.queryLabelStore(triple);
-        Assertions.assertEquals(1, labels.labels.size());
+        final DatasetGraph emptyDsg = DatasetGraphFactory.create();
+        final LabelsQueryService queryService = new LabelsQueryService(rocksDbLabelsStore, emptyDsg);
+        final List<TripleLabels> labels = queryService.queryOnlyLabelStore(triple);
+        Assertions.assertEquals(1, labels.size());
+        Assertions.assertEquals(1, labels.getFirst().labels.size());
     }
 
     @AfterEach


### PR DESCRIPTION
Addresses CORE-694 & CORE-695 at the same time.

We now return the incoming triple(s), can handle a list of entries and also wild cards.

To illustrate:
**Single query**
```json
{
    "subject": "http://dbpedia.org/resource/London",
    "predicate": "http://dbpedia.org/ontology/country",
    "object": "http://dbpedia.org/resource/United_Kingdom"
}
```
**Multi query**
```json
[
    {
        "subject": "http://telicent.io/data#ALG12538_labor_group_algeria_actor1_participant",
        "predicate": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
        "object": "http://acleddata.com/ontology#Actor1Participant"
    },
    {
        "subject": "http://telicent.io/data#ALG12538_labor_group_algeria_actor1_participant",
        "predicate": "http://ies.data.gov.uk/ontology/ies4#isParticipantIn",
        "object": "http://telicent.io/data#ALG12538"
    },
    {
        "subject": "http://telicent.io/data#ALG12538_labor_group_algeria_actor1_participant",
        "predicate": "http://ies.data.gov.uk/ontology/ies4#isParticipationOf",
        "object": "http://telicent.io/data#labor_group_algeria"
    },
    {
        "subject": "http://telicent.io/data#ALG12538_labor_group_algeria_actor1_participant",
        "predicate": "http://telicent.io/ontology/primaryName",
        "object": "Actor1Side: Labor Group (Algeria)"
    },
    {
        "subject": "http://telicent.io/data#ALG12538",
        "predicate": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
        "object": "http://acleddata.com/ontology#PeacefulProtest"
    }
]
```

**Wildcard query**
```json
{
    "subject": "http://www.w3.org/1999/02/22-rdf-syntax-ns#first",
    "predicate": "http://www.w3.org/2000/01/rdf-schema#range",
    "object": "*"
}
```