### PR TITLE
[Minor] Strip out path for Kafka Connectors.

### DIFF
--- a/scg-system/src/main/java/io/telicent/core/FMod_FusekiKafkaSCG.java
+++ b/scg-system/src/main/java/io/telicent/core/FMod_FusekiKafkaSCG.java
@@ -116,7 +116,8 @@ public class FMod_FusekiKafkaSCG extends FMod_FusekiKafka {
 
     public void backupKafka(DataAccessPoint dataAccessPoint, String path, ObjectNode resultNode) {
         String dataset = dataAccessPoint.getName();
-        KConnectorDesc conn = connectors.get(dataset);
+        String strippedDownName = stripStringPath(dataset);
+        KConnectorDesc conn = connectors.get(strippedDownName);
         if (conn != null) {
             String sanitizedDataset = sanitiseName(dataset);
             String filename = path + "/" + sanitizedDataset + ".json";
@@ -134,7 +135,8 @@ public class FMod_FusekiKafkaSCG extends FMod_FusekiKafka {
 
     public void restoreKafka(DataAccessPoint dataAccessPoint, String path, ObjectNode resultNode) {
         String dataset = dataAccessPoint.getName();
-        if (connectors.get(dataset) != null) {
+        String strippedDownName = stripStringPath(dataset);
+        if (connectors.get(strippedDownName) != null) {
             String sanitizedDataset = sanitiseName(dataset);
             String filename = path + "/" + sanitizedDataset + ".json";
             PersistentState persistentState = new PersistentState(filename);
@@ -154,6 +156,15 @@ public class FMod_FusekiKafkaSCG extends FMod_FusekiKafka {
             FmtLog.info(LOG, errorMessage);
             resultNode.put("success", false);
             resultNode.put("reason", errorMessage);
+        }
+    }
+
+    public static String stripStringPath(String input) {
+        int lastSlashIndex = input.lastIndexOf("/");
+        if (lastSlashIndex != -1) {
+            return input.substring(0, lastSlashIndex);
+        } else {
+            return input;
         }
     }
 }

--- a/scg-system/src/test/java/io/telicent/core/TestFusekiKafkaSCG.java
+++ b/scg-system/src/test/java/io/telicent/core/TestFusekiKafkaSCG.java
@@ -83,10 +83,10 @@ public class TestFusekiKafkaSCG {
         KConnectorDesc mockDesc = mock(KConnectorDesc.class);
         when(mockDesc.getStateFile()).thenReturn(stateFile.getAbsolutePath());
 
-        cut.connectors.put("matchingdataset", mockDesc);
+        cut.connectors.put("/matchingdataset", mockDesc);
 
         DataAccessPoint mockDataAccessPoint = mock(DataAccessPoint.class);
-        when(mockDataAccessPoint.getName()).thenReturn("matchingdataset");
+        when(mockDataAccessPoint.getName()).thenReturn("/matchingdataset/upload");
 
         // when
         cut.backupKafka(mockDataAccessPoint, tempDir.toString(), node);
@@ -96,7 +96,7 @@ public class TestFusekiKafkaSCG {
         assertTrue(node.has("success"));
         assertFalse(node.has("reason"));
         assertTrue(node.get("success").asBoolean());
-        File copiedFile = new File(tempDir.toString(), "matchingdataset.json");
+        File copiedFile = new File(tempDir.toString(), "matchingdataset_upload.json");
         assertTrue(copiedFile.exists());
 
     }
@@ -149,7 +149,7 @@ public class TestFusekiKafkaSCG {
         Path tempDir = Files.createTempDirectory("test_restore_dir2");
         tempDir.toFile().deleteOnExit();
 
-        File stateFile = new File(tempDir.toString(), "matchingdataset.json");
+        File stateFile = new File(tempDir.toString(), "matchingdataset_upload.json");
         assertTrue(stateFile.createNewFile());
         stateFile.deleteOnExit();
 
@@ -169,10 +169,10 @@ public class TestFusekiKafkaSCG {
         ObjectNode node = MAPPER.createObjectNode();
         KConnectorDesc mockDesc = mock(KConnectorDesc.class);
 
-        cut.connectors.put("matchingdataset", mockDesc);
+        cut.connectors.put("/matchingdataset", mockDesc);
 
         DataAccessPoint mockDataAccessPoint = mock(DataAccessPoint.class);
-        when(mockDataAccessPoint.getName()).thenReturn("matchingdataset");
+        when(mockDataAccessPoint.getName()).thenReturn("/matchingdataset/upload");
 
         // when
         cut.restoreKafka(mockDataAccessPoint, tempDir.toString(), node);


### PR DESCRIPTION
Fixing issues with Kafka Connections which could have additional path suffix to underlying dataset.

We have config as such:

:connector3  rdf:type         fk:Connector;
        fk:configFile         "env:{KAFKA_CONFIG_FILE_PATH:}";
        fk:fusekiServiceName  "/catalog/upload";
        fk:replayTopic        false;
        fk:stateFile          "/fuseki/databases/Replay-Catalog-RDF.state";
        fk:topic              "catalog" .

for the "catalog" dataset. 

That means when looking up "/catalog" doesn't match. We need to strip that off. 