### PR TITLE
CORE-738: adding ability to query triple access

### DIFF
--- a/docs/access-api.yaml
+++ b/docs/access-api.yaml
@@ -7,10 +7,17 @@ servers:
   - url: http://localhost:3030/
     description: Base path for query operations.
 paths:
-  /$/access/query:
+  /{datasetName}/access/query:
     post:
       summary: Return the objects for a given subject and predicate in an RDF triple
       description: Returns zero or more objects for a given subject and predicate in an RDF triple provided 1) they exist and 2) the user has access - otherwise null is returned.
+      parameters:
+        - name: datasetName
+          in: path
+          required: true
+          description: The name of the dataset to query.
+          schema:
+            type: string
       requestBody:
         description: The subject and predicate to retrieve objects for.
         required: true

--- a/docs/access-api.yaml
+++ b/docs/access-api.yaml
@@ -1,0 +1,81 @@
+openapi: 3.0.3
+info:
+  title: Triple Access Query API
+  description: API for querying access to RDF triples.
+  version: 0.83.6
+servers:
+  - url: http://localhost:3030/
+    description: Base path for query operations.
+paths:
+  /$/access/query:
+    post:
+      summary: Return the objects for a given subject and predicate in an RDF triple
+      description: Returns zero or more objects for a given subject and predicate in an RDF triple provided 1) they exist and 2) the user has access - otherwise null is returned.
+      requestBody:
+        description: The subject and predicate to retrieve objects for.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                subject:
+                  type: string
+                predicate:
+                  type: string
+            examples:
+              London Population:
+                value:
+                  subject: http://dbpedia.org/resource/London
+                  predicate: http://dbpedia.org/ontology/populationTotal
+              London Country:
+                value:
+                  subject: http://dbpedia.org/resource/London
+                  predicate: http://dbpedia.org/ontology/country
+              London Birth Date:
+                value:
+                  subject: http://dbpedia.org/resource/London
+                  predicate: http://dbpedia.org/ontology/birthDate
+      responses:
+        '200':
+          description: Request processed successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  subject:
+                    type: string
+                  predicate:
+                    type: string
+                  objects:
+                    type: array
+                    items:
+                      type: string
+                    description: List of the labels.
+              examples:
+                London Population:
+                  value:
+                    subject: http://dbpedia.org/resource/London
+                    predicate: http://dbpedia.org/ontology/populationTotal
+                    objects: [  "\"8799800\"^^xsd:integer" ]
+                London Country:
+                  value:
+                    subject: http://dbpedia.org/resource/London
+                    predicate: http://dbpedia.org/ontology/country
+                    objects: [ "http://dbpedia.org/resource/United_Kingdom", "http://dbpedia.org/resource/England" ]
+                London Birth Date:
+                  value:
+                    subject: http://dbpedia.org/resource/London
+                    predicate: http://dbpedia.org/ontology/birthDate
+                    objects: null
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error message.

--- a/scg-system/src/main/java/io/telicent/access/AccessQuery.java
+++ b/scg-system/src/main/java/io/telicent/access/AccessQuery.java
@@ -1,0 +1,6 @@
+package io.telicent.access;
+
+public class AccessQuery {
+    public String subject;
+    public String predicate;
+}

--- a/scg-system/src/main/java/io/telicent/access/AccessQueryResults.java
+++ b/scg-system/src/main/java/io/telicent/access/AccessQueryResults.java
@@ -1,0 +1,17 @@
+package io.telicent.access;
+
+import java.util.List;
+
+public class AccessQueryResults {
+
+    public String subject;
+    public String predicate;
+    public List<String> objects;
+
+    public AccessQueryResults(AccessQuery query, List<String> objects){
+        this.subject = query.subject;
+        this.predicate = query.predicate;
+        this.objects = objects;
+    }
+
+}

--- a/scg-system/src/main/java/io/telicent/access/FMod_AccessQuery.java
+++ b/scg-system/src/main/java/io/telicent/access/FMod_AccessQuery.java
@@ -18,22 +18,15 @@ public class FMod_AccessQuery implements FusekiAutoModule {
     }
 
     @Override
-    public void configured(FusekiServer.Builder serverBuilder, DataAccessPointRegistry dapRegistry, Model configModel) {
-        final AccessQueryService queryService = getAccessQueryService(dapRegistry);
-        if(queryService != null) {
-            serverBuilder.addServlet("/$/access/query", new AccessQueryServlet(queryService));
-        }
-    }
-
-    private AccessQueryService getAccessQueryService(DataAccessPointRegistry dapRegistry) {
-        AccessQueryService accessQueryService = null;
+    public void configured(final FusekiServer.Builder serverBuilder, final DataAccessPointRegistry dapRegistry, final Model configModel) {
         for (DataAccessPoint dap : dapRegistry.accessPoints()) {
             final DatasetGraph dsg = dap.getDataService().getDataset();
             if (dsg instanceof DatasetGraphABAC abac) {
-                accessQueryService = new AccessQueryService(abac);
+                final String datasetName = dap.getName();
+                final AccessQueryService queryService = new AccessQueryService(abac);
+                serverBuilder.addServlet(datasetName + "/access/query", new AccessQueryServlet(queryService));
             }
         }
-        return accessQueryService;
     }
 
 }

--- a/scg-system/src/main/java/io/telicent/access/FMod_AccessQuery.java
+++ b/scg-system/src/main/java/io/telicent/access/FMod_AccessQuery.java
@@ -1,0 +1,39 @@
+package io.telicent.access;
+
+import io.telicent.access.services.AccessQueryService;
+import io.telicent.access.servlets.AccessQueryServlet;
+import io.telicent.jena.abac.core.DatasetGraphABAC;
+import org.apache.jena.fuseki.main.FusekiServer;
+import org.apache.jena.fuseki.main.sys.FusekiAutoModule;
+import org.apache.jena.fuseki.server.DataAccessPoint;
+import org.apache.jena.fuseki.server.DataAccessPointRegistry;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.sparql.core.DatasetGraph;
+
+public class FMod_AccessQuery implements FusekiAutoModule {
+
+    @Override
+    public String name() {
+        return "Access Query Module";
+    }
+
+    @Override
+    public void configured(FusekiServer.Builder serverBuilder, DataAccessPointRegistry dapRegistry, Model configModel) {
+        final AccessQueryService queryService = getAccessQueryService(dapRegistry);
+        if(queryService != null) {
+            serverBuilder.addServlet("/$/access/query", new AccessQueryServlet(queryService));
+        }
+    }
+
+    private AccessQueryService getAccessQueryService(DataAccessPointRegistry dapRegistry) {
+        AccessQueryService accessQueryService = null;
+        for (DataAccessPoint dap : dapRegistry.accessPoints()) {
+            final DatasetGraph dsg = dap.getDataService().getDataset();
+            if (dsg instanceof DatasetGraphABAC abac) {
+                accessQueryService = new AccessQueryService(abac);
+            }
+        }
+        return accessQueryService;
+    }
+
+}

--- a/scg-system/src/main/java/io/telicent/access/services/AccessQueryService.java
+++ b/scg-system/src/main/java/io/telicent/access/services/AccessQueryService.java
@@ -17,7 +17,7 @@ public class AccessQueryService implements ABAC_Processor {
         this.datasetGraph = datasetGraph;
     }
 
-    public List<Triple> getTriples(HttpAction action, Triple triple) {
+    public List<Triple> getTriples(final HttpAction action, final Triple triple) {
         final DatasetGraph datasetGraphForUser = ABAC_Request.decideDataset(action, datasetGraph, ServerABAC.userForRequest());
         return datasetGraphForUser.getDefaultGraph().find(triple).toList();
     }

--- a/scg-system/src/main/java/io/telicent/access/services/AccessQueryService.java
+++ b/scg-system/src/main/java/io/telicent/access/services/AccessQueryService.java
@@ -1,0 +1,25 @@
+package io.telicent.access.services;
+
+import io.telicent.jena.abac.fuseki.ABAC_Processor;
+import io.telicent.jena.abac.fuseki.ABAC_Request;
+import io.telicent.jena.abac.fuseki.ServerABAC;
+import org.apache.jena.fuseki.servlets.HttpAction;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.sparql.core.DatasetGraph;
+
+import java.util.List;
+
+public class AccessQueryService implements ABAC_Processor {
+
+    private final DatasetGraph datasetGraph;
+
+    public AccessQueryService(DatasetGraph datasetGraph) {
+        this.datasetGraph = datasetGraph;
+    }
+
+    public List<Triple> getTriples(HttpAction action, Triple triple) {
+        final DatasetGraph datasetGraphForUser = ABAC_Request.decideDataset(action, datasetGraph, ServerABAC.userForRequest());
+        return datasetGraphForUser.getDefaultGraph().find(triple).toList();
+    }
+
+}

--- a/scg-system/src/main/java/io/telicent/access/servlets/AccessQueryServlet.java
+++ b/scg-system/src/main/java/io/telicent/access/servlets/AccessQueryServlet.java
@@ -1,0 +1,73 @@
+package io.telicent.access.servlets;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.telicent.access.AccessQuery;
+import io.telicent.access.AccessQueryResults;
+import io.telicent.access.services.AccessQueryService;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.jena.fuseki.servlets.HttpAction;
+import org.apache.jena.fuseki.system.ActionCategory;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.kafka.FusekiKafka;
+import org.apache.jena.riot.WebContent;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AccessQueryServlet extends HttpServlet {
+
+    private final static Logger LOG = FusekiKafka.LOG;
+
+    public static ObjectMapper MAPPER = new ObjectMapper();
+
+    private final AccessQueryService queryService;
+
+    public AccessQueryServlet(AccessQueryService queryService) {
+        this.queryService = queryService;
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        try (final InputStream inputStream = request.getInputStream()) {
+            final AccessQuery query = MAPPER.readValue(inputStream, AccessQuery.class);
+            final Triple accessQueryTriple = getAccessQueryTriple(query);
+            final HttpAction action = new HttpAction(1L, LOG, ActionCategory.ACTION, request, response);
+            final List<Triple> triples = queryService.getTriples(action, accessQueryTriple);
+            final List<String> results = new ArrayList<>();
+            for (Triple triple : triples) {
+                results.add(triple.getObject().toString());
+            }
+            final AccessQueryResults queryResults = new AccessQueryResults(query, (results.isEmpty() ? null : results));
+            processResponse(response, queryResults);
+        }
+    }
+
+    private static void processResponse(HttpServletResponse response, AccessQueryResults results) {
+        String jsonOutput;
+        try (ServletOutputStream out = response.getOutputStream()) {
+            jsonOutput = MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(results);
+            response.setContentLength(jsonOutput.length());
+            response.setContentType(WebContent.contentTypeJSON);
+            response.setCharacterEncoding(WebContent.charsetUTF8);
+            out.print(jsonOutput);
+        } catch (IOException ex) {
+            response.setStatus(HttpServletResponse.SC_UNPROCESSABLE_CONTENT);
+        }
+    }
+
+    private Triple getAccessQueryTriple(AccessQuery accessQuery) {
+        final Node s = NodeFactory.createURI(accessQuery.subject);
+        final Node p = NodeFactory.createURI(accessQuery.predicate);
+        final Node o = Node.ANY;
+        return Triple.create(s, p, o);
+    }
+
+}

--- a/scg-system/src/main/java/io/telicent/backup/services/DatasetBackupService.java
+++ b/scg-system/src/main/java/io/telicent/backup/services/DatasetBackupService.java
@@ -22,7 +22,6 @@ import io.telicent.jena.abac.core.DatasetGraphABAC;
 import io.telicent.jena.abac.labels.LabelsStore;
 import io.telicent.jena.abac.labels.LabelsStoreRocksDB;
 import io.telicent.jena.abac.labels.node.LabelToNodeGenerator;
-import io.telicent.jena.graphql.utils.ExcludeFromJacocoGeneratedReport;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.io.FileUtils;

--- a/scg-system/src/main/java/io/telicent/backup/utils/BackupUtils.java
+++ b/scg-system/src/main/java/io/telicent/backup/utils/BackupUtils.java
@@ -16,26 +16,23 @@
 
 package io.telicent.backup.utils;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.telicent.smart.cache.configuration.Configurator;
-import jakarta.servlet.ServletOutputStream;
+import io.telicent.utils.ServletUtils;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.jena.atlas.logging.FmtLog;
-import org.apache.jena.riot.WebContent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.*;
 import java.util.stream.Stream;
 
 /**
  * Utility class for carrying out common back-up operations and file I/O.
  */
-public class BackupUtils {
+public class BackupUtils extends ServletUtils {
 
     public static final Logger LOG = LoggerFactory.getLogger("BackupUtils");
 
@@ -45,8 +42,6 @@ public class BackupUtils {
     public static final String ENV_BACKUPS_DIR = "ENV_BACKUPS_DIR";
 
     public static String dirBackups;
-
-    public static ObjectMapper MAPPER = new ObjectMapper();
 
     private BackupUtils() {
     }
@@ -344,24 +339,6 @@ public class BackupUtils {
         directory.delete();
     }
 
-    /**
-     * Populate an HTTP Response from given JSON Node
-     *
-     * @param response     Response to populate
-     * @param jsonResponse Response data (in JSON form).
-     */
-    public static void processResponse(HttpServletResponse response, ObjectNode jsonResponse) {
-        String jsonOutput;
-        try (ServletOutputStream out = response.getOutputStream()) {
-            jsonOutput = MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(jsonResponse);
-            response.setContentLength(jsonOutput.length());
-            response.setContentType(WebContent.contentTypeJSON);
-            response.setCharacterEncoding(WebContent.charsetUTF8);
-            out.print(jsonOutput);
-        } catch (IOException ex) {
-            response.setStatus(HttpServletResponse.SC_UNPROCESSABLE_CONTENT);
-        }
-    }
 
     /**
      * Populate an HTTP Response with error data
@@ -376,19 +353,6 @@ public class BackupUtils {
         processResponse(response, jsonResponse);
     }
 
-    /**
-     * Populate an HTTP Response with error data
-     *
-     * @param response     Response to populate
-     * @param jsonResponse Response data (in JSON form)
-     * @param status       HTTP status code for response
-     * @param message      Description of error encountered
-     */
-    public static void handleError(HttpServletResponse response, ObjectNode jsonResponse, int status, String message) {
-        response.setStatus(status);
-        jsonResponse.put("error", message);
-        processResponse(response, jsonResponse);
-    }
 
     /**
      * Checks to see if the requested parameter is empty or just a '/'

--- a/scg-system/src/main/java/io/telicent/core/SmartCacheGraph.java
+++ b/scg-system/src/main/java/io/telicent/core/SmartCacheGraph.java
@@ -16,6 +16,7 @@
 
 package io.telicent.core;
 
+import io.telicent.access.FMod_AccessQuery;
 import io.telicent.backup.FMod_BackupData;
 import io.telicent.graphql.FMod_TelicentGraphQL;
 import io.telicent.jena.abac.fuseki.FMod_ABAC;
@@ -122,6 +123,7 @@ public class SmartCacheGraph {
                 , new FMod_RequestIDFilter()
                 , new FMod_BackupData()
                 , new FMod_LabelsQuery()
+                , new FMod_AccessQuery()
         ));
 
         // Initial compaction gets added again per the earlier comments

--- a/scg-system/src/main/java/io/telicent/labels/servlets/LabelsQueryServlet.java
+++ b/scg-system/src/main/java/io/telicent/labels/servlets/LabelsQueryServlet.java
@@ -22,7 +22,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import static io.telicent.backup.utils.BackupUtils.processResponse;
+import static io.telicent.utils.ServletUtils.*;
 
 public class LabelsQueryServlet extends HttpServlet {
 

--- a/scg-system/src/main/java/io/telicent/utils/ServletUtils.java
+++ b/scg-system/src/main/java/io/telicent/utils/ServletUtils.java
@@ -1,0 +1,50 @@
+package io.telicent.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.jena.riot.WebContent;
+
+import java.io.IOException;
+
+/**
+ * Utility class for carrying out common servlet operations
+ */
+public class ServletUtils {
+
+    public static ObjectMapper MAPPER = new ObjectMapper();
+
+    /**
+     * Populate an HTTP Response from given JSON Node
+     *
+     * @param response     Response to populate
+     * @param jsonResponse Response data (in JSON form).
+     */
+    public static void processResponse(HttpServletResponse response, ObjectNode jsonResponse) {
+        String jsonOutput;
+        try (ServletOutputStream out = response.getOutputStream()) {
+            jsonOutput = MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(jsonResponse);
+            response.setContentLength(jsonOutput.length());
+            response.setContentType(WebContent.contentTypeJSON);
+            response.setCharacterEncoding(WebContent.charsetUTF8);
+            out.print(jsonOutput);
+        } catch (IOException ex) {
+            response.setStatus(HttpServletResponse.SC_UNPROCESSABLE_CONTENT);
+        }
+    }
+
+    /**
+     * Populate an HTTP Response with error data
+     *
+     * @param response     Response to populate
+     * @param jsonResponse Response data (in JSON form)
+     * @param status       HTTP status code for response
+     * @param message      Description of error encountered
+     */
+    public static void handleError(HttpServletResponse response, ObjectNode jsonResponse, int status, String message) {
+        response.setStatus(status);
+        jsonResponse.put("error", message);
+        processResponse(response, jsonResponse);
+    }
+}

--- a/scg-system/src/main/java/io/telicent/utils/SmartCacheGraphException.java
+++ b/scg-system/src/main/java/io/telicent/utils/SmartCacheGraphException.java
@@ -1,0 +1,9 @@
+package io.telicent.utils;
+
+public class SmartCacheGraphException extends Exception {
+
+    public SmartCacheGraphException(String message) {
+        super(message);
+    }
+
+}

--- a/scg-system/src/test/files/access-query-data-labelled-ds1.trig
+++ b/scg-system/src/test/files/access-query-data-labelled-ds1.trig
@@ -2,7 +2,7 @@ PREFIX dbr: <http://dbpedia.org/resource/>
 PREFIX dbo: <http://dbpedia.org/ontology/>
 PREFIX security: <http://telicent.io/security#>
 
-## Basic data on 3 cities
+## Some London data
 dbr:London dbo:populationTotal 8799800 .
 dbr:London dbo:country dbr:United_Kingdom .
 dbr:London dbo:country dbr:England .

--- a/scg-system/src/test/files/access-query-data-labelled-ds2.trig
+++ b/scg-system/src/test/files/access-query-data-labelled-ds2.trig
@@ -1,0 +1,17 @@
+PREFIX dbr: <http://dbpedia.org/resource/>
+PREFIX dbo: <http://dbpedia.org/ontology/>
+PREFIX security: <http://telicent.io/security#>
+
+## Some Paris data
+dbr:Paris dbo:populationTotal 2165423 .
+dbr:Paris dbo:country dbr:France .
+
+## ABAC Security labels to apply
+GRAPH security:labels {
+
+    ## Something everyone can see
+    [ security:pattern 'dbr:Paris dbo:country dbr:France'  ; security:label "everyone" ] .
+
+    ## Something only admin users can see
+    [ security:pattern 'dbr:Paris dbo:populationTotal 2165423'  ; security:label "admin" ] .
+}

--- a/scg-system/src/test/files/access-query-data-labelled.trig
+++ b/scg-system/src/test/files/access-query-data-labelled.trig
@@ -1,0 +1,19 @@
+PREFIX dbr: <http://dbpedia.org/resource/>
+PREFIX dbo: <http://dbpedia.org/ontology/>
+PREFIX security: <http://telicent.io/security#>
+
+## Basic data on 3 cities
+dbr:London dbo:populationTotal 8799800 .
+dbr:London dbo:country dbr:United_Kingdom .
+dbr:London dbo:country dbr:England .
+
+## ABAC Security labels to apply
+GRAPH security:labels {
+
+    ## Something everyone can see
+    [ security:pattern 'dbr:London dbo:country dbr:United_Kingdom'  ; security:label "everyone" ] .
+
+    ## Something only admin users can see
+    [ security:pattern 'dbr:London dbo:populationTotal 8799800'  ; security:label "admin" ] .
+    [ security:pattern 'dbr:London dbo:country dbr:England' ; security:label "admin" ] .
+}

--- a/scg-system/src/test/files/access-query-test-attribute-store.ttl
+++ b/scg-system/src/test/files/access-query-test-attribute-store.ttl
@@ -1,0 +1,10 @@
+PREFIX security: <http://telicent.io/security#>
+
+[] security:user "User1" ;
+    security:userAttribute "everyone";
+    .
+    
+[] security:user "User2" ;
+   security:userAttribute "admin";
+   security:userAttribute "everyone";
+    .

--- a/scg-system/src/test/files/access-query-test-config.ttl
+++ b/scg-system/src/test/files/access-query-test-config.ttl
@@ -4,19 +4,34 @@ PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
 PREFIX authz:   <http://telicent.io/security#>
 
-:secureService rdf:type fuseki:Service ;
-    fuseki:name "ds" ;
+:secureService1 rdf:type fuseki:Service ;
+    fuseki:name "ds1" ;
     fuseki:endpoint [ fuseki:operation fuseki:query ; fuseki:name "query" ] ;
     fuseki:endpoint [ fuseki:operation fuseki:gsp-r ; fuseki:name "read" ] ;
     fuseki:endpoint [ fuseki:operation authz:upload ; fuseki:name "upload" ] ;
-    fuseki:dataset :dataset ;
+    fuseki:dataset :dataset1 ;
     .
 
-:dataset rdf:type authz:DatasetAuthz ;
+:secureService2 rdf:type fuseki:Service ;
+    fuseki:name "ds2" ;
+    fuseki:endpoint [ fuseki:operation fuseki:query ; fuseki:name "query" ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:gsp-r ; fuseki:name "read" ] ;
+    fuseki:endpoint [ fuseki:operation authz:upload ; fuseki:name "upload" ] ;
+    fuseki:dataset :dataset2 ;
+    .
+
+:dataset1 rdf:type authz:DatasetAuthz ;
          authz:dataset :inMemoryDatabase;
          authz:labelsStore  [ authz:labelsStorePath "labels" ];
          authz:attributes <file:access-query-test-attribute-store.ttl> ;
          authz:tripleDefaultAttributes "!";
          .
+
+:dataset2 rdf:type authz:DatasetAuthz ;
+         authz:dataset :inMemoryDatabase;
+         authz:labelsStore  [ authz:labelsStorePath "labels" ];
+         authz:attributes <file:access-query-test-attribute-store.ttl> ;
+         authz:tripleDefaultAttributes "!";
+.
 
 :inMemoryDatabase rdf:type ja:MemoryDataset .

--- a/scg-system/src/test/files/access-query-test-config.ttl
+++ b/scg-system/src/test/files/access-query-test-config.ttl
@@ -1,0 +1,22 @@
+PREFIX :        <#>
+PREFIX fuseki:  <http://jena.apache.org/fuseki#>
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
+PREFIX authz:   <http://telicent.io/security#>
+
+:secureService rdf:type fuseki:Service ;
+    fuseki:name "ds" ;
+    fuseki:endpoint [ fuseki:operation fuseki:query ; fuseki:name "query" ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:gsp-r ; fuseki:name "read" ] ;
+    fuseki:endpoint [ fuseki:operation authz:upload ; fuseki:name "upload" ] ;
+    fuseki:dataset :dataset ;
+    .
+
+:dataset rdf:type authz:DatasetAuthz ;
+         authz:dataset :inMemoryDatabase;
+         authz:labelsStore  [ authz:labelsStorePath "labels" ];
+         authz:attributes <file:access-query-test-attribute-store.ttl> ;
+         authz:tripleDefaultAttributes "!";
+         .
+
+:inMemoryDatabase rdf:type ja:MemoryDataset .

--- a/scg-system/src/test/java/io/telicent/access/TestAccessQueryService.java
+++ b/scg-system/src/test/java/io/telicent/access/TestAccessQueryService.java
@@ -1,0 +1,192 @@
+package io.telicent.access;
+
+import io.telicent.LibTestsSCG;
+import io.telicent.jena.abac.fuseki.SysFusekiABAC;
+import io.telicent.smart.cache.configuration.Configurator;
+import org.apache.jena.fuseki.main.FusekiServer;
+import org.apache.jena.fuseki.system.FusekiLogging;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+
+import static io.telicent.LibTestsSCG.tokenHeader;
+import static io.telicent.LibTestsSCG.tokenHeaderValue;
+import static io.telicent.core.SmartCacheGraph.construct;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestAccessQueryService {
+
+    private static final Path DIR = Path.of("src/test/files");
+    private static final String SERVICE_NAME = "ds";
+    private FusekiServer server;
+    private HttpClient httpClient;
+    private static final String REQUEST_COUNTRY = """
+            {
+              "subject":"http://dbpedia.org/resource/London",
+              "predicate":"http://dbpedia.org/ontology/country"
+            }""";
+
+    private static final String REQUEST_POPULATION = """
+            {
+              "subject":"http://dbpedia.org/resource/London",
+              "predicate":"http://dbpedia.org/ontology/populationTotal"
+            }""";
+
+    private static final String USER1 = "User1";
+    private static final String USER2 = "User2";
+
+    @BeforeEach
+    void setUp() throws Exception {
+        FusekiLogging.setLogging();
+        SysFusekiABAC.init();
+        LibTestsSCG.setupAuthentication();
+        LibTestsSCG.disableInitialCompaction();
+        httpClient = HttpClient.newHttpClient();
+    }
+
+    @AfterEach
+    void clearDown() throws Exception {
+        LibTestsSCG.teardownAuthentication();
+        if (null != server) {
+            server.stop();
+        }
+        Configurator.reset();
+    }
+
+    @AfterAll
+    static void afterAll() throws Exception {
+        FileUtils.deleteDirectory(new File("labels"));
+    }
+
+    /**
+     * In this test the User should be able to access one country object got the subject and predicate
+     */
+    @Test
+    void testUserAccessCountry() throws Exception {
+        final String expectedResponseBody = """
+                {
+                  "subject" : "http://dbpedia.org/resource/London",
+                  "predicate" : "http://dbpedia.org/ontology/country",
+                  "objects" : [ "http://dbpedia.org/resource/United_Kingdom" ]
+                }""";
+
+        startServer();
+        loadData();
+        final String response = callAccessQueryEndpoint(REQUEST_COUNTRY, USER1);
+        assertEquals(expectedResponseBody, response, "Unexpected access query response");
+    }
+
+    /**
+     * In this test the User should not be able to access a population value for the subject and predicate
+     */
+    @Test
+    void testUserNoAccessPopulation() throws Exception {
+        final String expectedResponseBody = """
+                {
+                  "subject" : "http://dbpedia.org/resource/London",
+                  "predicate" : "http://dbpedia.org/ontology/populationTotal",
+                  "objects" : null
+                }""";
+
+        startServer();
+        loadData();
+        final String response = callAccessQueryEndpoint(REQUEST_POPULATION, USER1);
+        assertEquals(expectedResponseBody, response, "Unexpected access query response");
+    }
+
+    /**
+     * In this test the Admin user should be able to access two country objects for the subject and predicate
+     */
+    @Test
+    void testAdminAccessCountry() throws Exception {
+        final String expectedResponseBody = """
+                {
+                  "subject" : "http://dbpedia.org/resource/London",
+                  "predicate" : "http://dbpedia.org/ontology/country",
+                  "objects" : [ "http://dbpedia.org/resource/United_Kingdom", "http://dbpedia.org/resource/England" ]
+                }""";
+
+        startServer();
+        loadData();
+        final String response = callAccessQueryEndpoint(REQUEST_COUNTRY, USER2);
+        assertEquals(expectedResponseBody, response, "Unexpected access query response");
+    }
+
+    /**
+     * In this test the Admin user should be able to access the population value for the subject and predicate
+     */
+    @Test
+    void testAdminAccessPopulation() throws Exception {
+        final String expectedResponseBody = """
+                {
+                  "subject" : "http://dbpedia.org/resource/London",
+                  "predicate" : "http://dbpedia.org/ontology/populationTotal",
+                  "objects" : [ "\\"8799800\\"^^xsd:integer" ]
+                }""";
+
+        startServer();
+        loadData();
+        final String response = callAccessQueryEndpoint(REQUEST_POPULATION, USER2);
+        assertEquals(expectedResponseBody, response, "Unexpected access query response");
+    }
+
+    /**
+     * In this test the Admin user attempts to access a subject and predicate for which there is no match
+     */
+    @Test
+    void testAdminAccessNoMatch() throws Exception {
+        final String noMatchRequest = """
+            {
+              "subject":"http://dbpedia.org/resource/Paris",
+              "predicate":"http://dbpedia.org/ontology/country"
+            }""";
+        final String expectedResponseBody = """
+                {
+                  "subject" : "http://dbpedia.org/resource/Paris",
+                  "predicate" : "http://dbpedia.org/ontology/country",
+                  "objects" : null
+                }""";
+        startServer();
+        loadData();
+        final String response = callAccessQueryEndpoint(noMatchRequest, USER2);
+        assertEquals(expectedResponseBody, response, "Unexpected access query response");
+    }
+
+
+    /**
+     * Calls the upload endpoint passing in the data file for loading
+     */
+    private void loadData() {
+        LibTestsSCG.uploadFile(server.serverURL() + SERVICE_NAME + "/upload", DIR + "/access-query-data-labelled.trig");
+    }
+
+    private String callAccessQueryEndpoint(String requestBody, String user) throws Exception {
+        final String accessQueryUrl = server.serverURL() + "$/access/query";
+        final String bearerToken = LibTestsSCG.tokenForUser(user);
+        final HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(accessQueryUrl))
+                .header("Content-type", "application/json")
+                .header(tokenHeader(), tokenHeaderValue(bearerToken))
+                .POST(HttpRequest.BodyPublishers.ofString(requestBody, StandardCharsets.UTF_8))
+                .build();
+        final HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        return response.body();
+    }
+
+    private void startServer() {
+        final List<String> arguments = List.of("--conf", DIR + "/access-query-test-config.ttl");
+        server = construct(arguments.toArray(new String[0])).start();
+    }
+
+}


### PR DESCRIPTION
This PR adds an endpoint at `/$/access/query` which accepts POST requests containing a subject and predicate and returns the same subject and predicate, plus an objects property which either contains an array of the object values for any triples that match that match the subject and predicate, or null if there is nothing found or the user has no access to the information.