### PR TITLE
CORE-743: Adding endpoint to show user access to triple(s) as boolean

### DIFF
--- a/docs/access-api.yaml
+++ b/docs/access-api.yaml
@@ -86,3 +86,92 @@ paths:
                   error:
                     type: string
                     description: Error message.
+  /{datasetName}/access/triple:
+    post:
+      summary: Return a boolean value to indicate whether the requested triple(s) are visible to the user.
+      description: Returns the request triples together with a boolean indicating whether the request triples are visible to the user, depending on 1) whether they exist 2) whether the user has access to see them 3) whether the user has indicated they want to know if all are visible or any of them.
+      parameters:
+        - name: datasetName
+          in: path
+          required: true
+          description: The name of the dataset to query.
+          schema:
+            type: string
+        - name: all
+          in: query
+          required: false
+          description: All triples need to be visible, not just some.
+          schema:
+            type: boolean
+            default: true
+      requestBody:
+        description: An array or triples, each containing the subject, predicate and object to be checked.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                triples:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      subject:
+                        type: string
+                      predicate:
+                        type: string
+                      object:
+                        type: string
+            examples:
+              London:
+                value:
+                  triples:
+                    - subject: http://dbpedia.org/resource/London
+                      predicate: http://dbpedia.org/ontology/populationTotal
+                      object: "8799800"
+                    - subject: http://dbpedia.org/resource/London
+                      predicate: http://dbpedia.org/ontology/country
+                      object: http://dbpedia.org/resource/United_Kingdom
+      responses:
+        '200':
+          description: Request processed successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  triples:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        subject:
+                          type: array
+                        predicate:
+                          type: string
+                        object:
+                          type: string
+                  visible:
+                    type: boolean
+              examples:
+                London:
+                  value:
+                    triples:
+                      - subject: http://dbpedia.org/resource/London
+                        predicate: http://dbpedia.org/ontology/populationTotal
+                        object: "8799800"
+                      - subject: http://dbpedia.org/resource/London
+                        predicate: http://dbpedia.org/ontology/country
+                        object: http://dbpedia.org/resource/United_Kingdom
+                    visible: true
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error message.

--- a/scg-system/src/main/java/io/telicent/access/AccessTriplesResults.java
+++ b/scg-system/src/main/java/io/telicent/access/AccessTriplesResults.java
@@ -1,0 +1,17 @@
+package io.telicent.access;
+
+import io.telicent.model.JsonTriple;
+
+import java.util.List;
+
+public class AccessTriplesResults {
+
+    public List<JsonTriple> triples;
+
+    public boolean visible;
+
+    public AccessTriplesResults(List<JsonTriple> triples, boolean visible) {
+        this.triples = triples;
+        this.visible = visible;
+    }
+}

--- a/scg-system/src/main/java/io/telicent/access/FMod_AccessQuery.java
+++ b/scg-system/src/main/java/io/telicent/access/FMod_AccessQuery.java
@@ -2,6 +2,7 @@ package io.telicent.access;
 
 import io.telicent.access.services.AccessQueryService;
 import io.telicent.access.servlets.AccessQueryServlet;
+import io.telicent.access.servlets.AccessTriplesServlet;
 import io.telicent.jena.abac.core.DatasetGraphABAC;
 import org.apache.jena.fuseki.main.FusekiServer;
 import org.apache.jena.fuseki.main.sys.FusekiAutoModule;
@@ -25,6 +26,7 @@ public class FMod_AccessQuery implements FusekiAutoModule {
                 final String datasetName = dap.getName();
                 final AccessQueryService queryService = new AccessQueryService(abac);
                 serverBuilder.addServlet(datasetName + "/access/query", new AccessQueryServlet(queryService));
+                serverBuilder.addServlet( datasetName + "/access/triples", new AccessTriplesServlet(queryService));
             }
         }
     }

--- a/scg-system/src/main/java/io/telicent/access/services/AccessQueryService.java
+++ b/scg-system/src/main/java/io/telicent/access/services/AccessQueryService.java
@@ -22,4 +22,15 @@ public class AccessQueryService implements ABAC_Processor {
         return datasetGraphForUser.getDefaultGraph().find(triple).toList();
     }
 
+    public int getVisibleTriplesCount(final HttpAction action, final List<Triple> triples){
+        final DatasetGraph datasetGraphForUser = ABAC_Request.decideDataset(action, datasetGraph, ServerABAC.userForRequest());
+        int visibleCount = 0;
+        for(Triple triple : triples) {
+            if(datasetGraphForUser.getDefaultGraph().contains(triple)){
+                visibleCount++;
+            }
+        }
+        return visibleCount;
+    }
+
 }

--- a/scg-system/src/main/java/io/telicent/access/servlets/AccessTriplesServlet.java
+++ b/scg-system/src/main/java/io/telicent/access/servlets/AccessTriplesServlet.java
@@ -1,0 +1,106 @@
+package io.telicent.access.servlets;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.telicent.model.JsonTriple;
+import io.telicent.model.JsonTriples;
+import io.telicent.access.AccessTriplesResults;
+import io.telicent.access.services.AccessQueryService;
+import io.telicent.utils.SmartCacheGraphException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.jena.fuseki.servlets.HttpAction;
+import org.apache.jena.fuseki.system.ActionCategory;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.kafka.FusekiKafka;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static io.telicent.utils.ServletUtils.handleError;
+import static io.telicent.utils.ServletUtils.processResponse;
+
+public class AccessTriplesServlet extends HttpServlet {
+
+    private final static Logger LOG = FusekiKafka.LOG;
+    private final static String HTTP = "http://";
+    private final static String HTTPS = "https://";
+
+    public static ObjectMapper MAPPER = new ObjectMapper();
+
+
+    private final AccessQueryService queryService;
+
+    public AccessTriplesServlet(AccessQueryService queryService) {
+        this.queryService = queryService;
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        boolean requireAllVisible = isAllVisibleRequired(request.getQueryString());
+        try (final InputStream inputStream = request.getInputStream()) {
+            final JsonTriples query = MAPPER.readValue(inputStream, JsonTriples.class);
+            final List<Triple> requestedTriples = getTripleList(query);
+            final HttpAction action = new HttpAction(1L, LOG, ActionCategory.ACTION, request, response);
+            final int requestedTriplesCount = query.triples.size();
+            final int visibleTriplesCount = queryService.getVisibleTriplesCount(action, requestedTriples);
+            final int notVisibleCount = requestedTriplesCount - visibleTriplesCount;
+            if (notVisibleCount == requestedTriplesCount) {
+                createResponse(response, query, false);
+            } else if (notVisibleCount > 0 && requireAllVisible) {
+                createResponse(response, query, false);
+            } else {
+                createResponse(response, query, true);
+            }
+        } catch (SmartCacheGraphException ex) {
+            handleError(response, MAPPER.createObjectNode(), HttpServletResponse.SC_BAD_REQUEST, ex.getMessage());
+        } catch (JsonProcessingException jpex) {
+            handleError(response, MAPPER.createObjectNode(), HttpServletResponse.SC_BAD_REQUEST, "Unable to interpret JSON request");
+        }
+    }
+
+    private void createResponse(HttpServletResponse response, JsonTriples query, boolean hasVisibility) {
+        final AccessTriplesResults results = new AccessTriplesResults(query.triples, hasVisibility);
+        processResponse(response, MAPPER.valueToTree(results));
+    }
+
+    private boolean isAllVisibleRequired(String queryString) {
+        if (queryString != null && !queryString.isEmpty()) {
+            String[] queryStringTokens = queryString.split("=");
+            if (queryStringTokens[0].equals("all")) {
+                return Boolean.parseBoolean(queryStringTokens[1]);
+            } else {
+                return false;
+            }
+        } else {
+            return true; // default value
+        }
+    }
+
+    private List<Triple> getTripleList(JsonTriples triplesRequest) throws SmartCacheGraphException {
+        try {
+            final List<Triple> triples = new ArrayList<>();
+            for (JsonTriple accessTriple : triplesRequest.triples) {
+                final Node s = NodeFactory.createURI(Objects.requireNonNull(accessTriple.subject));
+                final Node p = NodeFactory.createURI(Objects.requireNonNull(accessTriple.predicate));
+                final Node o;
+                if (accessTriple.object.startsWith(HTTP) || accessTriple.object.startsWith(HTTPS)) {
+                    o = NodeFactory.createURI(Objects.requireNonNull(accessTriple.object));
+                } else {
+                    o = NodeFactory.createLiteralByValue(Objects.requireNonNull(accessTriple.object));
+                }
+                triples.add(Triple.create(s, p, o));
+            }
+            return triples;
+        } catch (NullPointerException npex) {
+            throw new SmartCacheGraphException("Unable to process request as missing required values");
+        }
+    }
+}

--- a/scg-system/src/main/java/io/telicent/labels/LabelsQueryRequest.java
+++ b/scg-system/src/main/java/io/telicent/labels/LabelsQueryRequest.java
@@ -1,7 +1,0 @@
-package io.telicent.labels;
-
-import java.util.List;
-
-public class LabelsQueryRequest {
-    public List<LabelsQuery> triples;
-}

--- a/scg-system/src/main/java/io/telicent/labels/servlets/LabelsQueryServlet.java
+++ b/scg-system/src/main/java/io/telicent/labels/servlets/LabelsQueryServlet.java
@@ -4,10 +4,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import io.telicent.labels.LabelsQuery;
-import io.telicent.labels.LabelsQueryRequest;
 import io.telicent.labels.TripleLabels;
 import io.telicent.labels.services.LabelsQueryService;
+import io.telicent.model.JsonTriple;
+import io.telicent.model.JsonTriples;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -80,8 +80,8 @@ public class LabelsQueryServlet extends HttpServlet {
         try (final InputStream inputStream = request.getInputStream()) {
             JsonNode rootNode = MAPPER.readTree(inputStream);
             if (rootNode.has("triples") && rootNode.get("triples").isArray()) {
-                LabelsQueryRequest queryRequest = MAPPER.convertValue(rootNode, LabelsQueryRequest.class);
-                for (LabelsQuery query : queryRequest.triples) {
+                JsonTriples queryRequest = MAPPER.convertValue(rootNode, JsonTriples.class);
+                for (JsonTriple query : queryRequest.triples) {
                     tripleList.add(getTriple(query));
                 }
             } else {
@@ -93,7 +93,7 @@ public class LabelsQueryServlet extends HttpServlet {
         return tripleList;
     }
 
-    private Triple getTriple(LabelsQuery tripleQuery) {
+    private Triple getTriple(JsonTriple tripleQuery) {
         final Node s = getWildcardOrURI(tripleQuery.subject);
         final Node p = getWildcardOrURI(tripleQuery.predicate);
         final Node o = getObjectNode(tripleQuery.object);

--- a/scg-system/src/main/java/io/telicent/model/JsonTriple.java
+++ b/scg-system/src/main/java/io/telicent/model/JsonTriple.java
@@ -1,6 +1,6 @@
-package io.telicent.labels;
+package io.telicent.model;
 
-public class LabelsQuery {
+public class JsonTriple {
     public String subject;
     public String predicate;
     public String object;

--- a/scg-system/src/main/java/io/telicent/model/JsonTriples.java
+++ b/scg-system/src/main/java/io/telicent/model/JsonTriples.java
@@ -1,0 +1,8 @@
+package io.telicent.model;
+
+import java.util.List;
+
+public class JsonTriples {
+
+    public List<JsonTriple> triples;
+}

--- a/scg-system/src/test/java/io/telicent/access/TestAccessBase.java
+++ b/scg-system/src/test/java/io/telicent/access/TestAccessBase.java
@@ -1,0 +1,89 @@
+package io.telicent.access;
+
+import io.telicent.LibTestsSCG;
+import io.telicent.jena.abac.fuseki.SysFusekiABAC;
+import io.telicent.smart.cache.configuration.Configurator;
+import org.apache.jena.fuseki.main.FusekiServer;
+import org.apache.jena.fuseki.system.FusekiLogging;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.testcontainers.shaded.org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+
+import static io.telicent.LibTestsSCG.tokenHeader;
+import static io.telicent.LibTestsSCG.tokenHeaderValue;
+import static io.telicent.core.SmartCacheGraph.construct;
+
+public class TestAccessBase {
+
+    private static final Path DIR = Path.of("src/test/files");
+
+    private HttpClient httpClient;
+
+    protected static final String SERVICE_NAME_1 = "ds1";
+    protected static final String SERVICE_NAME_2 = "ds2";
+
+    protected FusekiServer server;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        FusekiLogging.setLogging();
+        SysFusekiABAC.init();
+        LibTestsSCG.setupAuthentication();
+        LibTestsSCG.disableInitialCompaction();
+        httpClient = HttpClient.newHttpClient();
+    }
+
+    @AfterEach
+    void clearDown() throws Exception {
+        LibTestsSCG.teardownAuthentication();
+        if (null != server) {
+            server.stop();
+        }
+        Configurator.reset();
+    }
+
+    @AfterAll
+    static void afterAll() throws Exception {
+        FileUtils.deleteDirectory(new File("labels"));
+    }
+
+    protected void startServer() {
+        final List<String> arguments = List.of("--conf", DIR + "/access-query-test-config.ttl");
+        server = construct(arguments.toArray(new String[0])).start();
+    }
+
+    /**
+     * Calls the upload endpoint passing in two distinct datasets for two different service endpoints
+     */
+    protected void loadData() {
+        LibTestsSCG.uploadFile(server.serverURL() + SERVICE_NAME_1 + "/upload", DIR + "/access-query-data-labelled-ds1.trig");
+        LibTestsSCG.uploadFile(server.serverURL() + SERVICE_NAME_2 + "/upload", DIR + "/access-query-data-labelled-ds2.trig");
+    }
+
+    protected String callServiceEndpoint(final String requestBody, final String user, final String serviceName, final String endpoint) throws Exception {
+        return callServiceEndpoint(requestBody, user, serviceName, endpoint, "");
+    }
+
+    protected String callServiceEndpoint(final String requestBody, final String user, final String serviceName, final String endpoint, final String queryParams) throws Exception {
+        final String accessQueryUrl = server.serverURL() + serviceName + endpoint + queryParams;
+        final String bearerToken = LibTestsSCG.tokenForUser(user);
+        final HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(accessQueryUrl))
+                .header("Content-type", "application/json")
+                .header(tokenHeader(), tokenHeaderValue(bearerToken))
+                .POST(HttpRequest.BodyPublishers.ofString(requestBody, StandardCharsets.UTF_8))
+                .build();
+        final HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        return response.body();
+    }
+}

--- a/scg-system/src/test/java/io/telicent/access/TestAccessQueryService.java
+++ b/scg-system/src/test/java/io/telicent/access/TestAccessQueryService.java
@@ -1,38 +1,12 @@
 package io.telicent.access;
 
-import io.telicent.LibTestsSCG;
-import io.telicent.jena.abac.fuseki.SysFusekiABAC;
-import io.telicent.smart.cache.configuration.Configurator;
-import org.apache.jena.fuseki.main.FusekiServer;
-import org.apache.jena.fuseki.system.FusekiLogging;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.shaded.org.apache.commons.io.FileUtils;
 
-import java.io.File;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
-import java.util.List;
-
-import static io.telicent.LibTestsSCG.tokenHeader;
-import static io.telicent.LibTestsSCG.tokenHeaderValue;
-import static io.telicent.core.SmartCacheGraph.construct;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class TestAccessQueryService {
+public class TestAccessQueryService extends TestAccessBase {
 
-    private static final Path DIR = Path.of("src/test/files");
-    private static final String SERVICE_NAME_1 = "ds1";
-    private static final String SERVICE_NAME_2 = "ds2";
-
-    private FusekiServer server;
-    private HttpClient httpClient;
+    private static final String ENDPOINT_UNDER_TEST = "/access/query";
 
     private static final String REQUEST_LONDON_COUNTRY = """
             {
@@ -61,28 +35,9 @@ public class TestAccessQueryService {
     private static final String USER1 = "User1";
     private static final String USER2 = "User2";
 
-    @BeforeEach
-    void setUp() throws Exception {
-        FusekiLogging.setLogging();
-        SysFusekiABAC.init();
-        LibTestsSCG.setupAuthentication();
-        LibTestsSCG.disableInitialCompaction();
-        httpClient = HttpClient.newHttpClient();
-    }
 
-    @AfterEach
-    void clearDown() throws Exception {
-        LibTestsSCG.teardownAuthentication();
-        if (null != server) {
-            server.stop();
-        }
-        Configurator.reset();
-    }
 
-    @AfterAll
-    static void afterAll() throws Exception {
-        FileUtils.deleteDirectory(new File("labels"));
-    }
+
 
     /**
      * In this test User1 successfully accesses only one country for London in dataset 1
@@ -98,7 +53,7 @@ public class TestAccessQueryService {
 
         startServer();
         loadData();
-        final String response = callAccessQueryEndpoint(REQUEST_LONDON_COUNTRY, USER1, SERVICE_NAME_1);
+        final String response = callServiceEndpoint(REQUEST_LONDON_COUNTRY, USER1, SERVICE_NAME_1, ENDPOINT_UNDER_TEST);
         assertEquals(expectedResponseBody, response, "Unexpected access query response");
     }
 
@@ -116,7 +71,7 @@ public class TestAccessQueryService {
 
         startServer();
         loadData();
-        final String response = callAccessQueryEndpoint(REQUEST_PARIS_COUNTRY, USER1, SERVICE_NAME_2);
+        final String response = callServiceEndpoint(REQUEST_PARIS_COUNTRY, USER1, SERVICE_NAME_2, ENDPOINT_UNDER_TEST);
         assertEquals(expectedResponseBody, response, "Unexpected access query response");
     }
 
@@ -134,7 +89,7 @@ public class TestAccessQueryService {
 
         startServer();
         loadData();
-        final String response = callAccessQueryEndpoint(REQUEST_LONDON_POPULATION, USER1, SERVICE_NAME_1);
+        final String response = callServiceEndpoint(REQUEST_LONDON_POPULATION, USER1, SERVICE_NAME_1, ENDPOINT_UNDER_TEST);
         assertEquals(expectedResponseBody, response, "Unexpected access query response");
     }
 
@@ -152,7 +107,7 @@ public class TestAccessQueryService {
 
         startServer();
         loadData();
-        final String response = callAccessQueryEndpoint(REQUEST_PARIS_POPULATION, USER1, SERVICE_NAME_1);
+        final String response = callServiceEndpoint(REQUEST_PARIS_POPULATION, USER1, SERVICE_NAME_1, ENDPOINT_UNDER_TEST);
         assertEquals(expectedResponseBody, response, "Unexpected access query response");
     }
 
@@ -169,7 +124,7 @@ public class TestAccessQueryService {
                 }""";
         startServer();
         loadData();
-        final String response = callAccessQueryEndpoint(REQUEST_PARIS_COUNTRY, USER1, SERVICE_NAME_1);
+        final String response = callServiceEndpoint(REQUEST_PARIS_COUNTRY, USER1, SERVICE_NAME_1, ENDPOINT_UNDER_TEST);
         assertEquals(expectedResponseBody, response, "Unexpected access query response");
     }
 
@@ -186,7 +141,7 @@ public class TestAccessQueryService {
                 }""";
         startServer();
         loadData();
-        final String response = callAccessQueryEndpoint(REQUEST_LONDON_COUNTRY, USER1, SERVICE_NAME_2);
+        final String response = callServiceEndpoint(REQUEST_LONDON_COUNTRY, USER1, SERVICE_NAME_2, ENDPOINT_UNDER_TEST);
         assertEquals(expectedResponseBody, response, "Unexpected access query response");
     }
 
@@ -205,7 +160,7 @@ public class TestAccessQueryService {
                 }""";
         startServer();
         loadData();
-        final String response = callAccessQueryEndpoint(noMatchRequest, USER1, SERVICE_NAME_1);
+        final String response = callServiceEndpoint(noMatchRequest, USER1, SERVICE_NAME_1, ENDPOINT_UNDER_TEST);
         assertEquals(expectedResponseBody, response, "Unexpected access query response");
     }
 
@@ -223,7 +178,7 @@ public class TestAccessQueryService {
 
         startServer();
         loadData();
-        final String response = callAccessQueryEndpoint(REQUEST_LONDON_COUNTRY, USER2, SERVICE_NAME_1);
+        final String response = callServiceEndpoint(REQUEST_LONDON_COUNTRY, USER2, SERVICE_NAME_1, ENDPOINT_UNDER_TEST);
         assertEquals(expectedResponseBody, response, "Unexpected access query response");
     }
 
@@ -241,7 +196,7 @@ public class TestAccessQueryService {
 
         startServer();
         loadData();
-        final String response = callAccessQueryEndpoint(REQUEST_LONDON_POPULATION, USER2, SERVICE_NAME_1);
+        final String response = callServiceEndpoint(REQUEST_LONDON_POPULATION, USER2, SERVICE_NAME_1, ENDPOINT_UNDER_TEST);
         assertEquals(expectedResponseBody, response, "Unexpected access query response");
     }
 
@@ -259,7 +214,7 @@ public class TestAccessQueryService {
 
         startServer();
         loadData();
-        final String response = callAccessQueryEndpoint(REQUEST_PARIS_POPULATION, USER2, SERVICE_NAME_2);
+        final String response = callServiceEndpoint(REQUEST_PARIS_POPULATION, USER2, SERVICE_NAME_2, ENDPOINT_UNDER_TEST);
         assertEquals(expectedResponseBody, response, "Unexpected access query response");
     }
 
@@ -276,7 +231,7 @@ public class TestAccessQueryService {
                 }""";
         startServer();
         loadData();
-        final String response = callAccessQueryEndpoint(REQUEST_PARIS_COUNTRY, USER2, SERVICE_NAME_1);
+        final String response = callServiceEndpoint(REQUEST_PARIS_COUNTRY, USER2, SERVICE_NAME_1, ENDPOINT_UNDER_TEST);
         assertEquals(expectedResponseBody, response, "Unexpected access query response");
     }
 
@@ -293,7 +248,7 @@ public class TestAccessQueryService {
                 }""";
         startServer();
         loadData();
-        final String response = callAccessQueryEndpoint(REQUEST_LONDON_COUNTRY, USER2, SERVICE_NAME_2);
+        final String response = callServiceEndpoint(REQUEST_LONDON_COUNTRY, USER2, SERVICE_NAME_2, ENDPOINT_UNDER_TEST);
         assertEquals(expectedResponseBody, response, "Unexpected access query response");
     }
 
@@ -310,7 +265,7 @@ public class TestAccessQueryService {
                 }""";
         startServer();
         loadData();
-        final String response = callAccessQueryEndpoint(REQUEST_PARIS_POPULATION, USER2, SERVICE_NAME_1);
+        final String response = callServiceEndpoint(REQUEST_PARIS_POPULATION, USER2, SERVICE_NAME_1, ENDPOINT_UNDER_TEST);
         assertEquals(expectedResponseBody, response, "Unexpected access query response");
     }
 
@@ -327,7 +282,7 @@ public class TestAccessQueryService {
                 }""";
         startServer();
         loadData();
-        final String response = callAccessQueryEndpoint(REQUEST_LONDON_POPULATION, USER2, SERVICE_NAME_2);
+        final String response = callServiceEndpoint(REQUEST_LONDON_POPULATION, USER2, SERVICE_NAME_2, ENDPOINT_UNDER_TEST);
         assertEquals(expectedResponseBody, response, "Unexpected access query response");
     }
 
@@ -345,7 +300,7 @@ public class TestAccessQueryService {
                 }""";
         startServer();
         loadData();
-        final String response = callAccessQueryEndpoint(REQUEST_PARIS_COUNTRY, USER2, SERVICE_NAME_2);
+        final String response = callServiceEndpoint(REQUEST_PARIS_COUNTRY, USER2, SERVICE_NAME_2, ENDPOINT_UNDER_TEST);
         assertEquals(expectedResponseBody, response, "Unexpected access query response");
     }
 
@@ -364,35 +319,8 @@ public class TestAccessQueryService {
                 }""";
         startServer();
         loadData();
-        final String response = callAccessQueryEndpoint(noMatchRequest, USER2, SERVICE_NAME_1);
+        final String response = callServiceEndpoint(noMatchRequest, USER2, SERVICE_NAME_1, ENDPOINT_UNDER_TEST);
         assertEquals(expectedResponseBody, response, "Unexpected access query response");
-    }
-
-
-    /**
-     * Calls the upload endpoint passing in two distinct datasets for two different service endpoints
-     */
-    private void loadData() {
-        LibTestsSCG.uploadFile(server.serverURL() + SERVICE_NAME_1 + "/upload", DIR + "/access-query-data-labelled-ds1.trig");
-        LibTestsSCG.uploadFile(server.serverURL() + SERVICE_NAME_2 + "/upload", DIR + "/access-query-data-labelled-ds2.trig");
-    }
-
-    private String callAccessQueryEndpoint(final String requestBody, final String user, final String serviceName) throws Exception {
-        final String accessQueryUrl = server.serverURL() + serviceName + "/access/query";
-        final String bearerToken = LibTestsSCG.tokenForUser(user);
-        final HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(accessQueryUrl))
-                .header("Content-type", "application/json")
-                .header(tokenHeader(), tokenHeaderValue(bearerToken))
-                .POST(HttpRequest.BodyPublishers.ofString(requestBody, StandardCharsets.UTF_8))
-                .build();
-        final HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-        return response.body();
-    }
-
-    private void startServer() {
-        final List<String> arguments = List.of("--conf", DIR + "/access-query-test-config.ttl");
-        server = construct(arguments.toArray(new String[0])).start();
     }
 
 }

--- a/scg-system/src/test/java/io/telicent/access/TestAccessTriplesService.java
+++ b/scg-system/src/test/java/io/telicent/access/TestAccessTriplesService.java
@@ -1,0 +1,403 @@
+package io.telicent.access;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestAccessTriplesService extends TestAccessBase {
+
+    private static final String ENDPOINT_UNDER_TEST = "/access/triples";
+
+    private static final String SERVICE_NAME_1 = "ds1";
+    private static final String SERVICE_NAME_2 = "ds2";
+
+    private final String countryTripleLondonUK = getRequestTripleUri("London", "country", "United_Kingdom");
+    private final String countryTripleLondonEngland = getRequestTripleUri("London", "country", "England");
+    private final String countryTripleParis = getRequestTripleUri("Paris", "country", "France");
+
+    private final String populationTripleLondon = getRequestTripleLiteral("London", "populationTotal", "8799800");
+    private final String populationTripleParis = getRequestTripleLiteral("Paris", "populationTotal", "2165423");
+
+
+    private final String requestCountryLondonUK = """
+            {
+              "triples": [%s]
+            }""".formatted(countryTripleLondonUK);
+
+    private final String requestCountryLondonEngland = """
+            {
+              "triples": [%s]
+            }""".formatted(countryTripleLondonEngland);
+
+    private final String requestLondon = """
+            {
+              "triples": [%s,%s]
+            }""".formatted(countryTripleLondonUK, populationTripleLondon);
+
+    private static final String USER1 = "User1";
+    private static final String USER2 = "User2";
+
+    /**
+     * Request London -> country -> United Kingdom returns true for User1 in dataset 1
+     */
+    @Test
+    void test_London_country_UK_user1_ds1_visible_true() throws Exception {
+        final String expectedResponseBody = """
+                {
+                  "triples" : [ {
+                    "subject" : "http://dbpedia.org/resource/London",
+                    "predicate" : "http://dbpedia.org/ontology/country",
+                    "object" : "http://dbpedia.org/resource/United_Kingdom"
+                  } ],
+                  "visible" : true
+                }""";
+
+        startServer();
+        loadData();
+        final String response = callServiceEndpoint(requestCountryLondonUK, USER1, SERVICE_NAME_1, ENDPOINT_UNDER_TEST, "?all=true");
+        assertEquals(expectedResponseBody, response, "Unexpected access query response");
+    }
+
+    /**
+     * Request London -> country -> England returns false for User1 in dataset 1 as no access
+     */
+    @Test
+    void test_London_country_England_user1_ds1_visible_false() throws Exception {
+        final String expectedResponseBody = """
+                {
+                  "triples" : [ {
+                    "subject" : "http://dbpedia.org/resource/London",
+                    "predicate" : "http://dbpedia.org/ontology/country",
+                    "object" : "http://dbpedia.org/resource/England"
+                  } ],
+                  "visible" : false
+                }""";
+
+        startServer();
+        loadData();
+        final String response = callServiceEndpoint(requestCountryLondonEngland, USER1, SERVICE_NAME_1, ENDPOINT_UNDER_TEST, "?all=true");
+        assertEquals(expectedResponseBody, response, "Unexpected access query response");
+    }
+
+    /**
+     * Request London -> country -> England returns true for User2 in dataset 1 as has access
+     */
+    @Test
+    void test_London_country_England_user2_ds1_visible_true() throws Exception {
+        final String expectedResponseBody = """
+                {
+                  "triples" : [ {
+                    "subject" : "http://dbpedia.org/resource/London",
+                    "predicate" : "http://dbpedia.org/ontology/country",
+                    "object" : "http://dbpedia.org/resource/England"
+                  } ],
+                  "visible" : true
+                }""";
+
+        startServer();
+        loadData();
+        final String response = callServiceEndpoint(requestCountryLondonEngland, USER2, SERVICE_NAME_1, ENDPOINT_UNDER_TEST, "?all=true");
+        assertEquals(expectedResponseBody, response, "Unexpected access query response");
+    }
+
+    /**
+     * Request London -> country -> United Kingdom returns false for User1 as triple not present in dataset 2
+     */
+    @Test
+    void test_London_country_England_ds2_visible_false() throws Exception {
+        final String expectedResponseBody = """
+                {
+                  "triples" : [ {
+                    "subject" : "http://dbpedia.org/resource/London",
+                    "predicate" : "http://dbpedia.org/ontology/country",
+                    "object" : "http://dbpedia.org/resource/United_Kingdom"
+                  } ],
+                  "visible" : false
+                }""";
+
+        startServer();
+        loadData();
+        final String response = callServiceEndpoint(requestCountryLondonUK, USER1, SERVICE_NAME_2, ENDPOINT_UNDER_TEST, "?all=true");
+        assertEquals(expectedResponseBody, response, "Unexpected access query response");
+    }
+
+    /**
+     * Request Paris -> country -> France returns true for User1 as triple in dataset 2
+     */
+    @Test
+    void test_Paris_country_France_ds2_visible_true() throws Exception {
+        final String requestCountryParis = """
+            {
+              "triples": [%s]
+            }""".formatted(countryTripleParis);
+        final String expectedResponseBody = """
+                {
+                  "triples" : [ {
+                    "subject" : "http://dbpedia.org/resource/Paris",
+                    "predicate" : "http://dbpedia.org/ontology/country",
+                    "object" : "http://dbpedia.org/resource/France"
+                  } ],
+                  "visible" : true
+                }""";
+
+        startServer();
+        loadData();
+        final String response = callServiceEndpoint(requestCountryParis, USER1, SERVICE_NAME_2, ENDPOINT_UNDER_TEST, "?all=true");
+        assertEquals(expectedResponseBody, response, "Unexpected access query response");
+    }
+
+    /**
+     * Request Paris -> population -> 2165423 returns false for User1 as no access to triple in dataset 2
+     */
+    @Test
+    void test_Paris_population_ds2_visible_false() throws Exception {
+        final String requestPopulationParis = """
+            {
+              "triples": [%s]
+            }""".formatted(populationTripleParis);
+        final String expectedResponseBody = """
+                {
+                  "triples" : [ {
+                    "subject" : "http://dbpedia.org/resource/Paris",
+                    "predicate" : "http://dbpedia.org/ontology/populationTotal",
+                    "object" : "2165423"
+                  } ],
+                  "visible" : false
+                }""";
+
+        startServer();
+        loadData();
+        final String response = callServiceEndpoint(requestPopulationParis, USER1, SERVICE_NAME_2, ENDPOINT_UNDER_TEST, "?all=true");
+        assertEquals(expectedResponseBody, response, "Unexpected access query response");
+    }
+
+    /**
+     * Request Paris -> population -> 2165423 returns true for User2 with access in dataset 2
+     */
+    @Test
+    @Disabled("Disabled until CORE-772 completed")
+    void test_Paris_population_ds2_visible_true() throws Exception {
+        final String requestPopulationParis = """
+            {
+              "triples": [%s]
+            }""".formatted(populationTripleParis);
+        final String expectedResponseBody = """
+                {
+                  "triples" : [ {
+                    "subject" : "http://dbpedia.org/resource/Paris",
+                    "predicate" : "http://dbpedia.org/ontology/populationTotal",
+                    "object" : "2165423"
+                  } ],
+                  "visible" : true
+                }""";
+
+        startServer();
+        loadData();
+        final String response = callServiceEndpoint(requestPopulationParis, USER2, SERVICE_NAME_2, ENDPOINT_UNDER_TEST, "?all=true");
+        assertEquals(expectedResponseBody, response, "Unexpected access query response");
+    }
+
+    /**
+     * Request London -> population total -> 8799800 returns false for User1 as no access to triple in dataset 1
+     */
+    @Test
+    void test_London_one_triple_visible_false() throws Exception {
+        final String requestPopulationLondon = """
+            {
+              "triples": [%s]
+            }""".formatted(populationTripleLondon);
+        final String expectedResponseBody = """
+                {
+                  "triples" : [ {
+                    "subject" : "http://dbpedia.org/resource/London",
+                    "predicate" : "http://dbpedia.org/ontology/populationTotal",
+                    "object" : "8799800"
+                  } ],
+                  "visible" : false
+                }""";
+        startServer();
+        loadData();
+        final String response = callServiceEndpoint(requestPopulationLondon, USER1, SERVICE_NAME_1, ENDPOINT_UNDER_TEST, "?all=true");
+        assertEquals(expectedResponseBody, response, "Unexpected access query response");
+    }
+
+    /**
+     * Request London data returns false for User1 with all=true as no access to 2nd triple in dataset 1
+     */
+    @Test
+    void test_London_two_triples_one_visible_with_all_required_false() throws Exception {
+        final String expectedResponseBody = """
+                {
+                  "triples" : [ {
+                    "subject" : "http://dbpedia.org/resource/London",
+                    "predicate" : "http://dbpedia.org/ontology/country",
+                    "object" : "http://dbpedia.org/resource/United_Kingdom"
+                  }, {
+                    "subject" : "http://dbpedia.org/resource/London",
+                    "predicate" : "http://dbpedia.org/ontology/populationTotal",
+                    "object" : "8799800"
+                  } ],
+                  "visible" : false
+                }""";
+
+        startServer();
+        loadData();
+        final String response = callServiceEndpoint(requestLondon, USER1, SERVICE_NAME_1, ENDPOINT_UNDER_TEST, "?all=true");
+        assertEquals(expectedResponseBody, response, "Unexpected access query response");
+    }
+
+    /**
+     * Request London data returns false for User1 with all at default value (true) as no access to 2nd triple in dataset 1
+     */
+    @Test
+    void test_London_two_triples_one_visible_with_all_required_as_default_false() throws Exception {
+        final String expectedResponseBody = """
+                {
+                  "triples" : [ {
+                    "subject" : "http://dbpedia.org/resource/London",
+                    "predicate" : "http://dbpedia.org/ontology/country",
+                    "object" : "http://dbpedia.org/resource/United_Kingdom"
+                  }, {
+                    "subject" : "http://dbpedia.org/resource/London",
+                    "predicate" : "http://dbpedia.org/ontology/populationTotal",
+                    "object" : "8799800"
+                  } ],
+                  "visible" : false
+                }""";
+
+        startServer();
+        loadData();
+        final String response = callServiceEndpoint(requestLondon, USER1, SERVICE_NAME_1, ENDPOINT_UNDER_TEST);
+        assertEquals(expectedResponseBody, response, "Unexpected access query response");
+    }
+
+    /**
+     * Request London data returns true for User1 with all=false as has access to 1st triple in dataset 1
+     */
+    @Test
+    void test_two_triples_one_visible_with_all_required_false() throws Exception {
+        final String expectedResponseBody = """
+                {
+                  "triples" : [ {
+                    "subject" : "http://dbpedia.org/resource/London",
+                    "predicate" : "http://dbpedia.org/ontology/country",
+                    "object" : "http://dbpedia.org/resource/United_Kingdom"
+                  }, {
+                    "subject" : "http://dbpedia.org/resource/London",
+                    "predicate" : "http://dbpedia.org/ontology/populationTotal",
+                    "object" : "8799800"
+                  } ],
+                  "visible" : true
+                }""";
+
+        startServer();
+        loadData();
+        final String response = callServiceEndpoint(requestLondon, USER1, SERVICE_NAME_1, ENDPOINT_UNDER_TEST, "?all=false");
+        assertEquals(expectedResponseBody, response, "Unexpected access query response");
+    }
+
+
+    @Test
+    void test_two_triples_one_visible_without_all_required_true() throws Exception {
+        final String expectedResponseBody = """
+                {
+                  "triples" : [ {
+                    "subject" : "http://dbpedia.org/resource/London",
+                    "predicate" : "http://dbpedia.org/ontology/country",
+                    "object" : "http://dbpedia.org/resource/United_Kingdom"
+                  }, {
+                    "subject" : "http://dbpedia.org/resource/London",
+                    "predicate" : "http://dbpedia.org/ontology/populationTotal",
+                    "object" : "8799800"
+                  } ],
+                  "visible" : true
+                }""";
+
+        startServer();
+        loadData();
+        final String response = callServiceEndpoint(requestLondon, USER1, SERVICE_NAME_1, ENDPOINT_UNDER_TEST, "?all=false");
+        assertEquals(expectedResponseBody, response, "Unexpected access query response");
+    }
+
+    /**
+     * Request London data returns true for User2 with all=true as has access to all triples in dataset 1
+     */
+    @Test
+    @Disabled("Disabled until CORE-772 completed")
+    void test_two_triples_all_visible_with_all_required_true() throws Exception {
+        final String expectedResponseBody = """
+                {
+                  "triples" : [ {
+                    "subject" : "http://dbpedia.org/resource/London",
+                    "predicate" : "http://dbpedia.org/ontology/country",
+                    "object" : "http://dbpedia.org/resource/United_Kingdom"
+                  }, {
+                    "subject" : "http://dbpedia.org/resource/London",
+                    "predicate" : "http://dbpedia.org/ontology/populationTotal",
+                    "object" : "8799800"
+                  } ],
+                  "visible" : true
+                }""";
+
+        startServer();
+        loadData();
+        final String response = callServiceEndpoint(requestLondon, USER2, SERVICE_NAME_1, ENDPOINT_UNDER_TEST, "?all=true");
+        assertEquals(expectedResponseBody, response, "Unexpected access query response");
+    }
+
+    @Test
+    void test_two_triples_none_visible_without_all_required_true() throws Exception {
+        final String requestLondonEngland = """
+            {
+              "triples": [%s,%s]
+            }""".formatted(countryTripleLondonEngland, populationTripleLondon);
+        final String expectedResponseBody = """
+                {
+                  "triples" : [ {
+                    "subject" : "http://dbpedia.org/resource/London",
+                    "predicate" : "http://dbpedia.org/ontology/country",
+                    "object" : "http://dbpedia.org/resource/England"
+                  }, {
+                    "subject" : "http://dbpedia.org/resource/London",
+                    "predicate" : "http://dbpedia.org/ontology/populationTotal",
+                    "object" : "8799800"
+                  } ],
+                  "visible" : false
+                }""";
+        startServer();
+        loadData();
+        final String response = callServiceEndpoint(requestLondonEngland, USER1, SERVICE_NAME_1, ENDPOINT_UNDER_TEST, "?all=false");
+        assertEquals(expectedResponseBody, response, "Unexpected access query response");
+    }
+
+    @Test
+    void bad_request_returns_error() throws Exception {
+        final String expectedResponseBody = """
+                {
+                  "error" : "Unable to interpret JSON request"
+                }""";
+        startServer();
+        loadData();
+        final String response = callServiceEndpoint(countryTripleLondonEngland, USER1, SERVICE_NAME_1, ENDPOINT_UNDER_TEST, "?all=false");
+        assertEquals(expectedResponseBody, response, "Unexpected access query response");
+    }
+
+    private String getRequestTripleUri(final String s, final String p, final String o) {
+        return """
+                {
+                  "subject" : "http://dbpedia.org/resource/%s",
+                  "predicate" : "http://dbpedia.org/ontology/%s",
+                  "object" : "http://dbpedia.org/resource/%s"
+                }""".formatted(s, p, o);
+    }
+
+    private String getRequestTripleLiteral(final String s, final String p, final String o) {
+        return """
+                {
+                  "subject" : "http://dbpedia.org/resource/%s",
+                  "predicate" : "http://dbpedia.org/ontology/%s",
+                  "object" : "%s"
+                }""".formatted(s, p, o);
+    }
+}


### PR DESCRIPTION
This PR adds a `POST` endpoint `/{dataset}/access/triple` which takes a list of one or more JSON triple representations and returns the data with a new boolean property `visible` added indicated whether the triples are visible to the requesting user or not. It will return `true` if all triples are visible and `false` if none. If only some of the triples are visible to the user it could return `true` or `false` depending on whether the user has specified `true` or `false` in the query param `all`. If `true` (the default value) it will only return `true` if all triples are visible.