### PR TITLE
Combine minor and patch versions in Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
     groups:
       maven-patch-group:
         update-types:
+        - "minor"
         - "patch"
     open-pull-requests-limit: 10
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Occassionally we get Dependabot PRs that aren't individually mergeable because taking a minor version bump in one dependency is incompatible with a minor/patch version in another, and they should be bumped together.  This aligns our Dependabot configuration with other repositories to reduce this possibility going forward.

E.g #200 and #201 should be combined because individually those dependency bumps don't work, but when applied together they do