### PR TITLE
CORE-791: improving error handling for access query requests

### DIFF
--- a/scg-system/src/main/java/io/telicent/access/servlets/AccessQueryServlet.java
+++ b/scg-system/src/main/java/io/telicent/access/servlets/AccessQueryServlet.java
@@ -1,5 +1,6 @@
 package io.telicent.access.servlets;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.telicent.access.AccessQuery;
 import io.telicent.access.AccessQueryResults;
@@ -65,6 +66,8 @@ public class AccessQueryServlet extends HttpServlet {
             processResponse(response, MAPPER.valueToTree(queryResults));
         } catch (SmartCacheGraphException ex) {
             handleError(response, MAPPER.createObjectNode(), HttpServletResponse.SC_BAD_REQUEST, ex.getMessage());
+        } catch (JsonProcessingException ex) {
+            handleError(response, MAPPER.createObjectNode(), HttpServletResponse.SC_BAD_REQUEST, "Missing or invalid request body content");
         }
     }
 

--- a/scg-system/src/test/java/io/telicent/access/TestAccessQueryService.java
+++ b/scg-system/src/test/java/io/telicent/access/TestAccessQueryService.java
@@ -35,10 +35,6 @@ public class TestAccessQueryService extends TestAccessBase {
     private static final String USER1 = "User1";
     private static final String USER2 = "User2";
 
-
-
-
-
     /**
      * In this test User1 successfully accesses only one country for London in dataset 1
      */
@@ -341,6 +337,41 @@ public class TestAccessQueryService extends TestAccessBase {
         startServer();
         loadData();
         final String response = callServiceEndpoint(noMatchRequest, USER2, SERVICE_NAME_1, ENDPOINT_UNDER_TEST);
+        assertEquals(expectedResponseBody, response, "Unexpected access query response");
+    }
+
+    /**
+     * In this test User2 has provided an invalid request body
+     */
+    @Test
+    void test_user2_invalid_request_body() throws Exception {
+        final String invalidRequestBody = """
+                {
+                    "foo":"bar"
+                }""";
+        final String expectedResponseBody = """
+                {
+                  "error" : "Missing or invalid request body content"
+                }""";
+        startServer();
+        loadData();
+        final String response = callServiceEndpoint(invalidRequestBody, USER2, SERVICE_NAME_1, ENDPOINT_UNDER_TEST);
+        assertEquals(expectedResponseBody, response, "Unexpected access query response");
+    }
+
+    /**
+     * In this test User2 has not provided a request body
+     */
+    @Test
+    void test_user2_missing_request_body() throws Exception {
+        final String emptyRequestBody = "";
+        final String expectedResponseBody = """
+                {
+                  "error" : "Missing or invalid request body content"
+                }""";
+        startServer();
+        loadData();
+        final String response = callServiceEndpoint(emptyRequestBody, USER2, SERVICE_NAME_1, ENDPOINT_UNDER_TEST);
         assertEquals(expectedResponseBody, response, "Unexpected access query response");
     }
 


### PR DESCRIPTION
Addresses issue with missing request body causing 500 errors as reported in [CORE-791](https://telicent.atlassian.net/browse/CORE-791) and also handles an unparseable request body.

[CORE-791]: https://telicent.atlassian.net/browse/CORE-791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ