### PR TITLE
CORE-799: adding support for language to triple access queries

### DIFF
--- a/docs/access-api.yaml
+++ b/docs/access-api.yaml
@@ -139,6 +139,9 @@ paths:
                             description: Can be a full URI or prefixed value (eg. xsd:string)
                           value:
                             type: string
+                          language:
+                            type: string
+                            description: An IETF BCP 47 language tag (e.g. 'en' or 'fr')
             examples:
               London:
                 value:
@@ -153,6 +156,11 @@ paths:
                       object:
                         - dataType: xsd:anyURI
                           value:  http://dbpedia.org/resource/United_Kingdom
+                    - subject: http://dbpedia.org/resource/London
+                      predicate: http://dbpedia.org/ontology/name
+                      object:
+                        - value: "London"
+                          language: "en"
       responses:
         '200':
           description: Request processed successfully.
@@ -167,7 +175,7 @@ paths:
                       type: object
                       properties:
                         subject:
-                          type: array
+                          type: string
                         predicate:
                           type: string
                         object:
@@ -176,6 +184,8 @@ paths:
                             dataType:
                               type: string
                             value:
+                              type: string
+                            language:
                               type: string
                   visible:
                     type: boolean
@@ -193,9 +203,14 @@ paths:
                         object:
                           - dataType: xsd:anyURI
                             value: http://dbpedia.org/resource/United_Kingdom
+                      - subject: http://dbpedia.org/resource/London
+                        predicate: http://dbpedia.org/ontology/name
+                        object:
+                          - value: "London"
+                            language: "en"
                     visible: true
-        '500':
-          description: Internal server error.
+        '400':
+          description: Bad Request.
           content:
             application/json:
               schema:

--- a/docs/access-api.yaml
+++ b/docs/access-api.yaml
@@ -139,6 +139,7 @@ paths:
                             description: Can be a full URI or prefixed value (eg. xsd:string)
                           value:
                             type: string
+                            description: If supplied without a dataType or language is assumed to be a URI
                           language:
                             type: string
                             description: An IETF BCP 47 language tag (e.g. 'en' or 'fr')
@@ -154,8 +155,12 @@ paths:
                     - subject: http://dbpedia.org/resource/London
                       predicate: http://dbpedia.org/ontology/country
                       object:
+                        value:  http://dbpedia.org/resource/United_Kingdom
+                    - subject: http://dbpedia.org/resource/London
+                      predicate: http://xmlns.com/foaf/0.1/homepage
+                      object:
                         - dataType: xsd:anyURI
-                          value:  http://dbpedia.org/resource/United_Kingdom
+                          value: "https://www.london.gov.uk/"
                     - subject: http://dbpedia.org/resource/London
                       predicate: http://dbpedia.org/ontology/name
                       object:
@@ -201,8 +206,12 @@ paths:
                       - subject: http://dbpedia.org/resource/London
                         predicate: http://dbpedia.org/ontology/country
                         object:
+                          - value: http://dbpedia.org/resource/United_Kingdom
+                      - subject: http://dbpedia.org/resource/London
+                        predicate: http://xmlns.com/foaf/0.1/homepage
+                        object:
                           - dataType: xsd:anyURI
-                            value: http://dbpedia.org/resource/United_Kingdom
+                            value: "https://www.london.gov.uk/"
                       - subject: http://dbpedia.org/resource/London
                         predicate: http://dbpedia.org/ontology/name
                         object:

--- a/scg-system/src/main/java/io/telicent/access/servlets/AccessTriplesServlet.java
+++ b/scg-system/src/main/java/io/telicent/access/servlets/AccessTriplesServlet.java
@@ -91,9 +91,14 @@ public class AccessTriplesServlet extends HttpServlet {
                 final Node o;
                 if (accessTriple.object.value.startsWith(HTTP) || accessTriple.object.value.startsWith(HTTPS)) {
                     o = NodeFactory.createURI(Objects.requireNonNull(accessTriple.object.value));
-                } else {
+                } else if (accessTriple.object.language == null || accessTriple.object.language.isEmpty()){
                     final TypedObject typedObject = Objects.requireNonNull(TypedObject.from(accessTriple.object));
                     o = NodeFactory.createLiteralDT(typedObject.value, typedObject.datatype);
+                } else if (accessTriple.object.dataType == null || accessTriple.object.dataType.isEmpty()){
+                    final TypedObject typedObject = Objects.requireNonNull(TypedObject.from(accessTriple.object));
+                    o = NodeFactory.createLiteralLang(typedObject.value, typedObject.language);
+                } else {
+                    throw new SmartCacheGraphException("Cannot have both language and dataType in request object");
                 }
                 triples.add(Triple.create(s, p, o));
             }

--- a/scg-system/src/main/java/io/telicent/access/servlets/AccessTriplesServlet.java
+++ b/scg-system/src/main/java/io/telicent/access/servlets/AccessTriplesServlet.java
@@ -21,11 +21,13 @@ import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import static io.telicent.utils.ServletUtils.*;
+import static io.telicent.utils.ServletUtils.handleError;
+import static io.telicent.utils.ServletUtils.processResponse;
 
 public class AccessTriplesServlet extends HttpServlet {
 
@@ -89,22 +91,34 @@ public class AccessTriplesServlet extends HttpServlet {
                 final Node s = NodeFactory.createURI(Objects.requireNonNull(accessTriple.subject));
                 final Node p = NodeFactory.createURI(Objects.requireNonNull(accessTriple.predicate));
                 final Node o;
-                if (accessTriple.object.value.startsWith(HTTP) || accessTriple.object.value.startsWith(HTTPS)) {
-                    o = NodeFactory.createURI(Objects.requireNonNull(accessTriple.object.value));
-                } else if (accessTriple.object.language == null || accessTriple.object.language.isEmpty()){
-                    final TypedObject typedObject = Objects.requireNonNull(TypedObject.from(accessTriple.object));
-                    o = NodeFactory.createLiteralDT(typedObject.value, typedObject.datatype);
-                } else if (accessTriple.object.dataType == null || accessTriple.object.dataType.isEmpty()){
-                    final TypedObject typedObject = Objects.requireNonNull(TypedObject.from(accessTriple.object));
-                    o = NodeFactory.createLiteralLang(typedObject.value, typedObject.language);
+                if (accessTriple.object.value.isEmpty()) {
+                    throw new SmartCacheGraphException("Triple object value cannot be empty");
                 } else {
-                    throw new SmartCacheGraphException("Cannot have both language and dataType in request object");
+                    if (accessTriple.object.language == null || accessTriple.object.language.isEmpty()) {
+                        // no language so either a typed literal or a URI
+                        if (accessTriple.object.dataType == null || accessTriple.object.dataType.isEmpty()) {
+                            // no datatype so value must be a URI
+                            final URI objectUri = URI.create(Objects.requireNonNull(accessTriple.object.value));
+                            o = NodeFactory.createURI(objectUri.toString());
+                        } else {
+                            // must be a typed literal (this could include a literal URI value)
+                            final TypedObject typedObject = Objects.requireNonNull(TypedObject.from(accessTriple.object));
+                            o = NodeFactory.createLiteralDT(typedObject.value, typedObject.datatype);
+                        }
+                    } else if (accessTriple.object.dataType == null || accessTriple.object.dataType.isEmpty()) {
+                        final TypedObject typedObject = Objects.requireNonNull(TypedObject.from(accessTriple.object));
+                        o = NodeFactory.createLiteralLang(typedObject.value, typedObject.language);
+                    } else {
+                        throw new SmartCacheGraphException("Cannot have both language and dataType in request object");
+                    }
                 }
                 triples.add(Triple.create(s, p, o));
             }
             return triples;
         } catch (NullPointerException npex) {
             throw new SmartCacheGraphException("Unable to process request as missing required values");
+        } catch (IllegalArgumentException iaex){
+            throw new SmartCacheGraphException(iaex.getMessage());
         }
     }
 }

--- a/scg-system/src/main/java/io/telicent/model/JsonTripleObject.java
+++ b/scg-system/src/main/java/io/telicent/model/JsonTripleObject.java
@@ -1,15 +1,27 @@
 package io.telicent.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
 public class JsonTripleObject {
 
+    @JsonInclude(Include.NON_NULL)
     public String dataType;
     public String value;
+    @JsonInclude(Include.NON_NULL)
+    public String language;
 
     public JsonTripleObject(){};
 
-    public JsonTripleObject(String dataType, String value){
+    public JsonTripleObject(String dataType, String value) {
         this.dataType = dataType;
         this.value = value;
+    }
+
+    public JsonTripleObject(String dataType, String value, String language){
+        this.dataType = dataType;
+        this.value = value;
+        this.language = language;
     }
 
 }

--- a/scg-system/src/main/java/io/telicent/model/TypedObject.java
+++ b/scg-system/src/main/java/io/telicent/model/TypedObject.java
@@ -9,16 +9,22 @@ import org.apache.jena.vocabulary.XSD;
 
 import java.util.Objects;
 
-import static io.telicent.utils.ServletUtils.HTTP;
-import static io.telicent.utils.ServletUtils.HTTPS;
+import static io.telicent.utils.ServletUtils.*;
 
 public class TypedObject {
     public RDFDatatype datatype;
     public String value;
+    public String language;
 
-    public TypedObject(RDFDatatype datatype, String value) {
+    public TypedObject(RDFDatatype datatype, String value){
         this.datatype = datatype;
         this.value = value;
+    }
+
+    public TypedObject(RDFDatatype datatype, String value, String language) {
+        this.datatype = datatype;
+        this.value = value;
+        this.language = language;
     }
 
     /**
@@ -30,7 +36,9 @@ public class TypedObject {
      * @throws SmartCacheGraphException if unable to resolve the RDFDataType
      */
     public static TypedObject from(final JsonTripleObject jsonTripleObject) throws SmartCacheGraphException {
-        if (jsonTripleObject.dataType.startsWith(HTTP) || jsonTripleObject.dataType.startsWith(HTTPS)) {
+        if(jsonTripleObject.language != null && !jsonTripleObject.language.isEmpty()) {
+            return new TypedObject(RDF.dtLangString, jsonTripleObject.value, jsonTripleObject.language);
+        } else if (jsonTripleObject.dataType.startsWith(HTTP) || jsonTripleObject.dataType.startsWith(HTTPS)) {
             return getTypedObjectFromUriValue(jsonTripleObject);
         } else {
             final String[] tokens = jsonTripleObject.dataType.split(":");

--- a/scg-system/src/test/files/access-query-data-labelled-ds1.trig
+++ b/scg-system/src/test/files/access-query-data-labelled-ds1.trig
@@ -1,17 +1,21 @@
 PREFIX dbr: <http://dbpedia.org/resource/>
 PREFIX dbo: <http://dbpedia.org/ontology/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX security: <http://telicent.io/security#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 ## Some London data
 dbr:London dbo:populationTotal 8799800 .
 dbr:London dbo:country dbr:United_Kingdom .
 dbr:London dbo:country dbr:England .
+dbr:London foaf:homepage "https://www.london.gov.uk/"^^xsd:anyURI .
 
 ## ABAC Security labels to apply
 GRAPH security:labels {
 
     ## Something everyone can see
     [ security:pattern 'dbr:London dbo:country dbr:United_Kingdom'  ; security:label "everyone" ] .
+    [ security:pattern 'dbr:London foaf:homepage "https://www.london.gov.uk/"^^xsd:anyURI' ; security:label "everyone" ] .
 
     ## Something only admin users can see
     [ security:pattern 'dbr:London dbo:populationTotal 8799800'  ; security:label "admin" ] .

--- a/scg-system/src/test/java/io/telicent/access/TestAccessTriplesService.java
+++ b/scg-system/src/test/java/io/telicent/access/TestAccessTriplesService.java
@@ -50,7 +50,6 @@ public class TestAccessTriplesService extends TestAccessBase {
                     "subject" : "http://dbpedia.org/resource/London",
                     "predicate" : "http://dbpedia.org/ontology/country",
                     "object" : {
-                      "dataType" : "xsd:anyURI",
                       "value" : "http://dbpedia.org/resource/United_Kingdom"
                     }
                   } ],
@@ -74,7 +73,6 @@ public class TestAccessTriplesService extends TestAccessBase {
                     "subject" : "http://dbpedia.org/resource/London",
                     "predicate" : "http://dbpedia.org/ontology/country",
                     "object" : {
-                      "dataType" : "xsd:anyURI",
                       "value" : "http://dbpedia.org/resource/England"
                     }
                   } ],
@@ -98,7 +96,6 @@ public class TestAccessTriplesService extends TestAccessBase {
                     "subject" : "http://dbpedia.org/resource/London",
                     "predicate" : "http://dbpedia.org/ontology/country",
                     "object" : {
-                      "dataType" : "xsd:anyURI",
                       "value" : "http://dbpedia.org/resource/England"
                     }
                   } ],
@@ -122,7 +119,6 @@ public class TestAccessTriplesService extends TestAccessBase {
                     "subject" : "http://dbpedia.org/resource/London",
                     "predicate" : "http://dbpedia.org/ontology/country",
                     "object" : {
-                      "dataType" : "xsd:anyURI",
                       "value" : "http://dbpedia.org/resource/United_Kingdom"
                     }
                   } ],
@@ -150,7 +146,6 @@ public class TestAccessTriplesService extends TestAccessBase {
                     "subject" : "http://dbpedia.org/resource/Paris",
                     "predicate" : "http://dbpedia.org/ontology/country",
                     "object" : {
-                      "dataType" : "xsd:anyURI",
                       "value" : "http://dbpedia.org/resource/France"
                     }
                   } ],
@@ -310,7 +305,6 @@ public class TestAccessTriplesService extends TestAccessBase {
                     "subject" : "http://dbpedia.org/resource/London",
                     "predicate" : "http://dbpedia.org/ontology/country",
                     "object" : {
-                      "dataType" : "xsd:anyURI",
                       "value" : "http://dbpedia.org/resource/United_Kingdom"
                     }
                   }, {
@@ -341,7 +335,6 @@ public class TestAccessTriplesService extends TestAccessBase {
                     "subject" : "http://dbpedia.org/resource/London",
                     "predicate" : "http://dbpedia.org/ontology/country",
                     "object" : {
-                      "dataType" : "xsd:anyURI",
                       "value" : "http://dbpedia.org/resource/United_Kingdom"
                     }
                   }, {
@@ -372,7 +365,6 @@ public class TestAccessTriplesService extends TestAccessBase {
                     "subject" : "http://dbpedia.org/resource/London",
                     "predicate" : "http://dbpedia.org/ontology/country",
                     "object" : {
-                      "dataType" : "xsd:anyURI",
                       "value" : "http://dbpedia.org/resource/United_Kingdom"
                     }
                   }, {
@@ -403,7 +395,6 @@ public class TestAccessTriplesService extends TestAccessBase {
                     "subject" : "http://dbpedia.org/resource/London",
                     "predicate" : "http://dbpedia.org/ontology/country",
                     "object" : {
-                      "dataType" : "xsd:anyURI",
                       "value" : "http://dbpedia.org/resource/United_Kingdom"
                     }
                   }, {
@@ -434,7 +425,6 @@ public class TestAccessTriplesService extends TestAccessBase {
                     "subject" : "http://dbpedia.org/resource/London",
                     "predicate" : "http://dbpedia.org/ontology/country",
                     "object" : {
-                      "dataType" : "xsd:anyURI",
                       "value" : "http://dbpedia.org/resource/United_Kingdom"
                     }
                   }, {
@@ -463,7 +453,6 @@ public class TestAccessTriplesService extends TestAccessBase {
                     "subject" : "http://dbpedia.org/resource/London",
                     "predicate" : "http://dbpedia.org/ontology/country",
                     "object" : {
-                      "dataType" : "xsd:anyURI",
                       "value" : "http://dbpedia.org/resource/United_Kingdom"
                     }
                   }, {
@@ -494,7 +483,6 @@ public class TestAccessTriplesService extends TestAccessBase {
                     "subject" : "http://dbpedia.org/resource/London",
                     "predicate" : "http://dbpedia.org/ontology/country",
                     "object" : {
-                      "dataType" : "xsd:anyURI",
                       "value" : "http://dbpedia.org/resource/United_Kingdom"
                     }
                   }, {
@@ -526,7 +514,6 @@ public class TestAccessTriplesService extends TestAccessBase {
                     "subject" : "http://dbpedia.org/resource/London",
                     "predicate" : "http://dbpedia.org/ontology/country",
                     "object" : {
-                      "dataType" : "xsd:anyURI",
                       "value" : "http://dbpedia.org/resource/England"
                     }
                   }, {
@@ -538,6 +525,59 @@ public class TestAccessTriplesService extends TestAccessBase {
                     }
                   } ],
                   "visible" : false
+                }""";
+        startServer();
+        loadData();
+        final String response = callServiceEndpoint(requestLondonEngland, USER1, SERVICE_NAME_1, ENDPOINT_UNDER_TEST, "?all=false");
+        assertEquals(expectedResponseBody, response, "Unexpected access query response");
+    }
+
+    @Test
+    void test_literal_uri_value() throws Exception {
+        final String requestLondonEngland = """
+                {
+                  "triples" : [ {
+                    "subject" : "http://dbpedia.org/resource/London",
+                    "predicate" : "http://xmlns.com/foaf/0.1/homepage",
+                    "object" : {
+                      "dataType" : "xsd:anyURI",
+                      "value" : "https://www.london.gov.uk/"
+                    }
+                  } ]
+                }""";
+        final String expectedResponseBody = """
+                {
+                  "triples" : [ {
+                    "subject" : "http://dbpedia.org/resource/London",
+                    "predicate" : "http://xmlns.com/foaf/0.1/homepage",
+                    "object" : {
+                      "dataType" : "xsd:anyURI",
+                      "value" : "https://www.london.gov.uk/"
+                    }
+                  } ],
+                  "visible" : true
+                }""";
+        startServer();
+        loadData();
+        final String response = callServiceEndpoint(requestLondonEngland, USER1, SERVICE_NAME_1, ENDPOINT_UNDER_TEST, "?all=false");
+        assertEquals(expectedResponseBody, response, "Unexpected access query response");
+    }
+
+    @Test
+    void test_not_a_valid_uri_value() throws Exception {
+        final String requestLondonEngland = """
+                {
+                  "triples" : [ {
+                    "subject" : "http://dbpedia.org/resource/London",
+                    "predicate" : "http://xmlns.com/foaf/0.1/homepage",
+                    "object" : {
+                      "value" : "not a URI"
+                    }
+                  } ]
+                }""";
+        final String expectedResponseBody = """
+                {
+                  "error" : "Illegal character in path at index 3: not a URI"
                 }""";
         startServer();
         loadData();
@@ -641,7 +681,6 @@ public class TestAccessTriplesService extends TestAccessBase {
                   "subject" : "http://dbpedia.org/resource/%s",
                   "predicate" : "http://dbpedia.org/ontology/%s",
                   "object" : {
-                    "dataType" : "xsd:anyURI",
                     "value" : "http://dbpedia.org/resource/%s"
                   }
                 }""".formatted(s, p, o);

--- a/scg-system/src/test/java/io/telicent/access/TestAccessTriplesService.java
+++ b/scg-system/src/test/java/io/telicent/access/TestAccessTriplesService.java
@@ -580,6 +580,61 @@ public class TestAccessTriplesService extends TestAccessBase {
         assertEquals(expectedResponseBody, response, "Unexpected access query response");
     }
 
+    @Test
+    void test_request_with_language_literal() throws Exception {
+        final String requestWithLanguage = """
+                {
+                  "triples" : [ {
+                    "subject" : "http://dbpedia.org/resource/London",
+                    "predicate" : "http://dbpedia.org/ontology/name",
+                    "object" : {
+                      "value" : "London",
+                      "language" : "en"
+                    }
+                  } ]
+                }""";
+        final String expectedResponseBody = """
+                {
+                  "triples" : [ {
+                    "subject" : "http://dbpedia.org/resource/London",
+                    "predicate" : "http://dbpedia.org/ontology/name",
+                    "object" : {
+                      "value" : "London",
+                      "language" : "en"
+                    }
+                  } ],
+                  "visible" : false
+                }""";
+        startServer();
+        loadData();
+        final String response = callServiceEndpoint(requestWithLanguage, USER1, SERVICE_NAME_1, ENDPOINT_UNDER_TEST);
+        assertEquals(expectedResponseBody, response, "Unexpected access query response");
+    }
+
+    @Test
+    void test_request_with_language_literal_and_datatype() throws Exception {
+        final String requestWithLanguage = """
+                {
+                  "triples" : [ {
+                    "subject" : "http://dbpedia.org/resource/London",
+                    "predicate" : "http://dbpedia.org/ontology/name",
+                    "object" : {
+                      "dataType" : "xsd:string",
+                      "value" : "London",
+                      "language" : "en"
+                    }
+                  } ]
+                }""";
+        final String expectedResponseBody = """
+                {
+                  "error" : "Cannot have both language and dataType in request object"
+                }""";
+        startServer();
+        loadData();
+        final String response = callServiceEndpoint(requestWithLanguage, USER1, SERVICE_NAME_1, ENDPOINT_UNDER_TEST);
+        assertEquals(expectedResponseBody, response, "Unexpected access query response");
+    }
+
     private String getRequestTripleUri(final String s, final String p, final String o) {
         return """
                 {


### PR DESCRIPTION
This PR adds language support to the triple access query. As language tagged strings are always of type `http://www.w3.org/1999/02/22-rdf-syntax-ns#langString` there is no requirement for the user to supply the datatype and therefore the language and datatype properties of the object have been made mutually exclusive.