### PR TITLE
[CORE-630] Consolidating backups into .gz file 

### DIFF
--- a/scg-system/src/main/java/io/telicent/access/servlets/AccessQueryServlet.java
+++ b/scg-system/src/main/java/io/telicent/access/servlets/AccessQueryServlet.java
@@ -1,7 +1,6 @@
 package io.telicent.access.servlets;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.telicent.access.AccessQuery;
 import io.telicent.access.AccessQueryResults;
 import io.telicent.access.services.AccessQueryService;
@@ -25,14 +24,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import static io.telicent.backup.utils.JsonFileUtils.OBJECT_MAPPER;
 import static io.telicent.utils.ServletUtils.handleError;
 import static io.telicent.utils.ServletUtils.processResponse;
 
 public class AccessQueryServlet extends HttpServlet {
 
     private final static Logger LOG = FusekiKafka.LOG;
-
-    public static ObjectMapper MAPPER = new ObjectMapper();
 
     private final AccessQueryService queryService;
 
@@ -43,7 +41,7 @@ public class AccessQueryServlet extends HttpServlet {
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
         try (final InputStream inputStream = request.getInputStream()) {
-            final AccessQuery query = MAPPER.readValue(inputStream, AccessQuery.class);
+            final AccessQuery query = OBJECT_MAPPER.readValue(inputStream, AccessQuery.class);
             final Triple accessQueryTriple = getAccessQueryTriple(query);
             final HttpAction action = new HttpAction(1L, LOG, ActionCategory.ACTION, request, response);
             final List<Triple> triples = queryService.getTriples(action, accessQueryTriple);
@@ -63,11 +61,11 @@ public class AccessQueryServlet extends HttpServlet {
                 }
             }
             final AccessQueryResults queryResults = new AccessQueryResults(query, (results.isEmpty() ? null : results));
-            processResponse(response, MAPPER.valueToTree(queryResults));
+            processResponse(response, OBJECT_MAPPER.valueToTree(queryResults));
         } catch (SmartCacheGraphException ex) {
-            handleError(response, MAPPER.createObjectNode(), HttpServletResponse.SC_BAD_REQUEST, ex.getMessage());
+            handleError(response, OBJECT_MAPPER.createObjectNode(), HttpServletResponse.SC_BAD_REQUEST, ex.getMessage());
         } catch (JsonProcessingException ex) {
-            handleError(response, MAPPER.createObjectNode(), HttpServletResponse.SC_BAD_REQUEST, "Missing or invalid request body content");
+            handleError(response, OBJECT_MAPPER.createObjectNode(), HttpServletResponse.SC_BAD_REQUEST, "Missing or invalid request body content");
         }
     }
 

--- a/scg-system/src/main/java/io/telicent/access/servlets/AccessTriplesServlet.java
+++ b/scg-system/src/main/java/io/telicent/access/servlets/AccessTriplesServlet.java
@@ -1,7 +1,6 @@
 package io.telicent.access.servlets;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.telicent.access.AccessTriplesResults;
 import io.telicent.access.services.AccessQueryService;
 import io.telicent.model.JsonTriple;
@@ -26,15 +25,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import static io.telicent.backup.utils.JsonFileUtils.OBJECT_MAPPER;
 import static io.telicent.utils.ServletUtils.handleError;
 import static io.telicent.utils.ServletUtils.processResponse;
 
 public class AccessTriplesServlet extends HttpServlet {
 
     private final static Logger LOG = FusekiKafka.LOG;
-
-    public static ObjectMapper MAPPER = new ObjectMapper();
-
 
     private final AccessQueryService queryService;
 
@@ -46,7 +43,7 @@ public class AccessTriplesServlet extends HttpServlet {
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
         boolean requireAllVisible = isAllVisibleRequired(request.getQueryString());
         try (final InputStream inputStream = request.getInputStream()) {
-            final JsonTriples query = MAPPER.readValue(inputStream, JsonTriples.class);
+            final JsonTriples query = OBJECT_MAPPER.readValue(inputStream, JsonTriples.class);
             final List<Triple> requestedTriples = getTripleList(query);
             final HttpAction action = new HttpAction(1L, LOG, ActionCategory.ACTION, request, response);
             final int requestedTriplesCount = query.triples.size();
@@ -60,15 +57,15 @@ public class AccessTriplesServlet extends HttpServlet {
                 createResponse(response, query, true);
             }
         } catch (SmartCacheGraphException ex) {
-            handleError(response, MAPPER.createObjectNode(), HttpServletResponse.SC_BAD_REQUEST, ex.getMessage());
+            handleError(response, OBJECT_MAPPER.createObjectNode(), HttpServletResponse.SC_BAD_REQUEST, ex.getMessage());
         } catch (JsonProcessingException jpex) {
-            handleError(response, MAPPER.createObjectNode(), HttpServletResponse.SC_BAD_REQUEST, "Unable to interpret JSON request");
+            handleError(response, OBJECT_MAPPER.createObjectNode(), HttpServletResponse.SC_BAD_REQUEST, "Unable to interpret JSON request");
         }
     }
 
     private void createResponse(HttpServletResponse response, JsonTriples query, boolean hasVisibility) {
         final AccessTriplesResults results = new AccessTriplesResults(query.triples, hasVisibility);
-        processResponse(response, MAPPER.valueToTree(results));
+        processResponse(response, OBJECT_MAPPER.valueToTree(results));
     }
 
     private boolean isAllVisibleRequired(String queryString) {

--- a/scg-system/src/main/java/io/telicent/backup/services/DatasetBackupService.java
+++ b/scg-system/src/main/java/io/telicent/backup/services/DatasetBackupService.java
@@ -24,7 +24,6 @@ import io.telicent.jena.abac.labels.LabelsStoreRocksDB;
 import io.telicent.jena.abac.labels.node.LabelToNodeGenerator;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.apache.commons.io.FileUtils;
 import org.apache.jena.atlas.lib.DateTimeUtils;
 import org.apache.jena.fuseki.mgt.Backup;
 import org.apache.jena.fuseki.server.DataAccessPoint;
@@ -56,15 +55,17 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
 
+import static io.telicent.backup.utils.BackupConstants.*;
 import static io.telicent.backup.utils.BackupUtils.*;
+import static io.telicent.backup.utils.CompressionUtils.*;
+import static io.telicent.backup.utils.JsonFileUtils.OBJECT_MAPPER;
+import static io.telicent.backup.utils.JsonFileUtils.writeObjectNodeToFile;
 import static io.telicent.otel.FMod_OpenTelemetry.fixupName;
 import static org.apache.jena.riot.Lang.NQUADS;
 
 public class DatasetBackupService {
 
     private final static String BACKUP_SUFFIX = "_backup";
-
-    private final static String REPORT_SUFFIX = "-validation-report.ttl";
 
     private final ReentrantLock lock;
 
@@ -89,7 +90,7 @@ public class DatasetBackupService {
      */
     public void process(HttpServletRequest request, HttpServletResponse response, boolean backup) {
         // Try to acquire the lock without blocking
-        ObjectNode resultNode = MAPPER.createObjectNode();
+        ObjectNode resultNode = OBJECT_MAPPER.createObjectNode();
         if (!lock.tryLock()) {
             response.setStatus(HttpServletResponse.SC_CONFLICT);
             resultNode.put("error", "Another conflicting operation is already in progress. Please try again later.");
@@ -98,7 +99,7 @@ public class DatasetBackupService {
             try {
                 String id = request.getPathInfo();
                 resultNode.put("id", id);
-                resultNode.put("date", DateTimeUtils.nowAsString("yyyy-MM-dd_HH-mm-ss"));
+                resultNode.put("date", DateTimeUtils.nowAsString(DATE_FORMAT));
                 resultNode.put("user", request.getRemoteUser());
                 String name = request.getParameter("description");
                 if (name != null) {
@@ -125,25 +126,26 @@ public class DatasetBackupService {
      */
     public ObjectNode backupDataset(String datasetName) {
         String sanitizedDatasetName = sanitiseName(datasetName);
-        ObjectNode response = MAPPER.createObjectNode();
+        ObjectNode response = OBJECT_MAPPER.createObjectNode();
         String backupPath = getBackUpDir();
         int backupID = getNextDirectoryNumberAndCreate(backupPath);
         String backupIDPath = backupPath + "/" + backupID;
         response.put("backup-id", backupID);
-        response.put("date", DateTimeUtils.nowAsString("yyyy-MM-dd_HH-mm-ss"));
+        response.put("date", DateTimeUtils.nowAsString(DATE_FORMAT));
 
-        ArrayNode datasetNodes = MAPPER.createArrayNode();
+        ArrayNode datasetNodes = OBJECT_MAPPER.createArrayNode();
         for (DataAccessPoint dataAccessPoint : dapRegistry.accessPoints()) {
             String dataAccessPointName = dataAccessPoint.getName();
             String sanitizedDataAccessPointName = sanitiseName(dataAccessPointName);
             if (requestIsEmpty(sanitizedDatasetName) || sanitizedDataAccessPointName.equals(sanitizedDatasetName)) {
-                ObjectNode datasetJSON = MAPPER.createObjectNode();
+                ObjectNode datasetJSON = OBJECT_MAPPER.createObjectNode();
                 datasetJSON.put("dataset-id", sanitizedDataAccessPointName);
                 applyBackUpMethods(datasetJSON, dataAccessPoint, backupIDPath + "/" + sanitizedDataAccessPointName);
                 datasetNodes.add(datasetJSON);
             }
         }
         response.set("datasets", datasetNodes);
+        compressAndStoreBackupMetadata(response, backupIDPath);
         return response;
     }
 
@@ -156,7 +158,7 @@ public class DatasetBackupService {
      */
     public void applyBackUpMethods(ObjectNode moduleJSON, DataAccessPoint dataAccessPoint, String backupPath) {
         for (Map.Entry<String, TriConsumer<DataAccessPoint, String, ObjectNode>> entry : backupConsumerMap.entrySet()) {
-            ObjectNode node = MAPPER.createObjectNode();
+            ObjectNode node = OBJECT_MAPPER.createObjectNode();
             String modBackupPath = backupPath + "/" + entry.getKey() + "/";
             node.put("folder", modBackupPath);
             if (!createPathIfNotExists(modBackupPath)) {
@@ -246,10 +248,7 @@ public class DatasetBackupService {
      * @return Object Node of the results
      */
     public ObjectNode listBackups() {
-        ObjectNode response = MAPPER.createObjectNode();
-        response.put("date", DateTimeUtils.nowAsString("yyyy-MM-dd_HH-mm-ss"));
-        response.set("backups", populateNodeFromDirNumerically(getBackUpDir()));
-        return response;
+        return getObjectNodeFromNumberedFiles(getBackUpDir(), JSON_INFO_SUFFIX);
     }
 
     /**
@@ -259,9 +258,15 @@ public class DatasetBackupService {
      * @return a node of the results
      */
     public ObjectNode restoreDatasets(String restoreId) {
-        ObjectNode response = MAPPER.createObjectNode();
+        ObjectNode response = OBJECT_MAPPER.createObjectNode();
         String restorePath = getBackUpDir() + "/" + restoreId;
         response.put("restorePath", restorePath);
+
+        boolean decompressDir = false;
+        if (checkPathExistsAndIsFile(restorePath + ZIP_SUFFIX)) {
+            unzipDirectory(restorePath + ZIP_SUFFIX, restorePath);
+            decompressDir=true;
+        }
         if (!checkPathExistsAndIsDir(restorePath)) {
             response.put("reason", "Restore path unsuitable: " + restorePath);
             response.put("success", false);
@@ -276,6 +281,10 @@ public class DatasetBackupService {
                 }
             }
         }
+
+        if(decompressDir) {
+            cleanupDirectory(restorePath);
+        }
         return response;
     }
 
@@ -287,7 +296,7 @@ public class DatasetBackupService {
      * @return a node with the results of the operation
      */
     ObjectNode restoreDataset(String restorePath, String datasetName) {
-        ObjectNode response = MAPPER.createObjectNode();
+        ObjectNode response = OBJECT_MAPPER.createObjectNode();
         response.put("dataset-id", datasetName);
         DataAccessPoint dataAccessPoint = getDataAccessPoint(datasetName);
         if (dataAccessPoint == null || dataAccessPoint.getDataService() == null) {
@@ -313,7 +322,7 @@ public class DatasetBackupService {
      * @param node            the results of the operation.
      */
     void restoreTDB(DataAccessPoint dataAccessPoint, String restorePath, ObjectNode node) {
-        String tdbRestoreFile = restorePath + "/" + sanitiseName(dataAccessPoint.getName()) + BACKUP_SUFFIX + ".nq.gz";
+        String tdbRestoreFile = restorePath + "/" + sanitiseName(dataAccessPoint.getName()) + BACKUP_SUFFIX + RDF_BACKUP_SUFFIX;
         node.put("restorePath", tdbRestoreFile);
         if (!checkPathExistsAndIsFile(tdbRestoreFile)) {
             node.put("reason", "Restore file not found: " + tdbRestoreFile);
@@ -339,7 +348,7 @@ public class DatasetBackupService {
      */
     public void applyRestoreMethods(ObjectNode moduleJSON, DataAccessPoint dataAccessPoint, String restorePath) {
         for (Map.Entry<String, TriConsumer<DataAccessPoint, String, ObjectNode>> entry : restoreConsumerMap.entrySet()) {
-            ObjectNode node = MAPPER.createObjectNode();
+            ObjectNode node = OBJECT_MAPPER.createObjectNode();
             String modRestorePath = restorePath + "/" + entry.getKey() + "/";
             node.put("folder", modRestorePath);
             if (!checkPathExistsAndIsDir(modRestorePath)) {
@@ -432,15 +441,18 @@ public class DatasetBackupService {
      */
     public ObjectNode deleteBackup(String deleteID) {
         String deletePath = getBackUpDir() + "/" + deleteID;
-        ObjectNode response = MAPPER.createObjectNode();
+        ObjectNode response = OBJECT_MAPPER.createObjectNode();
         response.put("delete-id", deleteID);
-        response.put("date", DateTimeUtils.nowAsString("yyyy-MM-dd_HH-mm-ss"));
+        response.put("date", DateTimeUtils.nowAsString(DATE_FORMAT));
         response.put("deletePath", deletePath);
-        if (!checkPathExistsAndIsDir(deletePath)) {
+        if (!checkPathExistsAndIsDir(deletePath) && !checkPathExistsAndIsFile(deletePath + JSON_INFO_SUFFIX)&& !checkPathExistsAndIsFile(deletePath + ZIP_SUFFIX)) {
             response.put("reason", "Backup path unsuitable: " + deletePath);
             response.put("success", false);
         } else {
             executeDeleteBackup(deletePath);
+            executeDeleteBackup(deletePath+ JSON_INFO_SUFFIX);
+            executeDeleteBackup(deletePath+ ZIP_SUFFIX);
+//            deleteFilesRegEx(getBackUpDir(), deleteID + WILDCARD_REPORT_SUFFIX);
             response.put("success", true);
         }
         return response;
@@ -458,8 +470,13 @@ public class DatasetBackupService {
         final String validatePath = getBackUpDir() + "/" + validateParams[0];
         final Model shapesModel = getShapeModel(shapeInputStream);
         final Graph shapesGraph = shapesModel.getGraph();
-        final ObjectNode resultNode = MAPPER.createObjectNode();
+        final ObjectNode resultNode = OBJECT_MAPPER.createObjectNode();
         final String datasetName = (validateParams.length > 1) ? "/" + validateParams[1] : "";
+        boolean decompressDir = false;
+        if (checkPathExistsAndIsFile(validatePath + ZIP_SUFFIX)) {
+            unzipDirectory(validatePath + ZIP_SUFFIX, validatePath);
+            decompressDir=true;
+        }
         if (!checkPathExistsAndIsDir(validatePath + datasetName)) {
             response.setStatus(HttpServletResponse.SC_NOT_FOUND);
             resultNode.put("reason", "Validation path unsuitable: " + validatePath + datasetName);
@@ -467,13 +484,16 @@ public class DatasetBackupService {
         } else {
             final Set<String> datasetDirs = listDirectories(validatePath, validateParams);
             resultNode.put("backup-id", validateParams[0]);
-            resultNode.put("date", DateTimeUtils.nowAsString("yyyy-MM-dd_HH-mm-ss"));
+            resultNode.put("date", DateTimeUtils.nowAsString(DATE_FORMAT));
             resultNode.put("validate-path", validatePath + datasetName);
-            final ObjectNode datasetResult = MAPPER.createObjectNode();
+            final ObjectNode datasetResult = OBJECT_MAPPER.createObjectNode();
             for (String datasetDir : datasetDirs) {
                 datasetResult.set(datasetDir, executeValidation(validatePath, datasetDir, shapesGraph));
             }
             resultNode.set("results", datasetResult);
+        }
+        if(decompressDir) {
+            cleanupDirectory(validatePath);
         }
         return resultNode;
     }
@@ -484,18 +504,19 @@ public class DatasetBackupService {
      * @param backupId    the back-up identifier
      * @param datasetName the dataset name
      * @return the SHACL validation report as a JSON String
-     * @throws Exception
+     * @throws Exception If error occurs
      */
     public ObjectNode getReport(final String backupId, final String datasetName, final HttpServletResponse response) throws Exception {
-        final ObjectNode resultNode = MAPPER.createObjectNode();
-        final String reportPathString = getBackUpDir() + "/" + backupId + "/" + datasetName + "/tdb/" + datasetName + BACKUP_SUFFIX + REPORT_SUFFIX;
+        final ObjectNode resultNode = OBJECT_MAPPER.createObjectNode();
+        final String reportPathString = getBackUpDir() + "/" + backupId + "-" + datasetName + REPORT_SUFFIX;
+
         if (checkPathExistsAndIsFile(reportPathString)) {
             final Model model = RDFDataMgr.loadModel(reportPathString);
             try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
                 RDFDataMgr.write(baos, model, Lang.RDFJSON);
                 resultNode.put("backup-id", backupId);
                 resultNode.put("dataset-name", datasetName);
-                return resultNode.set("result", MAPPER.readValue(baos.toString(StandardCharsets.UTF_8), ObjectNode.class));
+                return resultNode.set("result", OBJECT_MAPPER.readValue(baos.toString(StandardCharsets.UTF_8), ObjectNode.class));
             }
         } else {
             response.setStatus(HttpServletResponse.SC_NOT_FOUND);
@@ -553,16 +574,16 @@ public class DatasetBackupService {
     }
 
     private ObjectNode executeValidation(String validatePath, String datasetDir, Graph shapesGraph) {
-        final ObjectNode response = MAPPER.createObjectNode();
+        final ObjectNode response = OBJECT_MAPPER.createObjectNode();
         try {
-            final Path source = Path.of(validatePath, datasetDir, "tdb", datasetDir + BACKUP_SUFFIX + ".nq.gz");
+            final Path source = Path.of(validatePath, datasetDir, "tdb", datasetDir + BACKUP_SUFFIX + RDF_BACKUP_SUFFIX);
             final List<Path> tempPaths = new ArrayList<>();
 
             final Graph dataGraph = RDFDataMgr.loadGraph(source.toString());
             final Shapes shapes = Shapes.parse(shapesGraph);
 
             final ValidationReport report = ShaclValidator.get().validate(shapes, dataGraph);
-            writeValidationReport(report, source);
+            writeValidationReport(report, datasetDir, Path.of(validatePath));
             cleanUp(tempPaths);
             response.put("success", true);
         } catch (Exception ex) {
@@ -587,21 +608,16 @@ public class DatasetBackupService {
         return model.read(shapeInputStream, null, "TTL");
     }
 
-    private void writeValidationReport(final ValidationReport report, Path sourcePath) throws IOException {
-        String reportPathString = sourcePath.toString().replace(".nq.gz", REPORT_SUFFIX);
-        Path reportPath = Path.of(reportPathString);
+    private void writeValidationReport(final ValidationReport report, String dataset, Path sourcePath) throws IOException {
+        Path reportPath = Path.of(sourcePath + "-" + dataset + REPORT_SUFFIX);
         try (final FileOutputStream fos = new FileOutputStream(reportPath.toString())) {
             RDFDataMgr.write(fos, report.getModel(), Lang.TTL);
         }
     }
 
-    private void cleanUp(final List<Path> paths) {
-        for (Path path : paths) {
-            FileUtils.deleteQuietly(path.toFile());
-        }
-    }
 
-    /** Obtain the access point from the registry.
+    /**
+     * Obtain the access point from the registry.
      * We do two passes - a straight check and one
      * using the sanitised name
      * @param datasetName name
@@ -618,6 +634,17 @@ public class DatasetBackupService {
             }
         }
         return null;
+    }
+
+    /**
+     * Compress the files generated into a single zipped file and
+     * write a complimentary metadata file.
+     * @param response JSON object returned to client calls (and used to write metadata)
+     * @param dirPath location of files to compress
+     */
+    private void compressAndStoreBackupMetadata(ObjectNode response, String dirPath) {
+        zipDirectory(dirPath, dirPath + ZIP_SUFFIX, DELETE_GENERATED_FILES);
+        writeObjectNodeToFile(response, dirPath + JSON_INFO_SUFFIX);
     }
 
 }

--- a/scg-system/src/main/java/io/telicent/backup/servlets/DeleteServlet.java
+++ b/scg-system/src/main/java/io/telicent/backup/servlets/DeleteServlet.java
@@ -23,7 +23,10 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.jena.atlas.lib.DateTimeUtils;
 
+import static io.telicent.backup.utils.BackupConstants.DATE_FORMAT;
 import static io.telicent.backup.utils.BackupUtils.*;
+import static io.telicent.backup.utils.JsonFileUtils.OBJECT_MAPPER;
+
 /**
  * Servlet class responsible for the deletion of backups.
  */
@@ -36,11 +39,11 @@ public class DeleteServlet extends HttpServlet {
 
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) {
-        ObjectNode resultNode = MAPPER.createObjectNode();
+        ObjectNode resultNode = OBJECT_MAPPER.createObjectNode();
         try {
             String deleteId = request.getPathInfo();
             resultNode.put("delete-id", deleteId);
-            resultNode.put("date", DateTimeUtils.nowAsString("yyyy-MM-dd_HH-mm-ss"));
+            resultNode.put("date", DateTimeUtils.nowAsString(DATE_FORMAT));
             resultNode.set("delete", backupService.deleteBackup(deleteId));
             processResponse(response, resultNode);
         } catch (Exception exception) {

--- a/scg-system/src/main/java/io/telicent/backup/servlets/ListBackupsServlet.java
+++ b/scg-system/src/main/java/io/telicent/backup/servlets/ListBackupsServlet.java
@@ -23,7 +23,10 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.jena.atlas.lib.DateTimeUtils;
 
+import static io.telicent.backup.utils.BackupConstants.DATE_FORMAT;
 import static io.telicent.backup.utils.BackupUtils.*;
+import static io.telicent.backup.utils.JsonFileUtils.OBJECT_MAPPER;
+
 /**
  * Servlet class responsible for information on available back-ups.
  */
@@ -36,10 +39,10 @@ public class ListBackupsServlet extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) {
-        ObjectNode resultNode = MAPPER.createObjectNode();
+        ObjectNode resultNode = OBJECT_MAPPER.createObjectNode();
         try {
-            resultNode.put("date", DateTimeUtils.nowAsString("yyyy-MM-dd_HH-mm-ss"));
-            resultNode.set("list", backupService.listBackups());
+            resultNode.put("date", DateTimeUtils.nowAsString(DATE_FORMAT));
+            resultNode.set("backups", backupService.listBackups());
             processResponse(response, resultNode);
         } catch (Exception exception) {
             handleError(response, resultNode, exception);

--- a/scg-system/src/main/java/io/telicent/backup/servlets/ReportServlet.java
+++ b/scg-system/src/main/java/io/telicent/backup/servlets/ReportServlet.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import static io.telicent.backup.utils.BackupUtils.*;
+import static io.telicent.backup.utils.JsonFileUtils.OBJECT_MAPPER;
 
 public class ReportServlet extends HttpServlet {
 
@@ -23,7 +24,7 @@ public class ReportServlet extends HttpServlet {
             final ObjectNode report = backupService.getReport(pathElems[0], pathElems[1], response);
             processResponse(response, report);
         } catch (Exception exception) {
-            final ObjectNode resultNode = MAPPER.createObjectNode();
+            final ObjectNode resultNode = OBJECT_MAPPER.createObjectNode();
             handleError(response, resultNode, exception);
         }
     }

--- a/scg-system/src/main/java/io/telicent/backup/servlets/ValidateServlet.java
+++ b/scg-system/src/main/java/io/telicent/backup/servlets/ValidateServlet.java
@@ -11,6 +11,7 @@ import java.io.InputStream;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.telicent.backup.utils.BackupUtils.*;
+import static io.telicent.backup.utils.JsonFileUtils.OBJECT_MAPPER;
 
 public class ValidateServlet extends HttpServlet {
 
@@ -29,17 +30,17 @@ public class ValidateServlet extends HttpServlet {
                 if (request.getContentType().equals("text/turtle")) {
                     processRequest(request, response);
                 } else {
-                    final ObjectNode resultNode = MAPPER.createObjectNode();
+                    final ObjectNode resultNode = OBJECT_MAPPER.createObjectNode();
                     handleError(response, resultNode, HttpServletResponse.SC_BAD_REQUEST, "Invalid content type: " + request.getContentType());
                 }
             } catch (Exception exception) {
-                final ObjectNode resultNode = MAPPER.createObjectNode();
+                final ObjectNode resultNode = OBJECT_MAPPER.createObjectNode();
                 handleError(response, resultNode, exception);
             } finally {
                 RUNNING.set(false);
             }
         } else {
-            final ObjectNode resultNode = MAPPER.createObjectNode();
+            final ObjectNode resultNode = OBJECT_MAPPER.createObjectNode();
             response.setStatus(HttpServletResponse.SC_CONFLICT);
             resultNode.put("error", "Validation already in progress");
             processResponse(response, resultNode);

--- a/scg-system/src/main/java/io/telicent/backup/utils/BackupConstants.java
+++ b/scg-system/src/main/java/io/telicent/backup/utils/BackupConstants.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) Telicent Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.telicent.backup.utils;
+
+public final class BackupConstants {
+
+    private BackupConstants() {
+    }
+
+    public static final String ZIP_SUFFIX = ".zip";
+    public static final String JSON_INFO_SUFFIX = "_info.json";
+    public static final String REPORT_SUFFIX = "-validation-report.ttl";
+    public static final String WILDCARD_REPORT_SUFFIX = "-*-validation-report.ttl";
+    public static final String RDF_BACKUP_SUFFIX = ".nq.gz";
+    // this could become configurable?
+    public static final boolean DELETE_GENERATED_FILES = true;
+    public static final String DATE_FORMAT = "yyyy-MM-dd_HH-mm-ss";
+}

--- a/scg-system/src/main/java/io/telicent/backup/utils/CompressionUtils.java
+++ b/scg-system/src/main/java/io/telicent/backup/utils/CompressionUtils.java
@@ -1,0 +1,225 @@
+/*
+ *  Copyright (c) Telicent Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.telicent.backup.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import java.util.zip.ZipInputStream;
+
+public class CompressionUtils {
+
+    public static final Logger LOG = LoggerFactory.getLogger("CompressionUtils");
+    private static final int BUFFER_SIZE = 1024;
+
+    /**
+     * Zips a directory and its contents into a single ZIP file.
+     * @param sourceDirPath The path to the directory to be zipped.
+     * @param zipFilePath   The path where the resulting ZIP file will be created.
+     */
+    public static void zipDirectory(Path sourceDirPath, Path zipFilePath) {
+        zipDirectory(sourceDirPath, zipFilePath, false);
+    }
+
+    /**
+     * Zips a directory and its contents into a single ZIP file.
+     * @param sourceDirPath The path to the directory to be zipped.
+     * @param zipFilePath   The path where the resulting ZIP file will be created.
+     */
+    public static void zipDirectory(String sourceDirPath, String zipFilePath)  {
+        zipDirectory(Path.of(sourceDirPath), Path.of(zipFilePath), false);
+    }
+
+    /**
+     * Zips a directory and its contents into a single ZIP file.
+     * @param sourceDirPath The path to the directory to be zipped.
+     * @param zipFilePath   The path where the resulting ZIP file will be created.
+     */
+    public static void zipDirectory(String sourceDirPath, String zipFilePath, boolean deleteSource)  {
+        zipDirectory(Path.of(sourceDirPath), Path.of(zipFilePath), deleteSource);
+    }
+
+    /**
+     * Zips a directory and its contents into a single ZIP file.
+     * @param sourceDirPath The path to the directory to be zipped.
+     * @param zipFilePath   The path where the resulting ZIP file will be created.
+     * @param deleteSource  If true, the source directory will be deleted upon successful zipping.
+     */
+    public static void zipDirectory(Path sourceDirPath, Path zipFilePath, boolean deleteSource)  {
+        Objects.requireNonNull(sourceDirPath, "Source directory path cannot be null");
+        Objects.requireNonNull(zipFilePath, "ZIP file path cannot be null");
+
+        if (!Files.isDirectory(sourceDirPath)) {
+            throw new IllegalArgumentException("Source path must be a directory: " + sourceDirPath);
+        }
+
+        boolean zipSuccessful = false;
+        try (FileOutputStream fos = new FileOutputStream(zipFilePath.toFile());
+             ZipOutputStream zos = new ZipOutputStream(fos)) {
+
+            addDirToZip(sourceDirPath, sourceDirPath.toString(), zos);
+            zipSuccessful = true;
+
+        } catch (IOException e) {
+            LOG.error("Error zipping directory {}: {}", sourceDirPath, e.getMessage());
+            throw new RuntimeException(e);
+        } finally {
+            if (deleteSource && zipSuccessful) {
+                try {
+                    deleteDirectoryRecursive(sourceDirPath);
+                    LOG.info("Source directory deleted: {}", sourceDirPath);
+                } catch (IOException e) {
+                    LOG.error("Error deleting source directory {} after zipping: {}", sourceDirPath, e.getMessage());
+                }
+            }
+        }
+    }
+
+    /**
+     * Recursively adds a directory and its contents to the ZipOutputStream.
+     * @param sourceDir  The current directory being processed.
+     * @param parentPath The parent path (used to determine relative paths within the zip).
+     * @param zos        The ZipOutputStream to write to.
+     * @throws IOException If an I/O error occurs.
+     */
+    private static void addDirToZip(Path sourceDir, String parentPath, ZipOutputStream zos) throws IOException {
+        File[] files = sourceDir.toFile().listFiles();
+        if (files == null) {
+            return;
+        }
+
+        byte[] buffer = new byte[BUFFER_SIZE];
+
+        for (File file : files) {
+            String entryName = Paths.get(parentPath).relativize(file.toPath()).toString();
+
+            if (file.isDirectory()) {
+                zos.putNextEntry(new ZipEntry(entryName + "/"));
+                zos.closeEntry();
+                addDirToZip(file.toPath(), parentPath, zos);
+            } else {
+                try (FileInputStream fis = new FileInputStream(file)) {
+                    zos.putNextEntry(new ZipEntry(entryName));
+                    int len;
+                    while ((len = fis.read(buffer)) != -1) {
+                        zos.write(buffer, 0, len);
+                    }
+                    zos.closeEntry();
+                }
+            }
+        }
+    }
+
+    /**
+     * Unzips a ZIP file to a specified destination directory.
+     * @param zipFilePath     The path to the ZIP file.
+     * @param destDirectoryPath The path to the directory where contents will be extracted.
+     */
+    public static void unzipDirectory(String zipFilePath, String destDirectoryPath) {
+        try {
+            unzipDirectory(Path.of(zipFilePath), Path.of(destDirectoryPath));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Unzips a ZIP file to a specified destination directory.
+     *
+     * @param zipFilePath     The path to the ZIP file.
+     * @param destDirectoryPath The path to the directory where contents will be extracted.
+     * @throws IOException If an I/O error occurs.
+     */
+    public static void unzipDirectory(Path zipFilePath, Path destDirectoryPath) throws IOException {
+        Objects.requireNonNull(zipFilePath, "ZIP file path cannot be null");
+        Objects.requireNonNull(destDirectoryPath, "Destination directory path cannot be null");
+
+        if (!Files.exists(zipFilePath) || !Files.isRegularFile(zipFilePath)) {
+            throw new IllegalArgumentException("ZIP file does not exist or is not a regular file: " + zipFilePath);
+        }
+
+        Files.createDirectories(destDirectoryPath);
+
+        try (FileInputStream fis = new FileInputStream(zipFilePath.toFile());
+             ZipInputStream zis = new ZipInputStream(fis)) {
+
+            ZipEntry entry;
+            byte[] buffer = new byte[BUFFER_SIZE];
+
+            while ((entry = zis.getNextEntry()) != null) {
+                Path entryPath = destDirectoryPath.resolve(entry.getName()).normalize();
+                if (!entryPath.startsWith(destDirectoryPath)) {
+                    throw new IOException("Attempted path traversal attack: " + entry.getName() + " is outside " + destDirectoryPath);
+                }
+
+                if (entry.isDirectory()) {
+                    Files.createDirectories(entryPath);
+                } else {
+                    Files.createDirectories(entryPath.getParent());
+                    try (FileOutputStream fos = new FileOutputStream(entryPath.toFile())) {
+                        int len;
+                        while ((len = zis.read(buffer)) != -1) {
+                            fos.write(buffer, 0, len);
+                        }
+                    }
+                }
+                zis.closeEntry();
+            }
+        }
+    }
+
+    /**
+     * Deletes a directory and all its contents recursively.
+     * @param path The path to the directory to delete.
+     */
+    public static void cleanupDirectory(String path) {
+        try {
+            deleteDirectoryRecursive(Path.of(path));
+        } catch (IOException e) {
+            LOG.error(String.format("Unable to clean up directory: %s", path), e);
+        }
+    }
+
+    /**
+     * Deletes a directory and all its contents recursively.
+     * @param directory The path to the directory to delete.
+     * @throws IOException If an I/O error occurs during deletion.
+     */
+    private static void deleteDirectoryRecursive(Path directory) throws IOException {
+        if (Files.exists(directory)) {
+            try (Stream<Path> walk = Files.walk(directory)) {
+                walk.sorted(java.util.Comparator.reverseOrder())
+                        .map(Path::toFile)
+                        .forEach(file -> {
+                            if (!file.delete()) {
+                                LOG.error("Failed to delete: {}", file.getAbsolutePath());
+                            }
+                        });
+            }
+        }
+    }
+}

--- a/scg-system/src/main/java/io/telicent/backup/utils/JsonFileUtils.java
+++ b/scg-system/src/main/java/io/telicent/backup/utils/JsonFileUtils.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) Telicent Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.telicent.backup.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Objects;
+
+public class JsonFileUtils {
+
+    public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    /**
+     * Writes an ObjectNode to a specified file.
+     *
+     * @param objectNode The ObjectNode to write.
+     * @param filePath   The Path to the file where the JSON will be written.
+     */
+    public static void writeObjectNodeToFile(ObjectNode objectNode, Path filePath) {
+        Objects.requireNonNull(objectNode, "ObjectNode cannot be null.");
+        Objects.requireNonNull(filePath, "File path cannot be null.");
+        try{
+            OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValue(filePath.toFile(), objectNode);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Writes an ObjectNode to a specified file (String path)
+     *
+     * @param objectNode The ObjectNode to write.
+     * @param filePath   The String path to the file where the JSON will be written.
+     */
+    public static void writeObjectNodeToFile(ObjectNode objectNode, String filePath){
+        writeObjectNodeToFile(objectNode, Path.of(filePath));
+    }
+}

--- a/scg-system/src/main/java/io/telicent/core/FMod_FusekiKafkaSCG.java
+++ b/scg-system/src/main/java/io/telicent/core/FMod_FusekiKafkaSCG.java
@@ -41,7 +41,7 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.sparql.core.DatasetGraph;
 
 import static io.telicent.backup.services.DatasetBackupService.sanitiseName;
-import static io.telicent.backup.utils.BackupUtils.MAPPER;
+import static io.telicent.backup.utils.JsonFileUtils.OBJECT_MAPPER;
 import static org.apache.jena.kafka.FusekiKafka.LOG;
 
 /**
@@ -118,7 +118,7 @@ public class FMod_FusekiKafkaSCG extends FMod_FusekiKafka {
     public void backupKafka(DataAccessPoint dataAccessPoint, String path, ObjectNode resultNode) {
         String dataset = dataAccessPoint.getName();
         List<KConnectorDesc> kafkaConnectionList = obtainKafkaConnection(dataset, dataAccessPoint.getDataService());
-        ArrayNode nodeList = MAPPER.createArrayNode();
+        ArrayNode nodeList = OBJECT_MAPPER.createArrayNode();
         for (KConnectorDesc conn : kafkaConnectionList) {
             nodeList.add(backupKafkaConnection(conn, path));
         }
@@ -128,7 +128,7 @@ public class FMod_FusekiKafkaSCG extends FMod_FusekiKafka {
     public void restoreKafka(DataAccessPoint dataAccessPoint, String path, ObjectNode resultNode) {
         String dataset = dataAccessPoint.getName();
         List<KConnectorDesc> kafkaConnectionList = obtainKafkaConnection(dataset, dataAccessPoint.getDataService());
-        ArrayNode nodeList = MAPPER.createArrayNode();
+        ArrayNode nodeList = OBJECT_MAPPER.createArrayNode();
         for (KConnectorDesc conn : kafkaConnectionList) {
             nodeList.add(restoreKafkaConnection(conn, dataset, path));
         }
@@ -152,7 +152,7 @@ public class FMod_FusekiKafkaSCG extends FMod_FusekiKafka {
     }
 
     private ObjectNode backupKafkaConnection(KConnectorDesc conn, String path) {
-        ObjectNode resultNode = MAPPER.createObjectNode();
+        ObjectNode resultNode = OBJECT_MAPPER.createObjectNode();
         String sanitizedDataset = sanitiseName(conn.getLocalDispatchPath());
         resultNode.put("name", sanitizedDataset);
         String filename = path + "/" + sanitizedDataset + ".json";
@@ -164,7 +164,7 @@ public class FMod_FusekiKafkaSCG extends FMod_FusekiKafka {
     }
 
     private ObjectNode restoreKafkaConnection(KConnectorDesc conn, String dataset, String path) {
-        ObjectNode resultNode = MAPPER.createObjectNode();
+        ObjectNode resultNode = OBJECT_MAPPER.createObjectNode();
         String sanitizedDataset = sanitiseName(conn.getLocalDispatchPath());
         resultNode.put("name", sanitizedDataset);
         String filename = path + "/" + sanitizedDataset + ".json";

--- a/scg-system/src/main/java/io/telicent/labels/TripleLabels.java
+++ b/scg-system/src/main/java/io/telicent/labels/TripleLabels.java
@@ -1,15 +1,14 @@
 package io.telicent.labels;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.jena.graph.Triple;
 
 import java.util.List;
 
-public class TripleLabels {
+import static io.telicent.backup.utils.JsonFileUtils.OBJECT_MAPPER;
 
-    public static ObjectMapper MAPPER = new ObjectMapper();
+public class TripleLabels {
 
     public TripleLabels(Triple triple, List<String> labels){
         this.triple = triple;
@@ -20,11 +19,11 @@ public class TripleLabels {
     public Triple triple;
 
     public ObjectNode toJSONNode() {
-        ObjectNode node = MAPPER.createObjectNode();
+        ObjectNode node = OBJECT_MAPPER.createObjectNode();
         node.put("subject", triple.getSubject().toString());
         node.put("predicate", triple.getPredicate().toString());
         node.put("object", triple.getObject().toString());
-        ArrayNode labelNode = MAPPER.createArrayNode();
+        ArrayNode labelNode = OBJECT_MAPPER.createArrayNode();
         labels.forEach(labelNode::add);
         node.set("labels", labelNode);
         return node;

--- a/scg-system/src/main/java/io/telicent/labels/servlets/LabelsQueryServlet.java
+++ b/scg-system/src/main/java/io/telicent/labels/servlets/LabelsQueryServlet.java
@@ -1,7 +1,6 @@
 package io.telicent.labels.servlets;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.telicent.labels.TripleLabels;
@@ -22,6 +21,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import static io.telicent.backup.utils.JsonFileUtils.OBJECT_MAPPER;
 import static io.telicent.utils.ServletUtils.*;
 
 public class LabelsQueryServlet extends HttpServlet {
@@ -34,8 +34,6 @@ public class LabelsQueryServlet extends HttpServlet {
 
     private final LabelsQueryService queryService;
 
-    public static ObjectMapper MAPPER = new ObjectMapper();
-
     public LabelsQueryServlet(LabelsQueryService queryService) {
         this.queryService = queryService;
     }
@@ -43,13 +41,13 @@ public class LabelsQueryServlet extends HttpServlet {
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) {
         List<Triple> tripleQueryList = obtainTripleQueries(request);
-        ObjectNode resultNode = MAPPER.createObjectNode();
+        ObjectNode resultNode = OBJECT_MAPPER.createObjectNode();
         resultNode.set("results", processQueryList(tripleQueryList));
         processResponse(response, resultNode);
     }
 
     ArrayNode processQueryList(List<Triple> tripleQueryList) {
-        ArrayNode resultNodeList = MAPPER.createArrayNode();
+        ArrayNode resultNodeList = OBJECT_MAPPER.createArrayNode();
         tripleQueryList.forEach(triple -> {
             List<TripleLabels> results = processTriple(triple);
             results.forEach(tripleLabel -> resultNodeList.add(tripleLabel.toJSONNode()));
@@ -78,9 +76,9 @@ public class LabelsQueryServlet extends HttpServlet {
     private List<Triple> obtainTripleQueries(HttpServletRequest request) {
         List<Triple> tripleList = new ArrayList<>();
         try (final InputStream inputStream = request.getInputStream()) {
-            JsonNode rootNode = MAPPER.readTree(inputStream);
+            JsonNode rootNode = OBJECT_MAPPER.readTree(inputStream);
             if (rootNode.has("triples") && rootNode.get("triples").isArray()) {
-                JsonTriples queryRequest = MAPPER.convertValue(rootNode, JsonTriples.class);
+                JsonTriples queryRequest = OBJECT_MAPPER.convertValue(rootNode, JsonTriples.class);
                 for (JsonTriple query : queryRequest.triples) {
                     tripleList.add(getTriple(query));
                 }

--- a/scg-system/src/main/java/io/telicent/utils/ServletUtils.java
+++ b/scg-system/src/main/java/io/telicent/utils/ServletUtils.java
@@ -1,12 +1,13 @@
 package io.telicent.utils;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.jena.riot.WebContent;
 
 import java.io.IOException;
+
+import static io.telicent.backup.utils.JsonFileUtils.OBJECT_MAPPER;
 
 /**
  * Utility class for carrying out common servlet operations
@@ -15,8 +16,6 @@ public class ServletUtils {
 
     public final static String HTTP = "http://";
     public final static String HTTPS = "https://";
-
-    public static ObjectMapper MAPPER = new ObjectMapper();
 
     /**
      * Populate an HTTP Response from given JSON Node
@@ -27,7 +26,7 @@ public class ServletUtils {
     public static void processResponse(HttpServletResponse response, ObjectNode jsonResponse) {
         String jsonOutput;
         try (ServletOutputStream out = response.getOutputStream()) {
-            jsonOutput = MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(jsonResponse);
+            jsonOutput = OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(jsonResponse);
             response.setContentLength(jsonOutput.length());
             response.setContentType(WebContent.contentTypeJSON);
             response.setCharacterEncoding(WebContent.charsetUTF8);

--- a/scg-system/src/test/java/io/telicent/TestYamlConfigParserAuthz.java
+++ b/scg-system/src/test/java/io/telicent/TestYamlConfigParserAuthz.java
@@ -38,7 +38,6 @@ import org.apache.jena.sparql.exec.QueryExec;
 import org.apache.jena.sparql.exec.RowSetOps;
 import org.apache.jena.sparql.exec.RowSetRewindable;
 import org.apache.jena.sparql.exec.http.QueryExecHTTPBuilder;
-import org.apache.jena.sparql.resultset.ResultSetCompare;
 import org.junit.jupiter.api.*;
 import org.rocksdb.RocksDBException;
 
@@ -46,6 +45,7 @@ import org.rocksdb.RocksDBException;
 import java.io.File;
 import java.util.List;
 
+import static io.telicent.DockerTestYamlConfigParser.isomorphic;
 import static io.telicent.LibTestsSCG.*;
 import static io.telicent.core.SmartCacheGraph.construct;
 import static io.telicent.jena.abac.labels.Labels.createLabelsStoreRocksDB;
@@ -118,7 +118,7 @@ class TestYamlConfigParserAuthz {
                         LibTestsSCG.tokenHeaderValue(validToken))
                 .select().rewindable();
         RowSetOps.out(System.out, actualResponseRSR);
-        boolean equals = ResultSetCompare.isomorphic(expectedRSR, actualResponseRSR);
+        boolean equals = isomorphic(expectedRSR, actualResponseRSR);
         assertTrue(equals);
     }
 
@@ -135,7 +135,7 @@ class TestYamlConfigParserAuthz {
                         LibTestsSCG.tokenHeaderValue(validToken))
                 .select().rewindable();
         RowSetOps.out(System.out, actualResponseRSR);
-        boolean equals = ResultSetCompare.isomorphic(expectedRSR, actualResponseRSR);
+        boolean equals = isomorphic(expectedRSR, actualResponseRSR);
         assertTrue(equals);
     }
 
@@ -170,7 +170,7 @@ class TestYamlConfigParserAuthz {
                         LibTestsSCG.tokenHeaderValue(validToken))
                 .select().rewindable();
         RowSetOps.out(System.out, actualResponseRSR);
-        boolean equals = ResultSetCompare.isomorphic(expectedRSR, actualResponseRSR);
+        boolean equals = isomorphic(expectedRSR, actualResponseRSR);
         assertTrue(equals);
     }
 
@@ -190,7 +190,7 @@ class TestYamlConfigParserAuthz {
                 .httpHeader(LibTestsSCG.tokenHeader(),
                         LibTestsSCG.tokenHeaderValue(validToken))
                 .select().rewindable();
-        boolean equals = ResultSetCompare.isomorphic(expectedRSR, actualResponseRSR);
+        boolean equals = isomorphic(expectedRSR, actualResponseRSR);
         assertTrue(equals);
     }
 
@@ -207,7 +207,7 @@ class TestYamlConfigParserAuthz {
                         LibTestsSCG.tokenHeaderValue(validToken))
                 .select().rewindable();
         RowSetOps.out(System.out, actualResponseRSR);
-        boolean equals = ResultSetCompare.isomorphic(expectedRSR, actualResponseRSR);
+        boolean equals = isomorphic(expectedRSR, actualResponseRSR);
         assertTrue(equals);
     }
 
@@ -224,7 +224,7 @@ class TestYamlConfigParserAuthz {
                         LibTestsSCG.tokenHeaderValue(validToken))
                 .select().rewindable();
         RowSetOps.out(System.out, actualResponseRSR);
-        boolean equals = ResultSetCompare.isomorphic(expectedRSRtdl, actualResponseRSR);
+        boolean equals = isomorphic(expectedRSRtdl, actualResponseRSR);
         assertTrue(equals);
     }
 
@@ -241,7 +241,7 @@ class TestYamlConfigParserAuthz {
                         LibTestsSCG.tokenHeaderValue(validToken))
                 .select().rewindable();
         RowSetOps.out(System.out, actualResponseRSR);
-        boolean equals = ResultSetCompare.isomorphic(expectedRSR, actualResponseRSR);
+        boolean equals = isomorphic(expectedRSR, actualResponseRSR);
         assertTrue(equals);
     }
 }

--- a/scg-system/src/test/java/io/telicent/backup/TestBackupData.java
+++ b/scg-system/src/test/java/io/telicent/backup/TestBackupData.java
@@ -15,7 +15,6 @@
  */
 package io.telicent.backup;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.telicent.LibTestsSCG;
 import io.telicent.backup.services.DatasetBackupService;
 import io.telicent.backup.services.DatasetBackupService_Test;
@@ -41,6 +40,7 @@ import java.util.List;
 
 import static io.telicent.TestJwtServletAuth.makeAuthGETCallWithPath;
 import static io.telicent.TestJwtServletAuth.makeAuthPOSTCallWithPath;
+import static io.telicent.backup.utils.JsonFileUtils.OBJECT_MAPPER;
 import static org.apache.jena.graph.Graph.emptyGraph;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -240,9 +240,8 @@ public class TestBackupData {
         try {
             InputStream inputStream = response.body();
             InputStreamReader reader = new InputStreamReader(inputStream);
-            ObjectMapper mapper = new ObjectMapper();
-            Object jsonObject = mapper.readValue(reader, Object.class);
-            return mapper.writeValueAsString(jsonObject);
+            Object jsonObject = OBJECT_MAPPER.readValue(reader, Object.class);
+            return OBJECT_MAPPER.writeValueAsString(jsonObject);
         }catch (IOException e) {
             return e.getMessage();
         }

--- a/scg-system/src/test/java/io/telicent/backup/services/TestBackupAndRestore.java
+++ b/scg-system/src/test/java/io/telicent/backup/services/TestBackupAndRestore.java
@@ -18,7 +18,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static io.telicent.backup.utils.BackupUtils.MAPPER;
+import static io.telicent.backup.utils.JsonFileUtils.OBJECT_MAPPER;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TestBackupAndRestore {
@@ -94,7 +94,7 @@ public class TestBackupAndRestore {
 
         String backupFilename = TEST_BACKUP_DIR + "test_file.nq";
         String backupCompressedFilename = backupFilename+".gz";
-        ObjectNode resultNode = MAPPER.createObjectNode();
+        ObjectNode resultNode = OBJECT_MAPPER.createObjectNode();
         // when
         datasetBackupService.executeBackupTDB(dsgABAC, backupFilename, resultNode);
         // then

--- a/scg-system/src/test/java/io/telicent/backup/utils/TestBackupUtils.java
+++ b/scg-system/src/test/java/io/telicent/backup/utils/TestBackupUtils.java
@@ -15,7 +15,6 @@
  */
 package io.telicent.backup.utils;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.telicent.smart.cache.configuration.Configurator;
 import io.telicent.smart.cache.configuration.sources.PropertiesSource;
@@ -23,21 +22,30 @@ import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.jena.riot.WebContent;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
 import static io.telicent.backup.utils.BackupUtils.*;
+import static io.telicent.backup.utils.JsonFileUtils.OBJECT_MAPPER;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.*;
 
 public class TestBackupUtils {
+
+    @TempDir
+    Path tempDir;
 
     @BeforeEach
     public void setup() {
@@ -54,6 +62,7 @@ public class TestBackupUtils {
     }
 
     @Test
+    @DisplayName("Tests that generateBackUpDirPath creates the default backup directory if not specified")
     public void test_generateBackUpDirPath_defaultBackupDir() {
         // given
         // when
@@ -63,6 +72,7 @@ public class TestBackupUtils {
     }
 
     @Test
+    @DisplayName("Tests that generateBackUpDirPath uses the default backup directory when an empty property is set")
     public void test_generateBackUpDirPath_emptyProperty() {
         // given
         setBackUpDirProperty("");
@@ -74,9 +84,9 @@ public class TestBackupUtils {
     }
 
     @Test
+    @DisplayName("Tests that generateBackUpDirPath uses the default backup directory when an invalid property is set")
     public void test_generateBackUpDirPath_invalidProperty() {
         // given
-//        setBackUpDirProperty("?:|");
         setBackUpDirProperty("/non/existent/directory");
         // when
         String dirPath = generateBackUpDirPath();
@@ -86,133 +96,211 @@ public class TestBackupUtils {
     }
 
     @Test
+    @DisplayName("Tests that generateBackUpDirPath returns an existing backup directory path")
     public void test_generateBackUpDirPath_existingBackupDir() throws IOException {
         // given
-        Path tempDir = Files.createTempDirectory("test_backup_dir");
-        tempDir.toFile().deleteOnExit();
-        setBackUpDirProperty(tempDir.toString());
+        Path tempBackupDir = Files.createTempDirectory(tempDir, "test_backup_dir_existing");
+        tempBackupDir.toFile().deleteOnExit();
+        setBackUpDirProperty(tempBackupDir.toString());
         // when
         String dirPath = generateBackUpDirPath();
         // then
-        assertEquals(tempDir.toString(), dirPath);
+        assertEquals(tempBackupDir.toString(), dirPath);
     }
 
     @Test
+    @DisplayName("Tests that generateBackUpDirPath creates a new backup directory if it doesn't exist")
     public void test_generateBackUpDirPath_createBackupDir() {
         // given
-        String tempDir = System.getProperty("java.io.tmpdir") + "/new_backup_dir";
-        setBackUpDirProperty(tempDir);
+        Path newBackupDir = tempDir.resolve("new_backup_dir");
+        setBackUpDirProperty(newBackupDir.toString());
 
         // when
         String dirPath = generateBackUpDirPath();
 
         // then
-        assertEquals(tempDir, dirPath);
-        assertTrue(new File(tempDir).exists());
-        new File(tempDir).deleteOnExit();
+        assertEquals(newBackupDir.toString(), dirPath);
+        assertTrue(Files.exists(newBackupDir));
     }
 
     @Test
-    public void test_checkPathExistsAndIsDir_existingDirectory() {
-        File tempDir = new File("temp1_dir");
-        tempDir.deleteOnExit();
-        assertTrue(tempDir.mkdir());
-        assertTrue(checkPathExistsAndIsDir(tempDir.getAbsolutePath()));
+    @DisplayName("Tests that getBackUpDir generates and returns the path on the first call")
+    public void test_getBackUpDir_firstCallGeneratesPath() {
+        // given
+        assertNull(dirBackups);
+        // when
+        String dirPath = getBackUpDir();
+        // then
+        assertNotNull(dirBackups);
+        assertEquals(dirPath, dirBackups);
+        assertTrue(new File(dirPath).exists());
     }
 
     @Test
+    @DisplayName("Tests that getBackUpDir returns the cached path on subsequent calls")
+    public void test_getBackUpDir_subsequentCallsReturnCachedPath() {
+        // given
+        String firstCallPath = getBackUpDir();
+        // when
+        String secondCallPath = getBackUpDir();
+        // then
+        assertEquals(firstCallPath, secondCallPath);
+        assertEquals(firstCallPath, dirBackups);
+    }
+
+    @Test
+    @DisplayName("Tests checkPathExistsAndIsDir with an existing directory")
+    public void test_checkPathExistsAndIsDir_existingDirectory() throws IOException {
+        // given
+        // when
+        Path testDir = Files.createDirectory(tempDir.resolve("test_dir"));
+        // then
+        assertTrue(checkPathExistsAndIsDir(testDir.toAbsolutePath().toString()));
+    }
+
+    @Test
+    @DisplayName("Tests checkPathExistsAndIsDir with a non-existent directory")
     public void test_checkPathExistsAndIsDir_nonexistentDirectory() {
+        // given
+        // when
+        // then
         assertFalse(checkPathExistsAndIsDir("nonexistent_dir"));
     }
 
     @Test
+    @DisplayName("Tests checkPathExistsAndIsDir with an existing file")
     public void test_checkPathExistsAndIsDir_existingFile() throws IOException {
-        File tempFile = new File("temp1.txt");
-        tempFile.deleteOnExit();
-        assertTrue(tempFile.createNewFile());
-        assertFalse(checkPathExistsAndIsDir(tempFile.getAbsolutePath()));
+        // given
+        // when
+        Path testFile = Files.createFile(tempDir.resolve("test_file.txt"));
+        // then
+        assertFalse(checkPathExistsAndIsDir(testFile.toAbsolutePath().toString()));
     }
 
     @Test
+    @DisplayName("Tests checkPathExistsAndIsDir with a null path")
     public void test_checkPathExistsAndIsDir_nullPath() {
+        // given
+        // when
+        // then
         assertFalse(checkPathExistsAndIsDir(null));
     }
 
     @Test
+    @DisplayName("Tests checkPathExistsAndIsDir with an empty path")
     public void test_checkPathExistsAndIsDir_emptyPath() {
+        // given
+        // when
+        // then
         assertFalse(checkPathExistsAndIsDir(""));
     }
 
 
     @Test
+    @DisplayName("Tests checkPathExistsAndIsFile with a null path")
     public void test_checkPathExistsAndIsFile_nullPath() {
+        // given
+        // when
+        // then
         assertFalse(checkPathExistsAndIsFile(null));
     }
 
     @Test
+    @DisplayName("Tests checkPathExistsAndIsFile with an empty path")
     public void test_checkPathExistsAndIsFile_emptyPath() {
+        // given
+        // when
+        // then
         assertFalse(checkPathExistsAndIsFile(""));
     }
 
     @Test
+    @DisplayName("Tests checkPathExistsAndIsFile with a root slash path")
     public void test_checkPathExistsAndIsFile_slashPath() {
+        // given
+        // when
+        // then
         assertFalse(checkPathExistsAndIsFile("/"));
     }
 
     @Test
+    @DisplayName("Tests checkPathExistsAndIsFile with an existing file")
     public void test_checkPathExistsAndIsFile_existingFile() throws IOException {
-        File tempFile = new File("temp2.txt");
-        tempFile.deleteOnExit();
-        assertTrue(tempFile.createNewFile());
-        assertTrue(checkPathExistsAndIsFile(tempFile.getAbsolutePath()));
+        // given
+        // when
+        Path testFile = Files.createFile(tempDir.resolve("temp2.txt"));
+        // then
+        assertTrue(checkPathExistsAndIsFile(testFile.toAbsolutePath().toString()));
     }
 
     @Test
+    @DisplayName("Tests checkPathExistsAndIsFile with a non-existent file")
     public void test_checkPathExistsAndIsFile_nonexistentFile() {
+        // given
+        // when
+        // then
         assertFalse(checkPathExistsAndIsFile("nonexistent_file.txt"));
     }
 
     @Test
-    public void test_checkPathExistsAndIsFile_existingDirectory() {
-        File tempDir = new File("temp2_dir");
-        tempDir.deleteOnExit();
-        assertTrue(tempDir.mkdir());
-        assertFalse(checkPathExistsAndIsFile(tempDir.getAbsolutePath()));
+    @DisplayName("Tests checkPathExistsAndIsFile with an existing directory")
+    public void test_checkPathExistsAndIsFile_existingDirectory() throws IOException {
+        // given
+        // when
+        Path testDir = Files.createDirectory(tempDir.resolve("temp2_dir"));
+        // then
+        assertFalse(checkPathExistsAndIsFile(testDir.toAbsolutePath().toString()));
     }
 
     @Test
+    @DisplayName("Tests requestIsEmpty with a null request name")
     public void test_requestIsEmpty_NullRequestName() {
+        // given
+        // when
+        // then
         assertTrue(requestIsEmpty(null));
     }
 
     @Test
+    @DisplayName("Tests requestIsEmpty with empty or blank request names")
     public void test_requestIsEmpty_EmptyRequestName() {
+        // given
+        // when
+        // then
         assertTrue(requestIsEmpty(""));
         assertTrue(requestIsEmpty(" "));
         assertTrue(requestIsEmpty("   "));
     }
 
     @Test
+    @DisplayName("Tests requestIsEmpty with a slash request name")
     public void test_requestIsEmpty_SlashRequestName() {
+        // given
+        // when
+        // then
         assertTrue(requestIsEmpty("/"));
         assertTrue(requestIsEmpty(" / "));
     }
 
     @Test
+    @DisplayName("Tests requestIsEmpty with a non-empty request name")
     public void test_requestIsEmpty_NonEmptyRequestName() {
+        // given
+        // when
+        // then
         assertFalse(requestIsEmpty("test"));
         assertFalse(requestIsEmpty("test/"));
         assertFalse(requestIsEmpty("/test"));
     }
 
     @Test
+    @DisplayName("Tests processResponse for a successful JSON response")
     public void test_processResponse_successfulResponse() throws IOException {
         // given
         HttpServletResponse response = mock(HttpServletResponse.class);
         ServletOutputStream outputStream = mock(ServletOutputStream.class);
 
-        ObjectMapper mapper = new ObjectMapper();
-        ObjectNode jsonResponse = mapper.createObjectNode();
+        ObjectNode jsonResponse = OBJECT_MAPPER.createObjectNode();
         jsonResponse.put("key", "value");
 
         when(response.getOutputStream()).thenReturn(outputStream);
@@ -227,27 +315,31 @@ public class TestBackupUtils {
     }
 
     @Test
+    @DisplayName("Tests processResponse when an IOException occurs during writing")
     public void test_processResponse_IOException() throws IOException {
+        // given
         HttpServletResponse response = mock(HttpServletResponse.class);
         ServletOutputStream outputStream = mock(ServletOutputStream.class);
 
-        ObjectMapper mapper = new ObjectMapper();
-        ObjectNode jsonResponse = mapper.createObjectNode();
+        ObjectNode jsonResponse = OBJECT_MAPPER.createObjectNode();
         jsonResponse.put("key", "value");
 
         when(response.getOutputStream()).thenReturn(outputStream);
         doThrow(new IOException("error")).when(outputStream).print(anyString());
 
+        // when
         processResponse(response, jsonResponse);
 
+        // then
         verify(response).setStatus(HttpServletResponse.SC_UNPROCESSABLE_CONTENT);
     }
 
     @Test
+    @DisplayName("Tests deleteDirectoryRecursively with an empty directory")
     public void test_deleteDirectoryRecursively_deleteEmptyDirectory() throws IOException {
         // given
-        Path tempDir = Files.createTempDirectory("test_empty_dir_1");
-        File directory = new File(tempDir.toString());
+        Path tempDirForTest = Files.createTempDirectory(tempDir, "test_empty_dir_1");
+        File directory = tempDirForTest.toFile();
         // when
         deleteDirectoryRecursively(directory);
         // then
@@ -255,16 +347,22 @@ public class TestBackupUtils {
     }
 
     @Test
+    @DisplayName("Tests deleteDirectoryRecursively with a non-empty directory")
     public void test_deleteDirectoryRecursively_deleteNonEmptyDirectory() throws IOException {
         // given
-        Path tempDir = Files.createTempDirectory("test_empty_dir_2");
-        File directory = tempDir.toFile();
+        Path tempDirForTest = Files.createTempDirectory(tempDir, "test_empty_dir_2");
+        File directory = tempDirForTest.toFile();
 
         File file1 = new File(directory, "file1.txt");
         assertTrue(file1.createNewFile());
 
         File file2 = new File(directory, "file2.txt");
         assertTrue(file2.createNewFile());
+
+        File subDir = new File(directory, "subDir");
+        assertTrue(subDir.mkdir());
+        File subFile = new File(subDir, "subFile.txt");
+        assertTrue(subFile.createNewFile());
 
         // when
         deleteDirectoryRecursively(directory);
@@ -273,13 +371,16 @@ public class TestBackupUtils {
         assertFalse(directory.exists());
         assertFalse(file1.exists());
         assertFalse(file2.exists());
+        assertFalse(subDir.exists());
+        assertFalse(subFile.exists());
     }
 
     @Test
+    @DisplayName("Tests deleteDirectoryRecursively with a file (should delete the file)")
     public void test_deleteDirectoryRecursively_deleteFile() throws IOException {
         // given
-        Path tempDir = Files.createTempDirectory("test_empty_dir_3");
-        File file = tempDir.resolve("temp.txt").toFile();
+        Path tempDirForTest = Files.createTempDirectory(tempDir, "test_empty_dir_3");
+        File file = tempDirForTest.resolve("temp.txt").toFile();
         assertTrue(file.createNewFile());
 
         // when
@@ -290,138 +391,801 @@ public class TestBackupUtils {
     }
 
     @Test
+    @DisplayName("Tests deleteDirectoryRecursively with a null directory path")
     public void test_deleteDirectoryRecursively_deleteNullDirectory() {
-        deleteDirectoryRecursively(null);
+        // given
+        // when
+        // then
+        deleteDirectoryRecursively((String) null);
     }
 
     @Test
+    @DisplayName("Tests deleteDirectoryRecursively with a non-existent directory")
     public void test_deleteDirectoryRecursively_nonExistentDirectory() {
-        deleteDirectoryRecursively(new File("/does/not/exist"));
-        // No specific assertion needed, as the method should handle null gracefully
+        // given
+        // when
+        // then
+        deleteDirectoryRecursively(new File("/does/not/exist/surely"));
     }
 
     @Test
+    @DisplayName("Tests getHighestExistingDirectoryNumber with an empty directory")
+    public void test_getHighestExistingDirectoryNumber_emptyDirectory() throws IOException {
+        // given
+        // when
+        Path testDir = Files.createDirectory(tempDir.resolve("empty_numbered_dir"));
+        // then
+        assertEquals(0, getHighestExistingDirectoryNumber(testDir.toAbsolutePath().toString()));
+    }
+
+    @Test
+    @DisplayName("Tests getHighestExistingDirectoryNumber with numerically named directories")
+    public void test_getHighestExistingDirectoryNumber_withNumberedDirectories() throws IOException {
+        // given
+        Path testDir = Files.createDirectory(tempDir.resolve("numbered_dirs"));
+        Files.createDirectory(testDir.resolve("1"));
+        Files.createDirectory(testDir.resolve("5"));
+        Files.createDirectory(testDir.resolve("10"));
+        Files.createDirectory(testDir.resolve("abc")); // Non-numeric
+        Files.createFile(testDir.resolve("2.txt")); // File, not directory
+        // when
+        int actual = getHighestExistingDirectoryNumber(testDir.toAbsolutePath().toString());
+        // then
+        assertEquals(10, actual);
+    }
+
+    @Test
+    @DisplayName("Tests getHighestExistingDirectoryNumber with no numerically named directories")
+    public void test_getHighestExistingDirectoryNumber_noNumericDirectories() throws IOException {
+        // given
+        Path testDir = Files.createDirectory(tempDir.resolve("no_numeric_dirs"));
+        Files.createDirectory(testDir.resolve("abc"));
+        Files.createDirectory(testDir.resolve("xyz"));
+        Files.createFile(testDir.resolve("file.txt"));
+        // when
+        int actual = getHighestExistingDirectoryNumber(testDir.toAbsolutePath().toString());
+        // then
+        assertEquals(0, actual);
+    }
+
+    @Test
+    @DisplayName("Tests getHighestExistingDirectoryNumber with a non-existent directory")
+    public void test_getHighestExistingDirectoryNumber_nonExistentDirectory() {
+        // given
+        // when
+        // then
+        assertEquals(-1, getHighestExistingDirectoryNumber("/this/path/does/not/exist"));
+    }
+
+    @Test
+    @DisplayName("Tests getHighestExistingDirectoryNumber with a null path")
+    public void test_getHighestExistingDirectoryNumber_nullPath() {
+        // given
+        // when
+        // then
+        assertEquals(-1, getHighestExistingDirectoryNumber(null));
+    }
+
+    @Test
+    @DisplayName("Tests getHighestExistingDirectoryNumber when directory creation fails")
     public void test_getHighestExistingDirectoryNumber_cannot_mkdir() {
         // given
-        String cannotCreatePath = "/this/will/not/work";
-        // when
-        int actual = getHighestExistingDirectoryNumber(cannotCreatePath);
-        // then
-        assertEquals(-1, actual);
+        try (MockedStatic<BackupUtils> mocked = Mockito.mockStatic(BackupUtils.class, CALLS_REAL_METHODS)) {
+            mocked.when(() -> BackupUtils.createPathIfNotExists(anyString())).thenReturn(false);
+            // when
+            int actual = getHighestExistingDirectoryNumber("/this/will/not/work");
+            // then
+            assertEquals(-1, actual);
+        }
     }
 
     @Test
-    public void test_getHighestExistingDirectoryNumber_null() {
+    @DisplayName("Tests getNextDirectoryNumber with an empty directory")
+    public void test_getNextDirectoryNumber_emptyDirectory() throws IOException {
         // given
+        Path testDir = Files.createDirectory(tempDir.resolve("next_num_empty"));
         // when
-        int actual = getHighestExistingDirectoryNumber(null);
+        int actual = getNextDirectoryNumber(testDir.toAbsolutePath().toString());
         // then
-        assertEquals(-1, actual);
+        assertEquals(1, actual);
     }
 
     @Test
-    public void test_getNextDirectoryNumber_null() {
+    @DisplayName("Tests getNextDirectoryNumber with existing numbered directories")
+    public void test_getNextDirectoryNumber_withExistingDirectories() throws IOException {
         // given
+        Path testDir = Files.createDirectory(tempDir.resolve("next_num_existing"));
+        Files.createDirectory(testDir.resolve("1"));
+        Files.createDirectory(testDir.resolve("5"));
         // when
-        int actual = getNextDirectoryNumber(null);
+        int actual = getNextDirectoryNumber(testDir.toAbsolutePath().toString());
         // then
-        assertEquals(-1, actual);
+        assertEquals(6, actual);
     }
 
     @Test
-    public void test_getNextDirectoryNumberAndCreate_null() {
-        // given
-        // when
-        int actual = getNextDirectoryNumberAndCreate(null);
-        // then
-        assertEquals(-1, actual);
-    }
-
-    @Test
-    public void test_populateNodeFromDir_null() {
-        // given
-        // when
-        // then
-        populateNodeFromDir(null, null);
-    }
-
-    @Test
-    public void test_populateNodeFromDir_nonExistentDirectory() {
+    @DisplayName("Tests getNextDirectoryNumber with a non-existent directory")
+    public void test_getNextDirectoryNumber_nonExistentDirectory() {
         // given
         // when
         // then
-        populateNodeFromDir(new File("/Folder/does/not/exist"), null);
+        assertEquals(-1, getNextDirectoryNumber("/non/existent/path/for/next"));
     }
 
     @Test
-    public void test_populateNodeFromDir_notDirectory() throws IOException {
+    @DisplayName("Tests getNextDirectoryNumber with a null path")
+    public void test_getNextDirectoryNumber_nullPath() {
         // given
-        Path tempDir = Files.createTempDirectory("test_pop_dir");
-        tempDir.toFile().deleteOnExit();
-        File file = tempDir.resolve("temp.txt").toFile();
-        assertTrue(file.createNewFile());
-        file.deleteOnExit();
         // when
         // then
-        populateNodeFromDir(file, null);
+        assertEquals(-1, getNextDirectoryNumber(null));
     }
 
     @Test
+    @DisplayName("Tests getNextDirectoryNumberAndCreate with an empty directory")
+    public void test_getNextDirectoryNumberAndCreate_emptyDirectory() throws IOException {
+        // given
+        Path parentDir = Files.createDirectory(tempDir.resolve("next_and_create_empty"));
+        // when
+        int nextNum = getNextDirectoryNumberAndCreate(parentDir.toAbsolutePath().toString());
+        // then
+        assertEquals(1, nextNum);
+        assertTrue(Files.exists(parentDir.resolve("1")));
+        assertTrue(Files.isDirectory(parentDir.resolve("1")));
+    }
+
+    @Test
+    @DisplayName("Tests getNextDirectoryNumberAndCreate with existing numbered directories")
+    public void test_getNextDirectoryNumberAndCreate_withExistingDirectories() throws IOException {
+        // given
+        Path parentDir = Files.createDirectory(tempDir.resolve("next_and_create_existing"));
+        Files.createDirectory(parentDir.resolve("1"));
+        Files.createDirectory(parentDir.resolve("5"));
+        // when
+        int nextNum = getNextDirectoryNumberAndCreate(parentDir.toAbsolutePath().toString());
+        // then
+        assertEquals(6, nextNum);
+        assertTrue(Files.exists(parentDir.resolve("6")));
+        assertTrue(Files.isDirectory(parentDir.resolve("6")));
+    }
+
+    @Test
+    @DisplayName("Tests getNextDirectoryNumberAndCreate when parent directory does not exist (should create it)")
+    public void test_getNextDirectoryNumberAndCreate_nonExistentParentDirectory() {
+        // given
+        // when
+        String nonExistentParent = tempDir.resolve("non_existent_parent_for_create").toAbsolutePath().toString();
+        // then
+        assertEquals(1, getNextDirectoryNumberAndCreate(nonExistentParent));
+        assertTrue(Files.exists(new File(nonExistentParent + "/1").toPath()));
+    }
+
+    @Test
+    @DisplayName("Tests getNextDirectoryNumberAndCreate with a null path")
+    public void test_getNextDirectoryNumberAndCreate_nullPath() {
+        // given
+        // when
+        // then
+        assertEquals(-1, getNextDirectoryNumberAndCreate(null));
+    }
+
+    @Test
+    @DisplayName("Tests getNextDirectoryNumberAndCreate when directory creation fails")
+    public void test_getNextDirectoryNumberAndCreate_creationFails() {
+        // given
+        try (MockedStatic<BackupUtils> mocked = Mockito.mockStatic(BackupUtils.class, CALLS_REAL_METHODS)) {
+            mocked.when(() -> BackupUtils.createPathIfNotExists(anyString())).thenReturn(true).thenReturn(false); // First call for parent succeeds, second for child fails
+            mocked.when(() -> BackupUtils.getNextDirectoryNumber(anyString())).thenReturn(1); // Simulate that getNextNumber works
+            // when
+            int actual = getNextDirectoryNumberAndCreate("/temp/path/that/fails/creation");
+            // then
+            assertEquals(-1, actual);
+        }
+    }
+
+    @Test
+    @DisplayName("Tests getNextDirectoryNumberAndCreate when getting the next number fails")
+    public void test_getNextDirectoryNumberAndCreate_getNextNumberFails() {
+        // given
+        try (MockedStatic<BackupUtils> mocked = Mockito.mockStatic(BackupUtils.class, CALLS_REAL_METHODS)) {
+            mocked.when(() -> BackupUtils.getNextDirectoryNumber(anyString())).thenReturn(-1);
+            // when
+            int actual = getNextDirectoryNumberAndCreate("/some/path");
+            // then
+            assertEquals(-1, actual);
+        }
+    }
+
+    @Test
+    @DisplayName("Tests createPathIfNotExists with a null path")
+    public void test_createPathIfNotExists_nullPath() {
+        // given
+        // when
+        // then
+        assertFalse(createPathIfNotExists(null));
+    }
+
+    @Test
+    @DisplayName("Tests createPathIfNotExists when the path already exists")
+    public void test_createPathIfNotExists_pathAlreadyExists() throws IOException {
+        // given
+        Path existingDir = Files.createDirectory(tempDir.resolve("existing_path"));
+        // when
+        // then
+        assertTrue(createPathIfNotExists(existingDir.toAbsolutePath().toString()));
+    }
+
+    @Test
+    @DisplayName("Tests createPathIfNotExists to create a new path")
+    public void test_createPathIfNotExists_createNewPath() {
+        // given
+        Path newDir = tempDir.resolve("new_path");
+        // when
+        // then
+        assertFalse(Files.exists(newDir));
+        assertTrue(createPathIfNotExists(newDir.toAbsolutePath().toString()));
+        assertTrue(Files.exists(newDir));
+        assertTrue(Files.isDirectory(newDir));
+    }
+
+    @Test
+    @DisplayName("Tests createPathIfNotExists to create nested paths")
+    public void test_createPathIfNotExists_createNestedPaths() {
+        // given
+        Path newNestedDir = tempDir.resolve("new_parent").resolve("new_child");
+        // when
+        // then
+        assertFalse(Files.exists(newNestedDir));
+        assertTrue(createPathIfNotExists(newNestedDir.toAbsolutePath().toString()));
+        assertTrue(Files.exists(newNestedDir));
+        assertTrue(Files.isDirectory(newNestedDir));
+    }
+
+    @Test
+    @DisplayName("Tests getSubdirectoryNames with a non-existent directory")
     public void test_getSubdirectoryNames_nonExistentDirectory() {
         // given
+        List<String> results = getSubdirectoryNames("/Folder/does/not/exist");
         // when
-        List<String> results  = getSubdirectoryNames("/Folder/does/not/exist");
         // then
         assertTrue(results.isEmpty());
     }
 
     @Test
+    @DisplayName("Tests getSubdirectoryNames with a path that is not a directory")
     public void test_getSubdirectoryNames_notDirectory() throws IOException {
         // given
-        Path tempDir = Files.createTempDirectory("test_getsub_dir");
-        tempDir.toFile().deleteOnExit();
-        File file = tempDir.resolve("temp.txt").toFile();
-        assertTrue(file.createNewFile());
-        file.deleteOnExit();
+        Path tempFile = Files.createFile(tempDir.resolve("temp_file_for_subdir_test.txt"));
         // when
-        List<String> results  = getSubdirectoryNames(file.getAbsolutePath());
+        List<String> results = getSubdirectoryNames(tempFile.toAbsolutePath().toString());
         // then
         assertTrue(results.isEmpty());
     }
 
-
     @Test
+    @DisplayName("Tests getSubdirectoryNames with an empty directory")
     public void test_getSubdirectoryNames_emptyDirectory() throws IOException {
         // given
-        Path tempDir = Files.createTempDirectory("test_getsub_dir_1");
-        File directory = new File(tempDir.toString());
+        Path testDir = Files.createDirectory(tempDir.resolve("empty_subdir_test"));
         // when
-        List<String> results  = getSubdirectoryNames(directory.getAbsolutePath());
+        List<String> results = getSubdirectoryNames(testDir.toAbsolutePath().toString());
         // then
         assertTrue(results.isEmpty());
     }
 
-
     @Test
+    @DisplayName("Tests getSubdirectoryNames with a populated directory")
     public void test_getSubdirectoryNames_populatedDirectory() throws IOException {
         // given
-        Path tempDir = Files.createTempDirectory("test_getsub_dir_2");
-        File directory = new File(tempDir.toString());
-        tempDir.toFile().deleteOnExit();
-
-        File file = tempDir.resolve("temp.txt").toFile();
-        assertTrue(file.createNewFile());
-        file.deleteOnExit();
-
-        File subDir = new File(directory, "sub");
-        assertTrue(subDir.mkdir());
-        subDir.deleteOnExit();
-
+        Path testDir = Files.createDirectory(tempDir.resolve("populated_subdir_test"));
+        Files.createDirectory(testDir.resolve("sub1"));
+        Files.createDirectory(testDir.resolve("sub2"));
+        Files.createFile(testDir.resolve("file.txt"));
         // when
-        List<String> results  = getSubdirectoryNames(directory.getAbsolutePath());
+        List<String> results = getSubdirectoryNames(testDir.toAbsolutePath().toString());
         // then
-        assertFalse(results.isEmpty());
+        assertEquals(2, results.size());
+        assertTrue(results.contains("sub1"));
+        assertTrue(results.contains("sub2"));
     }
 
+    @Test
+    @DisplayName("Tests populateNodeFromDir with a null file input")
+    public void test_populateNodeFromDir_nullFile() {
+        // given
+        ObjectNode node = OBJECT_MAPPER.createObjectNode();
+        // when
+        populateNodeFromDir(null, node);
+        // then
+        assertTrue(node.isEmpty());
+    }
 
+    @Test
+    @DisplayName("Tests populateNodeFromDir with a non-existent directory")
+    public void test_populateNodeFromDir_nonExistentDirectory() {
+        // given
+        ObjectNode node = OBJECT_MAPPER.createObjectNode();
+        // when
+        populateNodeFromDir(new File("/non/existent/dir_for_populate"), node);
+        // then
+        assertTrue(node.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Tests populateNodeFromDir with a path that is not a directory")
+    public void test_populateNodeFromDir_notDirectory() throws IOException {
+        // given
+        Path tempFile = Files.createFile(tempDir.resolve("test_file_for_populate"));
+        ObjectNode node = OBJECT_MAPPER.createObjectNode();
+        // when
+        populateNodeFromDir(tempFile.toFile(), node);
+        // then
+        assertTrue(node.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Tests populateNodeFromDir with an empty directory")
+    public void test_populateNodeFromDir_emptyDirectory() throws IOException {
+        // given
+        Path testDir = Files.createDirectory(tempDir.resolve("empty_dir_populate"));
+        // when
+        ObjectNode resultNode = populateNodeFromDir(testDir.toAbsolutePath().toString());
+        // then
+        assertNotNull(resultNode);
+        assertTrue(resultNode.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Tests populateNodeFromDir with files and subdirectories")
+    public void test_populateNodeFromDir_withFilesAndSubdirectories() throws IOException {
+        // given
+        Path rootPath = Files.createDirectory(tempDir.resolve("root_dir"));
+        Path subDir1 = Files.createDirectory(rootPath.resolve("sub1"));
+        Files.createFile(subDir1.resolve("fileA.txt"));
+        Files.createFile(subDir1.resolve("fileB.txt"));
+        Path subDir2 = Files.createDirectory(rootPath.resolve("sub2"));
+        Files.createFile(subDir2.resolve("fileC.json"));
+        Files.createFile(rootPath.resolve("rootFile.txt"));
+
+        // when
+        ObjectNode resultNode = populateNodeFromDir(rootPath.toAbsolutePath().toString());
+
+        // then
+        assertNotNull(resultNode);
+        assertTrue(resultNode.has("sub1"));
+        assertTrue(resultNode.has("sub2"));
+        assertTrue(resultNode.has("files")); // Files directly in root_dir
+
+        ObjectNode sub1Node = (ObjectNode) resultNode.get("sub1");
+        assertNotNull(sub1Node);
+        assertTrue(sub1Node.has("files"));
+        assertEquals(2, sub1Node.get("files").size());
+        assertTrue(sub1Node.get("files").get(0).asText().equals("fileA.txt") || sub1Node.get("files").get(0).asText().equals("fileB.txt"));
+
+        ObjectNode sub2Node = (ObjectNode) resultNode.get("sub2");
+        assertNotNull(sub2Node);
+        assertTrue(sub2Node.has("files"));
+        assertEquals(1, sub2Node.get("files").size());
+        assertEquals("fileC.json", sub2Node.get("files").get(0).asText());
+
+        assertTrue(resultNode.get("files").isArray());
+        assertEquals(1, resultNode.get("files").size());
+        assertEquals("rootFile.txt", resultNode.get("files").get(0).asText());
+    }
+
+    @Test
+    @DisplayName("Tests populateNodeFromDirNumerically with an empty directory")
+    public void test_populateNodeFromDirNumerically_emptyDirectory() throws IOException {
+        // given
+        Path testDir = Files.createDirectory(tempDir.resolve("empty_numeric_populate"));
+        // when
+        ObjectNode resultNode = populateNodeFromDirNumerically(testDir.toAbsolutePath().toString());
+        // then
+        assertNotNull(resultNode);
+        assertTrue(resultNode.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Tests populateNodeFromDirNumerically with numbered subdirectories and files")
+    public void test_populateNodeFromDirNumerically_withNumberedSubdirectories() throws IOException {
+        // given
+        Path rootPath = Files.createDirectory(tempDir.resolve("numeric_dir"));
+        Files.createDirectory(rootPath.resolve("10"));
+        Files.createDirectory(rootPath.resolve("2"));
+        Files.createDirectory(rootPath.resolve("1"));
+        Files.createDirectory(rootPath.resolve("abc")); // Non-numeric
+
+        Files.createFile(rootPath.resolve("file.txt"));
+        Files.createFile(rootPath.resolve("file2.txt"));
+
+        // when
+        ObjectNode resultNode = populateNodeFromDirNumerically(rootPath.toAbsolutePath().toString());
+
+        // then
+        assertNotNull(resultNode);
+        assertTrue(resultNode.has("1"));
+        assertTrue(resultNode.has("2"));
+        assertTrue(resultNode.has("10"));
+        assertTrue(resultNode.has("abc"));
+        assertTrue(resultNode.has("files"));
+
+        assertEquals(2, resultNode.get("files").size());
+        assertTrue(resultNode.get("files").get(0).asText().equals("file.txt") || resultNode.get("files").get(0).asText().equals("file2.txt"));
+    }
+
+    @Test
+    @DisplayName("Tests populateNodeFromDirNumerically with a non-existent directory")
+    public void test_populateNodeFromDirNumerically_nonExistentDirectory() {
+        // given
+        ObjectNode node = OBJECT_MAPPER.createObjectNode();
+        // when
+        populateNodeFromDirNumerically(new File("/non/existent/numeric/dir"), node);
+        // then
+        assertTrue(node.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Tests populateNodeFromDirNumerically when listFiles returns null")
+    public void test_populateNodeFromDirNumerically_nullFileArray() {
+        // given
+        File mockDir = mock(File.class);
+        when(mockDir.listFiles()).thenReturn(null);
+        ObjectNode node = OBJECT_MAPPER.createObjectNode();
+        // when
+        populateNodeFromDirNumerically(mockDir, node);
+        // then
+        assertTrue(node.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Tests getNumberedFilesBySuffix with an empty directory")
+    public void test_getNumberedFilesBySuffix_emptyDirectory() throws IOException {
+        // given
+        Path testDir = Files.createDirectory(tempDir.resolve("empty_suffix_dir"));
+        // when
+        List<Path> files = getNumberedFilesBySuffix(testDir.toAbsolutePath().toString(), "_info.json");
+        // then
+        assertTrue(files.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Tests getNumberedFilesBySuffix with no matching files")
+    public void test_getNumberedFilesBySuffix_noMatchingFiles() throws IOException {
+        // given
+        Path testDir = Files.createDirectory(tempDir.resolve("no_match_suffix_dir"));
+        Files.createFile(testDir.resolve("1_data.txt"));
+        Files.createFile(testDir.resolve("other_info.json"));
+        // when
+        List<Path> files = getNumberedFilesBySuffix(testDir.toAbsolutePath().toString(), "_info.json");
+        // then
+        assertTrue(files.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Tests getNumberedFilesBySuffix with matching numbered files")
+    public void test_getNumberedFilesBySuffix_withMatchingFiles() throws IOException {
+        // given
+        Path testDir = Files.createDirectory(tempDir.resolve("match_suffix_dir"));
+        Files.createFile(testDir.resolve("1_info.json"));
+        Files.createFile(testDir.resolve("10_info.json"));
+        Files.createFile(testDir.resolve("2_info.json"));
+        Files.createFile(testDir.resolve("non_numeric_info.json")); // Should be ignored
+        Files.createFile(testDir.resolve("1_other.txt")); // Should be ignored
+
+        // when
+        List<Path> files = getNumberedFilesBySuffix(testDir.toAbsolutePath().toString(), "_info.json");
+
+        // then
+        assertEquals(3, files.size());
+        assertEquals("1_info.json", files.get(0).getFileName().toString());
+        assertEquals("2_info.json", files.get(1).getFileName().toString());
+        assertEquals("10_info.json", files.get(2).getFileName().toString());
+    }
+
+    @Test
+    @DisplayName("Tests getNumberedFilesBySuffix with a non-existent directory")
+    public void test_getNumberedFilesBySuffix_nonExistentDirectory() {
+        // given
+        // when
+        List<Path> files = getNumberedFilesBySuffix("/non/existent/path/for/suffix", "_info.json");
+        // then
+        assertTrue(files.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Tests getNumberedFilesBySuffix with a null directory path")
+    public void test_getNumberedFilesBySuffix_nullDirectoryPath() {
+        // given
+        // when
+        List<Path> files = getNumberedFilesBySuffix(null, "_info.json");
+        // then
+        assertTrue(files.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Tests getNumberedFilesBySuffix with a null suffix")
+    public void test_getNumberedFilesBySuffix_nullSuffix() {
+        // given
+        Path testDir = tempDir;
+        // when
+        List<Path> files = getNumberedFilesBySuffix(testDir.toAbsolutePath().toString(), null);
+        // then
+        assertTrue(files.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Tests getNumberedFilesBySuffix with an empty suffix")
+    public void test_getNumberedFilesBySuffix_emptySuffix() {
+        // given
+        Path testDir = tempDir;
+        // when
+        List<Path> files = getNumberedFilesBySuffix(testDir.toAbsolutePath().toString(), "");
+        // then
+        assertTrue(files.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Tests getNumberedFilesBySuffix when the path is a file, not a directory")
+    public void test_getNumberedFilesBySuffix_pathIsFile() throws IOException {
+        // given
+        Path testFile = Files.createFile(tempDir.resolve("a_file.txt"));
+        // when
+        List<Path> files = getNumberedFilesBySuffix(testFile.toAbsolutePath().toString(), ".txt");
+        // then
+        assertTrue(files.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Tests getNumberedFilesBySuffix with a directory containing no files")
+    public void test_getNumberedFilesBySuffix_directoryWithNoFiles() throws IOException {
+        // given
+        Path testDir = Files.createDirectory(tempDir.resolve("dir_no_files"));
+        Files.createDirectory(testDir.resolve("subdir"));
+        // when
+        List<Path> files = getNumberedFilesBySuffix(testDir.toAbsolutePath().toString(), "_info.json");
+        // then
+        assertTrue(files.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Tests populateObjectNodeFromNumberedFiles successfully populates the node")
+    public void test_populateObjectNodeFromNumberedFiles_success() throws IOException {
+        // given
+        Path testDir = Files.createDirectory(tempDir.resolve("populate_node_success"));
+        Files.writeString(testDir.resolve("1_data.json"), "{\"name\": \"item1\"}");
+        Files.writeString(testDir.resolve("3_data.json"), "{\"value\": 123}");
+        Files.writeString(testDir.resolve("2_data.json"), "{\"status\": \"active\"}");
+
+        ObjectNode targetNode = OBJECT_MAPPER.createObjectNode();
+        // when
+        populateObjectNodeFromNumberedFiles(targetNode, testDir.toAbsolutePath().toString(), "_data.json");
+
+        // then
+        assertNotNull(targetNode);
+        assertTrue(targetNode.has("1"));
+        assertTrue(targetNode.has("2"));
+        assertTrue(targetNode.has("3"));
+        assertEquals("item1", targetNode.get("1").get("name").asText());
+        assertEquals("active", targetNode.get("2").get("status").asText());
+        assertEquals(123, targetNode.get("3").get("value").asInt());
+    }
+
+    @Test
+    @DisplayName("Tests populateObjectNodeFromNumberedFiles with an empty directory")
+    public void test_populateObjectNodeFromNumberedFiles_emptyDirectory() throws IOException {
+        // given
+        Path testDir = Files.createDirectory(tempDir.resolve("populate_node_empty"));
+        ObjectNode targetNode = OBJECT_MAPPER.createObjectNode();
+        // when
+        populateObjectNodeFromNumberedFiles(targetNode, testDir.toAbsolutePath().toString(), "_data.json");
+        // then
+        assertTrue(targetNode.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Tests populateObjectNodeFromNumberedFiles with non-matching files")
+    public void test_populateObjectNodeFromNumberedFiles_nonMatchingFiles() throws IOException {
+        // given
+        Path testDir = Files.createDirectory(tempDir.resolve("populate_node_no_match"));
+        Files.writeString(testDir.resolve("1.json"), "{}");
+        Files.writeString(testDir.resolve("abc_data.json"), "{}");
+        ObjectNode targetNode = OBJECT_MAPPER.createObjectNode();
+        // when
+        populateObjectNodeFromNumberedFiles(targetNode, testDir.toAbsolutePath().toString(), "_data.json");
+        // then
+        assertTrue(targetNode.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Tests populateObjectNodeFromNumberedFiles with a null target node (should throw NullPointerException)")
+    public void test_populateObjectNodeFromNumberedFiles_nullTargetNode() {
+        // given
+        // when
+        // then
+        assertThrows(NullPointerException.class, () -> populateObjectNodeFromNumberedFiles(null, tempDir.toAbsolutePath().toString(), "_data.json"));
+    }
+
+@Test
+    @DisplayName("Tests populateObjectNodeFromNumberedFiles with a null directory path (should throw NullPointerException)")
+    public void test_populateObjectNodeFromNumberedFiles_nullDirectoryPath() {
+        // given
+        // when
+        // then
+        assertThrows(NullPointerException.class, () -> populateObjectNodeFromNumberedFiles(OBJECT_MAPPER.createObjectNode(), null, "_data.json"));
+    }
+
+    @Test
+    @DisplayName("Tests populateObjectNodeFromNumberedFiles with a null suffix (should throw NullPointerException)")
+    public void test_populateObjectNodeFromNumberedFiles_nullSuffix() {
+        // given
+        // when
+        // then
+        assertThrows(NullPointerException.class, () -> populateObjectNodeFromNumberedFiles(OBJECT_MAPPER.createObjectNode(), tempDir.toAbsolutePath().toString(), null));
+    }
+
+    @Test
+    @DisplayName("Tests populateObjectNodeFromNumberedFiles with invalid JSON content (should throw IOException)")
+    public void test_populateObjectNodeFromNumberedFiles_invalidJson() throws IOException {
+        // given
+        Path testDir = Files.createDirectory(tempDir.resolve("populate_node_invalid_json"));
+        Files.writeString(testDir.resolve("1_data.json"), "{invalid json");
+        ObjectNode targetNode = OBJECT_MAPPER.createObjectNode();
+        // when
+        // then
+        assertThrows(IOException.class, () -> populateObjectNodeFromNumberedFiles(targetNode, testDir.toAbsolutePath().toString(), "_data.json"));
+        assertTrue(targetNode.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Tests populateObjectNodeFromNumberedFiles when an IOException occurs during file read")
+    public void test_populateObjectNodeFromNumberedFiles_ioExceptionDuringRead() throws IOException {
+        Path testDir = Files.createDirectory(tempDir.resolve("populate_node_read_error"));
+        Path filePath = testDir.resolve("1_data.json");
+        Files.writeString(filePath, "{\"key\": \"value\"}");
+
+        try (MockedStatic<Files> mockedFiles = Mockito.mockStatic(Files.class, CALLS_REAL_METHODS)) {
+            mockedFiles.when(() -> Files.readString(filePath)).thenThrow(new IOException("Simulated read error"));
+
+            ObjectNode targetNode = OBJECT_MAPPER.createObjectNode();
+            assertThrows(IOException.class, () -> populateObjectNodeFromNumberedFiles(targetNode, testDir.toAbsolutePath().toString(), "_data.json"));
+            assertTrue(targetNode.isEmpty());
+        }
+    }
+
+    @Test
+    @DisplayName("Tests getObjectNodeFromNumberedFiles successfully retrieves and populates the node")
+    public void test_getObjectNodeFromNumberedFiles_success() throws IOException {
+        // given
+        Path testDir = Files.createDirectory(tempDir.resolve("get_node_success"));
+        Files.writeString(testDir.resolve("10_event.json"), "{\"id\": 10}");
+        Files.writeString(testDir.resolve("5_event.json"), "{\"type\": \"start\"}");
+
+        // when
+        ObjectNode resultNode = getObjectNodeFromNumberedFiles(testDir.toAbsolutePath().toString(), "_event.json");
+
+        // then
+        assertNotNull(resultNode);
+        assertTrue(resultNode.has("5"));
+        assertTrue(resultNode.has("10"));
+        assertEquals("start", resultNode.get("5").get("type").asText());
+        assertEquals(10, resultNode.get("10").get("id").asInt());
+    }
+
+    @Test
+    @DisplayName("Tests getObjectNodeFromNumberedFiles propagates IOException as RuntimeException")
+    public void test_getObjectNodeFromNumberedFiles_ioExceptionPropagatedAsRuntimeException() throws IOException {
+        // given
+        Path testDir = Files.createDirectory(tempDir.resolve("get_node_io_error"));
+        Path filePath = testDir.resolve("1_item.json");
+        Files.writeString(filePath, "{\"key\": \"value\"}");
+        // when
+        // then
+        try (MockedStatic<BackupUtils> mockedBackupUtils = Mockito.mockStatic(BackupUtils.class, CALLS_REAL_METHODS)) {
+            mockedBackupUtils.when(() -> BackupUtils.populateObjectNodeFromNumberedFiles(any(ObjectNode.class), anyString(), anyString()))
+                    .thenThrow(new IOException("Simulated IO exception for get"));
+
+            assertThrows(RuntimeException.class, () -> getObjectNodeFromNumberedFiles(testDir.toAbsolutePath().toString(), "_item.json"));
+        }
+    }
+
+    @Test
+    @DisplayName("Tests handleError successfully handles an exception and sets response status/content")
+    public void test_handleError_successfulHandling() throws IOException {
+        // given
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        ServletOutputStream outputStream = mock(ServletOutputStream.class);
+        when(response.getOutputStream()).thenReturn(outputStream);
+
+        ObjectNode jsonResponse = OBJECT_MAPPER.createObjectNode();
+        Exception exception = new RuntimeException("Test error message");
+
+        // when
+        handleError(response, jsonResponse, exception);
+
+        // then
+        verify(response).setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        assertTrue(jsonResponse.has("error"));
+        assertEquals("Test error message", jsonResponse.get("error").asText());
+        verify(response).setContentType(WebContent.contentTypeJSON);
+        verify(response).setCharacterEncoding(WebContent.charsetUTF8);
+    }
+
+    @Test
+    @DisplayName("Tests handleError when an IOException occurs during processing the error response")
+    public void test_handleError_ioExceptionDuringProcessResponse() throws IOException {
+        // given
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        ServletOutputStream outputStream = mock(ServletOutputStream.class);
+        when(response.getOutputStream()).thenReturn(outputStream);
+        doThrow(new IOException("Output error")).when(outputStream).print(anyString());
+
+        ObjectNode jsonResponse = OBJECT_MAPPER.createObjectNode();
+        Exception exception = new RuntimeException("Another test error");
+
+        // when
+        handleError(response, jsonResponse, exception);
+
+        // then
+        verify(response).setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        assertTrue(jsonResponse.has("error"));
+        assertEquals("Another test error", jsonResponse.get("error").asText());
+    }
+
+    @Test
+    @DisplayName("Tests cleanUp with a single file")
+    public void test_cleanUp_singleFile() throws IOException {
+        // given
+        Path fileToClean = Files.createFile(tempDir.resolve("file_to_clean.txt"));
+        List<Path> paths = Collections.singletonList(fileToClean);
+        // when
+        cleanUp(paths);
+        // then
+        assertFalse(Files.exists(fileToClean));
+    }
+
+    @Test
+    @DisplayName("Tests cleanUp with multiple files and directories")
+    public void test_cleanUp_multipleFilesAndDirectories() throws IOException {
+        // given
+        Path file1 = Files.createFile(tempDir.resolve("file1.txt"));
+        Path dir1 = Files.createDirectory(tempDir.resolve("dir1"));
+        Path file2 = Files.createFile(dir1.resolve("file2.txt"));
+        Path dir2 = Files.createDirectory(tempDir.resolve("dir2"));
+        Path subDir1 = Files.createDirectory(dir2.resolve("sub_dir1"));
+        Path file3 = Files.createFile(subDir1.resolve("file3.txt"));
+
+        List<Path> paths = Arrays.asList(file1, dir1, dir2);
+        // when
+        cleanUp(paths);
+
+        // then
+        assertFalse(Files.exists(file1));
+        assertFalse(Files.exists(file2));
+        assertFalse(Files.exists(dir1));
+        assertFalse(Files.exists(file3));
+        assertFalse(Files.exists(subDir1));
+        assertFalse(Files.exists(dir2));
+    }
+
+    @Test
+    @DisplayName("Tests cleanUp with a non-existent path")
+    public void test_cleanUp_nonExistentPath() {
+        // given
+        Path nonExistentPath = tempDir.resolve("non_existent_file.txt");
+        List<Path> paths = Collections.singletonList(nonExistentPath);
+        // when
+        cleanUp(paths);
+        // then
+        assertFalse(Files.exists(nonExistentPath));
+    }
+
+    @Test
+    @DisplayName("Tests cleanUp with an empty list of paths")
+    public void test_cleanUp_emptyList() {
+        // given
+        List<Path> paths = Collections.emptyList();
+        // when
+        // then
+        cleanUp(paths);
+    }
 }

--- a/scg-system/src/test/java/io/telicent/backup/utils/TestCompressionUtils.java
+++ b/scg-system/src/test/java/io/telicent/backup/utils/TestCompressionUtils.java
@@ -1,0 +1,284 @@
+/*
+ *  Copyright (c) Telicent Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.telicent.backup.utils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestCompressionUtils {
+
+    @TempDir
+    Path tempDir;
+
+    private Path sourceDir;
+    private Path destZipDir;
+    private Path destUnzipDir;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        sourceDir = tempDir.resolve("source");
+        Files.createDirectory(sourceDir);
+        destZipDir = tempDir.resolve("output_zip.zip"); // Ensure it's a file path with .zip extension
+        destUnzipDir = tempDir.resolve("unzipped_output");
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    @Test
+    @DisplayName("Should zip a simple directory with a file")
+    void testZipDirectorySimple() throws IOException {
+        Path file1 = sourceDir.resolve("file1.txt");
+        Files.write(file1, "Hello, world!".getBytes());
+
+        CompressionUtils.zipDirectory(sourceDir, destZipDir, false);
+
+        assertTrue(Files.exists(destZipDir), "ZIP file should be created");
+        assertTrue(Files.size(destZipDir) > 0, "ZIP file should not be empty");
+
+        try (ZipFile zipFile = new ZipFile(destZipDir.toFile())) {
+            assertNotNull(zipFile.getEntry("file1.txt"), "ZIP should contain file1.txt");
+            assertEquals(1, zipFile.size(), "ZIP should contain only the file entry");
+            assertNull(zipFile.getEntry(sourceDir.getFileName().toString() + "/"), "ZIP should not contain the root directory");
+        }
+    }
+
+    @Test
+    @DisplayName("Should zip a directory with subdirectories and multiple files")
+    void testZipDirectoryComplex() throws IOException {
+        Path subDir1 = sourceDir.resolve("sub1");
+        Files.createDirectory(subDir1);
+        Path subDir2 = subDir1.resolve("sub2");
+        Files.createDirectory(subDir2);
+
+        Files.write(sourceDir.resolve("root_file.txt"), "Root content".getBytes());
+        Files.write(subDir1.resolve("sub1_file.txt"), "Sub1 content".getBytes());
+        Files.write(subDir2.resolve("sub2_file.txt"), "Sub2 content".getBytes());
+
+        CompressionUtils.zipDirectory(sourceDir, destZipDir, false);
+
+        assertTrue(Files.exists(destZipDir));
+        try (ZipFile zipFile = new ZipFile(destZipDir.toFile())) {
+            assertNotNull(zipFile.getEntry("root_file.txt"), "root_file.txt should be present");
+            assertNotNull(zipFile.getEntry("sub1/"), "sub1 directory entry should be present");
+            assertNotNull(zipFile.getEntry("sub1/sub1_file.txt"), "sub1_file.txt should be present");
+            assertNotNull(zipFile.getEntry("sub1/sub2/"), "sub2 directory entry should be present");
+            assertNotNull(zipFile.getEntry("sub1/sub2/sub2_file.txt"), "sub2_file.txt should be present");
+            assertEquals(5, zipFile.size(), "ZIP should contain 3 files + 2 directories"); // 3 files + 3 directories
+        }
+    }
+
+    @Test
+    @DisplayName("Should zip and then delete the source directory")
+    void testZipDirectoryAndDeleteSource() throws IOException {
+        Path file1 = sourceDir.resolve("file_to_delete.txt");
+        Files.write(file1, "Content".getBytes());
+
+        CompressionUtils.zipDirectory(sourceDir, destZipDir, true);
+
+        assertTrue(Files.exists(destZipDir), "ZIP file should be created");
+        assertFalse(Files.exists(sourceDir), "Source directory should be deleted");
+    }
+
+    @Test
+    @DisplayName("Should throw IllegalArgumentException if source is not a directory")
+    void testZipDirectoryInvalidSource() {
+        Path nonDirFile = tempDir.resolve("not_a_directory.txt");
+        assertDoesNotThrow(() -> Files.createFile(nonDirFile));
+
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> CompressionUtils.zipDirectory(nonDirFile, destZipDir));
+        assertTrue(thrown.getMessage().contains("Source path must be a directory"));
+        assertFalse(Files.exists(destZipDir), "ZIP file should not be created on error");
+    }
+
+    @Test
+    @DisplayName("Should handle IOException during zipping")
+    void testZipDirectoryIOException() {
+        Path invalidZipPath = tempDir.resolve("invalid_zip_dir");
+        assertDoesNotThrow(() -> Files.createDirectory(invalidZipPath));
+
+        Path file1 = sourceDir.resolve("test.txt");
+        assertDoesNotThrow(() -> Files.write(file1, "content".getBytes()));
+
+        RuntimeException thrown = assertThrows(RuntimeException.class, () -> CompressionUtils.zipDirectory(sourceDir, invalidZipPath));
+
+        assertNotNull(thrown.getCause());
+        assertInstanceOf(IOException.class, thrown.getCause());
+    }
+
+    @Test
+    @DisplayName("Should throw NullPointerException for null source directory path (String)")
+    void testZipDirectoryNullSourceString() {
+        assertThrows(NullPointerException.class, () -> CompressionUtils.zipDirectory((String) null, destZipDir.toString()));
+    }
+
+    @Test
+    @DisplayName("Should throw NullPointerException for null source directory path (Path)")
+    void testZipDirectoryNullSourcePath() {
+        assertThrows(NullPointerException.class, () -> CompressionUtils.zipDirectory((Path) null, destZipDir, false));
+    }
+
+    @Test
+    @DisplayName("Should throw NullPointerException for null zip file path (String)")
+    void testZipDirectoryNullDestString() {
+        assertThrows(NullPointerException.class, () -> CompressionUtils.zipDirectory(sourceDir.toString(), (String) null));
+    }
+
+    @Test
+    @DisplayName("Should throw NullPointerException for null zip file path (Path)")
+    void testZipDirectoryNullDestPath() {
+        assertThrows(NullPointerException.class, () -> CompressionUtils.zipDirectory(sourceDir, (Path) null, false));
+    }
+
+    @Test
+    @DisplayName("Should use String instead of Path for zipDirectory")
+    void testZipDirectoryStringOverloads() throws IOException {
+        Path file1 = sourceDir.resolve("file_string.txt");
+        Files.write(file1, "Content string".getBytes());
+
+        Path zipFile1 = tempDir.resolve("test_string_zip1.zip");
+        CompressionUtils.zipDirectory(sourceDir.toString(), zipFile1.toString());
+        assertTrue(Files.exists(zipFile1));
+        try (ZipFile zipFile = new ZipFile(zipFile1.toFile())) {
+            assertNotNull(zipFile.getEntry("file_string.txt"));
+        }
+        Files.delete(zipFile1);
+
+        Path zipFile2 = tempDir.resolve("test_string_zip2.zip");
+        Path sourceDirForDelete = tempDir.resolve("source_for_delete_string");
+        Files.createDirectory(sourceDirForDelete);
+        Path file2 = sourceDirForDelete.resolve("file_to_delete_string.txt");
+        Files.write(file2, "Content to delete".getBytes());
+
+        CompressionUtils.zipDirectory(sourceDirForDelete.toString(), zipFile2.toString(), true);
+        assertTrue(Files.exists(zipFile2));
+        assertFalse(Files.exists(sourceDirForDelete), "Source directory should be deleted after zipping via string overload");
+    }
+
+    @Test
+    @DisplayName("Should unzip a simple ZIP file")
+    void testUnzipDirectorySimple() throws IOException {
+        Path file1 = sourceDir.resolve("zipped_file1.txt");
+        Files.write(file1, "Unzip test content.".getBytes());
+        CompressionUtils.zipDirectory(sourceDir, destZipDir, false); // Create a zip file
+
+        CompressionUtils.unzipDirectory(destZipDir, destUnzipDir);
+
+        assertTrue(Files.exists(destUnzipDir), "Unzipped directory should exist");
+        Path unzippedFile1 = destUnzipDir.resolve("zipped_file1.txt");
+        assertTrue(Files.exists(unzippedFile1), "Unzipped file should exist");
+        assertEquals("Unzip test content.", Files.readString(unzippedFile1));
+    }
+
+    @Test
+    @DisplayName("Should unzip a ZIP file with subdirectories and multiple files")
+    void testUnzipDirectoryComplex() throws IOException {
+        Path subDir1 = sourceDir.resolve("z_sub1");
+        Files.createDirectory(subDir1);
+        Path subDir2 = subDir1.resolve("z_sub2");
+        Files.createDirectory(subDir2);
+
+        Files.write(sourceDir.resolve("z_root_file.txt"), "Zipped Root content".getBytes());
+        Files.write(subDir1.resolve("z_sub1_file.txt"), "Zipped Sub1 content".getBytes());
+        Files.write(subDir2.resolve("z_sub2_file.txt"), "Zipped Sub2 content".getBytes());
+
+        CompressionUtils.zipDirectory(sourceDir, destZipDir, false); // Create a zip file
+
+        CompressionUtils.unzipDirectory(destZipDir.toString(), destUnzipDir.toString()); // Use the string based method for coverage
+
+        assertTrue(Files.exists(destUnzipDir));
+        assertTrue(Files.isDirectory(destUnzipDir.resolve("z_sub1")));
+        assertTrue(Files.isDirectory(destUnzipDir.resolve("z_sub1/z_sub2")));
+
+        assertTrue(Files.exists(destUnzipDir.resolve("z_root_file.txt")));
+        assertTrue(Files.exists(destUnzipDir.resolve("z_sub1/z_sub1_file.txt")));
+        assertTrue(Files.exists(destUnzipDir.resolve("z_sub1/z_sub2/z_sub2_file.txt")));
+
+        assertEquals("Zipped Root content", Files.readString(destUnzipDir.resolve("z_root_file.txt")));
+        assertEquals("Zipped Sub1 content", Files.readString(destUnzipDir.resolve("z_sub1/z_sub1_file.txt")));
+        assertEquals("Zipped Sub2 content", Files.readString(destUnzipDir.resolve("z_sub1/z_sub2/z_sub2_file.txt")));
+    }
+
+    @Test
+    @DisplayName("Should throw IllegalArgumentException if ZIP file does not exist")
+    void testUnzipDirectoryNonExistentZip() {
+        Path nonExistentZip = tempDir.resolve("non_existent.zip");
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> CompressionUtils.unzipDirectory(nonExistentZip, destUnzipDir));
+        assertTrue(thrown.getMessage().contains("ZIP file does not exist or is not a regular file"));
+    }
+
+    @Test
+    @DisplayName("Should throw IllegalArgumentException if ZIP file is a directory")
+    void testUnzipDirectoryZipIsDirectory() throws IOException {
+        Files.createDirectory(destZipDir); // Make destZipDir a directory to simulate error
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> CompressionUtils.unzipDirectory(destZipDir, destUnzipDir));
+        assertTrue(thrown.getMessage().contains("ZIP file does not exist or is not a regular file"));
+    }
+
+    @Test
+    @DisplayName("Should throw IOException on path traversal attempt during unzip")
+    void testUnzipDirectoryPathTraversal() throws IOException {
+        Path maliciousZip = tempDir.resolve("malicious.zip");
+        try (FileOutputStream fos = new FileOutputStream(maliciousZip.toFile());
+             ZipOutputStream zos = new ZipOutputStream(fos)) {
+            zos.putNextEntry(new ZipEntry("../../../malicious_file.txt"));
+            zos.write("I am a bad file!".getBytes());
+            zos.closeEntry();
+        }
+
+        IOException thrown = assertThrows(IOException.class, () -> CompressionUtils.unzipDirectory(maliciousZip, destUnzipDir));
+        assertTrue(thrown.getMessage().contains("Attempted path traversal attack"));
+        assertFalse(Files.exists(tempDir.getParent().resolve("malicious_file.txt")));
+    }
+
+    @Test
+    @DisplayName("Should throw NullPointerException for null zip file path (String)")
+    void testUnzipDirectoryNullSourceString() {
+        assertThrows(NullPointerException.class, () -> CompressionUtils.unzipDirectory((String) null, destUnzipDir.toString()));
+    }
+
+    @Test
+    @DisplayName("Should throw NullPointerException for null zip file path (Path)")
+    void testUnzipDirectoryNullSourcePath() {
+        assertThrows(NullPointerException.class, () -> CompressionUtils.unzipDirectory((Path) null, destUnzipDir));
+    }
+
+    @Test
+    @DisplayName("Should throw NullPointerException for null destination directory path (String)")
+    void testUnzipDirectoryNullDestString() {
+        assertThrows(NullPointerException.class, () -> CompressionUtils.unzipDirectory(destZipDir.toString(), (String) null));
+    }
+
+    @Test
+    @DisplayName("Should throw NullPointerException for null destination directory path (Path)")
+    void testUnzipDirectoryNullDestPath() {
+        assertThrows(NullPointerException.class, () -> CompressionUtils.unzipDirectory(destZipDir, (Path) null));
+    }
+}

--- a/scg-system/src/test/java/io/telicent/backup/utils/TestJsonFileUtils.java
+++ b/scg-system/src/test/java/io/telicent/backup/utils/TestJsonFileUtils.java
@@ -1,0 +1,137 @@
+/*
+ *  Copyright (c) Telicent Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.telicent.backup.utils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestJsonFileUtils {
+
+    @TempDir
+    Path tempDir;
+
+    private ObjectNode testObjectNode;
+
+    @BeforeEach
+    void setUp() {
+        testObjectNode = JsonFileUtils.OBJECT_MAPPER.createObjectNode();
+        testObjectNode.put("id", 123);
+        testObjectNode.put("name", "TestUser");
+        testObjectNode.putObject("details").put("email", "test@example.com");
+    }
+
+    @Test
+    @DisplayName("Should write ObjectNode to file with pretty printing (Path overload)")
+    void testWriteObjectNodeToFile_Path() throws IOException {
+        Path outputFile = tempDir.resolve("pretty_output.json");
+
+        JsonFileUtils.writeObjectNodeToFile(testObjectNode, outputFile);
+
+        assertTrue(Files.exists(outputFile), "Output file should exist");
+        String content = Files.readString(outputFile);
+
+        assertTrue(content.contains("{\n  \"id\" : 123,\n"));
+        assertTrue(content.contains("  \"name\" : \"TestUser\",\n"));
+        assertTrue(content.contains("  \"details\" : {\n    \"email\" : \"test@example.com\"\n  }\n}"));
+
+        JsonNode readNode = JsonFileUtils.OBJECT_MAPPER.readTree(content);
+        assertEquals(testObjectNode, readNode, "Read JSON should match written ObjectNode");
+    }
+
+    @Test
+    @DisplayName("Should throw NullPointerException if objectNode is null (Path overload)")
+    void testWriteObjectNodeToFile_Path_NullObjectNode() {
+        Path outputFile = tempDir.resolve("null_node.json");
+        NullPointerException thrown = assertThrows(NullPointerException.class, () -> JsonFileUtils.writeObjectNodeToFile(null, outputFile));
+        assertEquals("ObjectNode cannot be null.", thrown.getMessage());
+        assertFalse(Files.exists(outputFile), "File should not be created");
+    }
+
+    @Test
+    @DisplayName("Should throw NullPointerException if filePath is null (Path overload)")
+    void testWriteObjectNodeToFile_Path_NullFilePath() {
+        assertThrows(RuntimeException.class, () -> JsonFileUtils.writeObjectNodeToFile(testObjectNode, (String) null));
+    }
+
+    @Test
+    @DisplayName("Should catch IOException and rethrow as RuntimeException (Path overload)")
+    void testWriteObjectNodeToFile_Path_IOException() {
+        Path nonExistentParentPath = tempDir.resolve("non_existent_dir").resolve("file.json");
+
+        RuntimeException thrown = assertThrows(RuntimeException.class, () -> JsonFileUtils.writeObjectNodeToFile(testObjectNode, nonExistentParentPath));
+
+        assertInstanceOf(IOException.class, thrown.getCause());
+        String errorMessage = thrown.getCause().getMessage();
+        assertTrue(errorMessage.contains("No such file or directory") || errorMessage.contains("The system cannot find the path specified"),
+                "Error message should indicate missing directory: " + errorMessage);
+        assertFalse(Files.exists(nonExistentParentPath), "File should not be created");
+    }
+
+    @Test
+    @DisplayName("Should write ObjectNode to file using String path overload")
+    void testWriteObjectNodeToFile_String() throws IOException {
+        String outputFileString = tempDir.resolve("string_output.json").toString();
+        Path expectedOutputPath = Path.of(outputFileString);
+
+        JsonFileUtils.writeObjectNodeToFile(testObjectNode, outputFileString);
+
+        assertTrue(Files.exists(expectedOutputPath), "Output file should exist");
+        String content = Files.readString(expectedOutputPath);
+        assertTrue(content.contains("{\n  \"id\" : 123,\n"));
+
+        JsonNode readNode = JsonFileUtils.OBJECT_MAPPER.readTree(content);
+        assertEquals(testObjectNode, readNode, "Read JSON should match written ObjectNode");
+    }
+
+    @Test
+    @DisplayName("Should throw NullPointerException if objectNode is null (String overload)")
+    void testWriteObjectNodeToFile_String_NullObjectNode() {
+        String outputFileString = tempDir.resolve("null_node_string.json").toString();
+        NullPointerException thrown = assertThrows(NullPointerException.class, () -> JsonFileUtils.writeObjectNodeToFile(null, outputFileString));
+        assertEquals("ObjectNode cannot be null.", thrown.getMessage());
+        assertFalse(Files.exists(Path.of(outputFileString)), "File should not be created");
+    }
+
+    @Test
+    @DisplayName("Should throw NullPointerException if filePath is null (String overload)")
+    void testWriteObjectNodeToFile_String_NullFilePath() {
+        assertThrows(RuntimeException.class, () -> JsonFileUtils.writeObjectNodeToFile(testObjectNode, (String) null));
+    }
+
+    @Test
+    @DisplayName("Should catch IOException and rethrow as RuntimeException (String overload)")
+    void testWriteObjectNodeToFile_String_IOException() {
+        String nonExistentParentPathString = tempDir.resolve("another_non_existent_dir").resolve("file.json").toString();
+
+        RuntimeException thrown = assertThrows(RuntimeException.class, () -> JsonFileUtils.writeObjectNodeToFile(testObjectNode, nonExistentParentPathString));
+
+        assertInstanceOf(IOException.class, thrown.getCause());
+        String errorMessage = thrown.getCause().getMessage();
+        assertTrue(errorMessage.contains("No such file or directory") || errorMessage.contains("The system cannot find the path specified"),
+                "Error message should indicate missing directory: " + errorMessage);
+        assertFalse(Files.exists(Path.of(nonExistentParentPathString)), "File should not be created");
+    }
+}

--- a/scg-system/src/test/java/io/telicent/core/TestFusekiKafkaSCG.java
+++ b/scg-system/src/test/java/io/telicent/core/TestFusekiKafkaSCG.java
@@ -32,7 +32,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
-import static io.telicent.backup.utils.BackupUtils.MAPPER;
+import static io.telicent.backup.utils.JsonFileUtils.OBJECT_MAPPER;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -52,7 +52,7 @@ public class TestFusekiKafkaSCG {
         when(mockDataAccessPoint.getName()).thenReturn(dataset);
 
         // when
-        ObjectNode node = MAPPER.createObjectNode();
+        ObjectNode node = OBJECT_MAPPER.createObjectNode();
         cut.backupKafka(mockDataAccessPoint, "path doesn't matter", node);
 
         // then
@@ -76,7 +76,7 @@ public class TestFusekiKafkaSCG {
         when(mockDataAccessPoint.getName()).thenReturn(dataset);
 
         // when
-        ObjectNode node = MAPPER.createObjectNode();
+        ObjectNode node = OBJECT_MAPPER.createObjectNode();
         cut.backupKafka(mockDataAccessPoint, "path doesn't matter", node);
 
         // then
@@ -108,7 +108,7 @@ public class TestFusekiKafkaSCG {
             writer.write(jsonString);
         }
 
-        ObjectNode node = MAPPER.createObjectNode();
+        ObjectNode node = OBJECT_MAPPER.createObjectNode();
 
         String localPath = "/matchingdataset/sendkafka";
 
@@ -205,7 +205,7 @@ public class TestFusekiKafkaSCG {
         when(mockDataAccessPoint.getName()).thenReturn(dataset);
 
         // when
-        ObjectNode node = MAPPER.createObjectNode();
+        ObjectNode node = OBJECT_MAPPER.createObjectNode();
         cut.backupKafka(mockDataAccessPoint, tempDir.toString(), node);
 
         // then
@@ -240,7 +240,7 @@ public class TestFusekiKafkaSCG {
         when(mockDataAccessPoint.getName()).thenReturn(dataset);
 
         // when
-        ObjectNode node = MAPPER.createObjectNode();
+        ObjectNode node = OBJECT_MAPPER.createObjectNode();
         cut.restoreKafka(mockDataAccessPoint, "path doesn't matter", node);
 
         // then
@@ -264,7 +264,7 @@ public class TestFusekiKafkaSCG {
         when(mockDataAccessPoint.getName()).thenReturn(dataset);
 
         // when
-        ObjectNode node = MAPPER.createObjectNode();
+        ObjectNode node = OBJECT_MAPPER.createObjectNode();
         cut.restoreKafka(mockDataAccessPoint, "path doesn't matter", node);
 
         // then
@@ -280,7 +280,7 @@ public class TestFusekiKafkaSCG {
         Path tempDir = Files.createTempDirectory("test_restore_dir");
         tempDir.toFile().deleteOnExit();
 
-        ObjectNode node = MAPPER.createObjectNode();
+        ObjectNode node = OBJECT_MAPPER.createObjectNode();
         KConnectorDesc mockDesc = mock(KConnectorDesc.class);
 
         String dataset = "matching dataset";
@@ -332,7 +332,7 @@ public class TestFusekiKafkaSCG {
             writer.write(jsonString);
         }
 
-        ObjectNode node = MAPPER.createObjectNode();
+        ObjectNode node = OBJECT_MAPPER.createObjectNode();
         KConnectorDesc mockDesc = mock(KConnectorDesc.class);
         String localPath = "/matchingdataset/upload";
         when(mockDesc.getLocalDispatchPath()).thenReturn(localPath);
@@ -393,7 +393,7 @@ public class TestFusekiKafkaSCG {
             writer.write(jsonString);
         }
 
-        ObjectNode node = MAPPER.createObjectNode();
+        ObjectNode node = OBJECT_MAPPER.createObjectNode();
         KConnectorDesc mockDesc = mock(KConnectorDesc.class);
         String localPath = "/matchingdataset/upload";
         when(mockDesc.getLocalDispatchPath()).thenReturn(localPath);

--- a/scg-system/src/test/java/io/telicent/model/TestTypedObject.java
+++ b/scg-system/src/test/java/io/telicent/model/TestTypedObject.java
@@ -6,17 +6,15 @@ import org.apache.jena.datatypes.xsd.impl.XMLLiteralType;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.XSD;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
+import static io.telicent.backup.utils.JsonFileUtils.OBJECT_MAPPER;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TestTypedObject {
 
-    private final static ObjectMapper MAPPER = new ObjectMapper();
-
     @Test
     public void testXsdInteger() throws Exception {
-        final JsonTripleObject tripleObject = MAPPER.readValue(
+        final JsonTripleObject tripleObject = OBJECT_MAPPER.readValue(
                 getJsonString("xsd:integer", "123"), JsonTripleObject.class);
         final TypedObject result = TypedObject.from(tripleObject);
         assertNotNull(result);
@@ -25,7 +23,7 @@ public class TestTypedObject {
 
     @Test
     public void testXsdNonNegativeInteger() throws Exception {
-        final JsonTripleObject tripleObject = MAPPER.readValue(
+        final JsonTripleObject tripleObject = OBJECT_MAPPER.readValue(
                 getJsonString("xsd:nonNegativeInteger", "123"), JsonTripleObject.class);
         final TypedObject result = TypedObject.from(tripleObject);
         assertNotNull(result);
@@ -34,7 +32,7 @@ public class TestTypedObject {
 
     @Test
     public void testXsdString() throws Exception {
-        final JsonTripleObject tripleObject = MAPPER.readValue(
+        final JsonTripleObject tripleObject = OBJECT_MAPPER.readValue(
                 getJsonString("xsd:string", "123"), JsonTripleObject.class);
         final TypedObject result = TypedObject.from(tripleObject);
         assertNotNull(result);
@@ -43,7 +41,7 @@ public class TestTypedObject {
 
     @Test
     public void testXsdStringFullUri() throws Exception {
-        final JsonTripleObject tripleObject = MAPPER.readValue(
+        final JsonTripleObject tripleObject = OBJECT_MAPPER.readValue(
                 getJsonString(XSD.NS + "string", "123"), JsonTripleObject.class);
         final TypedObject result = TypedObject.from(tripleObject);
         assertNotNull(result);
@@ -52,7 +50,7 @@ public class TestTypedObject {
 
     @Test
     public void testXsdAnyUri() throws Exception {
-        final JsonTripleObject tripleObject = MAPPER.readValue(
+        final JsonTripleObject tripleObject = OBJECT_MAPPER.readValue(
                 getJsonString("xsd:anyURI", "123"), JsonTripleObject.class);
         final TypedObject result = TypedObject.from(tripleObject);
         assertNotNull(result);
@@ -61,7 +59,7 @@ public class TestTypedObject {
 
     @Test
     public void testXsdDate() throws Exception {
-        final JsonTripleObject tripleObject = MAPPER.readValue(
+        final JsonTripleObject tripleObject = OBJECT_MAPPER.readValue(
                 getJsonString("xsd:date", "2025-04-03"), JsonTripleObject.class);
         final TypedObject result = TypedObject.from(tripleObject);
         assertNotNull(result);
@@ -70,7 +68,7 @@ public class TestTypedObject {
 
     @Test
     public void testXsdDateTime() throws Exception {
-        final JsonTripleObject tripleObject = MAPPER.readValue(
+        final JsonTripleObject tripleObject = OBJECT_MAPPER.readValue(
                 getJsonString("xsd:dateTime", "2025-04-03T14:00:00Z"), JsonTripleObject.class);
         final TypedObject result = TypedObject.from(tripleObject);
         assertNotNull(result);
@@ -79,21 +77,17 @@ public class TestTypedObject {
 
     @Test
     public void testUnknownUnknown() throws Exception {
-        final JsonTripleObject tripleObject = MAPPER.readValue(
+        final JsonTripleObject tripleObject = OBJECT_MAPPER.readValue(
                 getJsonString("unknown:unknown", "123"), JsonTripleObject.class);
-        Exception exception = assertThrows(SmartCacheGraphException.class, () -> {
-            TypedObject.from(tripleObject);
-        });
+        Exception exception = assertThrows(SmartCacheGraphException.class, () -> TypedObject.from(tripleObject));
         assertEquals("Unknown data type: unknown:unknown", exception.getMessage(), "Unexpected exception message");
     }
 
     @Test
     public void testUnknownHttpUri() throws Exception {
-        final JsonTripleObject tripleObject = MAPPER.readValue(
+        final JsonTripleObject tripleObject = OBJECT_MAPPER.readValue(
                 getJsonString("http://example.org#unknown", "123"), JsonTripleObject.class);
-        Exception exception = assertThrows(SmartCacheGraphException.class, () -> {
-            TypedObject.from(tripleObject);
-        });
+        Exception exception = assertThrows(SmartCacheGraphException.class, () -> TypedObject.from(tripleObject));
         assertEquals("Unknown data type URI: http://example.org#unknown", exception.getMessage(), "Unexpected exception message");
     }
 
@@ -102,7 +96,7 @@ public class TestTypedObject {
      */
     @Test
     public void testXsdUnknown() throws Exception {
-        final JsonTripleObject tripleObject = MAPPER.readValue(
+        final JsonTripleObject tripleObject = OBJECT_MAPPER.readValue(
                 getJsonString("xsd:unknown", "123"), JsonTripleObject.class);
         final TypedObject result = TypedObject.from(tripleObject);
         assertNotNull(result);
@@ -111,18 +105,16 @@ public class TestTypedObject {
 
     @Test
     public void testRdfUnknown() throws Exception {
-        final JsonTripleObject tripleObject = MAPPER.readValue(
+        final JsonTripleObject tripleObject = OBJECT_MAPPER.readValue(
                 getJsonString("rdf:unknown", "123"), JsonTripleObject.class);
-        Exception exception = assertThrows(SmartCacheGraphException.class, () -> {
-            TypedObject.from(tripleObject);
-        });
+        Exception exception = assertThrows(SmartCacheGraphException.class, () -> TypedObject.from(tripleObject));
         assertEquals("Unknown data type: rdf:unknown", exception.getMessage(), "Unexpected exception message");
     }
 
 
     @Test
     public void testRdfXmlLiteral() throws Exception {
-        final JsonTripleObject tripleObject = MAPPER.readValue(
+        final JsonTripleObject tripleObject = OBJECT_MAPPER.readValue(
                 getJsonString("rdf:XMLLiteral", "<test>test</test>"), JsonTripleObject.class);
         final TypedObject result = TypedObject.from(tripleObject);
         assertNotNull(result);
@@ -131,7 +123,7 @@ public class TestTypedObject {
 
     @Test
     public void testRdfXmlLiteralFullUri() throws Exception {
-        final JsonTripleObject tripleObject = MAPPER.readValue(
+        final JsonTripleObject tripleObject = OBJECT_MAPPER.readValue(
                 getJsonString(RDF.uri + "XMLLiteral", "<test>test</test>"), JsonTripleObject.class);
         final TypedObject result = TypedObject.from(tripleObject);
         assertNotNull(result);


### PR DESCRIPTION
Previously we have left the file structure as is, primarily for debugging purposes, but for a variety of reasons we have decided to compress the generated folders into a single file. 

As a result we have written the data into an info file that can be read (when listing) and moved the location of the validation reports. There have been corresponding updates to the restore and delete logic. 

Also updated some deprecated Jena calls and code-refactor for consolidated object mapper call. Also started making use of @DisplayName annotation to make tests a little easier to read. 