### PR TITLE
[Minor] Upgrading to v1.0.2 RDF ABAC 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
 
     <!-- Dependency versions -->
     <!-- Internal dependencies -->
-    <dependency.rdf-abac>0.73.4</dependency.rdf-abac>
+    <dependency.rdf-abac>1.0.2</dependency.rdf-abac>
     <dependency.fuseki-kafka>1.5.3</dependency.fuseki-kafka>
     <dependency.jena>5.4.0</dependency.jena>
     <dependency.fuseki-server>${dependency.jena}</dependency.fuseki-server>

--- a/scg-benchmark/src/main/java/io/telicent/core/LabelParsingBenchMark.java
+++ b/scg-benchmark/src/main/java/io/telicent/core/LabelParsingBenchMark.java
@@ -1,0 +1,64 @@
+package io.telicent.core;
+
+import io.telicent.jena.abac.AE;
+import io.telicent.jena.abac.attributes.AttributeExpr;
+import io.telicent.jena.abac.labels.Label;
+import org.openjdk.jmh.annotations.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+public class LabelParsingBenchMark {
+
+    @Param({"1", "10", "100", "1000"})
+    private int numberOfLabels;
+
+    private String securityLabelsListString;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        // Generate a comma-separated string of 'numberOfLabels' (e.g., "label0,label1,label2")
+        List<String> labels = new ArrayList<>();
+        for (int i = 0; i < numberOfLabels; i++) {
+            labels.add("label" + i);
+        }
+        securityLabelsListString = String.join(",", labels);
+    }
+
+    /**
+     * Benchmarks the old method of parsing security labels into a List<String>.
+     * This directly simulates the logic found in the original FKProcessorSCG.java.
+     *
+     * @return A List of strings representing the parsed labels.
+     */
+    @Benchmark
+    public List<String> benchmarkOldParseAttributeList() {
+        // Original method returned null if input was null, replicating that behavior
+        if (securityLabelsListString == null || securityLabelsListString.isEmpty()) {
+            return null;
+        }
+        List<AttributeExpr> x = AE.parseExprList(securityLabelsListString);
+        return AE.asStrings(x);
+    }
+
+    /**
+     * Benchmarks the new method of parsing security labels into a List<Label>.
+     * This directly simulates the logic found in the modified FKProcessorSCG.java.
+     *
+     * @return A List of Label objects representing the parsed labels.
+     */
+    @Benchmark
+    public List<Label> benchmarkNewParseAttributeListToLabels() {
+        List<AttributeExpr> exprList = AE.parseExprList(securityLabelsListString);
+        List<Label> labels = new ArrayList<>(exprList.size());
+        for (AttributeExpr expr : exprList) {
+            labels.add(Label.fromText(expr.str(), StandardCharsets.UTF_8));
+        }
+        return labels;
+    }
+}

--- a/scg-benchmark/src/main/java/io/telicent/core/SCGBenchmark.java
+++ b/scg-benchmark/src/main/java/io/telicent/core/SCGBenchmark.java
@@ -4,6 +4,7 @@ import io.telicent.jena.abac.AttributeValueSet;
 import io.telicent.jena.abac.core.AttributesStoreLocal;
 import io.telicent.jena.abac.core.DatasetGraphABAC;
 import io.telicent.jena.abac.fuseki.ABAC_SPARQL_QueryDataset;
+import io.telicent.jena.abac.labels.Label;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.HttpServletRequest;
@@ -93,7 +94,7 @@ public class SCGBenchmark {
     private static void createDataService() {
         AttributesStoreLocal store = new AttributesStoreLocal();
         store.put("user", AttributeValueSet.of("userAttribute"));
-        datasetGraph = new DatasetGraphABAC(DatasetGraphFactory.createTxnMem(), "userAttribute", createLabelsStoreMem(), "test", store);
+        datasetGraph = new DatasetGraphABAC(DatasetGraphFactory.createTxnMem(), "userAttribute", createLabelsStoreMem(), Label.fromText("test"), store);
         dataService = DataService.newBuilder(datasetGraph).build();
         dataService.goActive();
     }

--- a/scg-system/src/main/java/io/telicent/labels/TripleLabels.java
+++ b/scg-system/src/main/java/io/telicent/labels/TripleLabels.java
@@ -2,6 +2,7 @@ package io.telicent.labels;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.telicent.jena.abac.labels.Label;
 import org.apache.jena.graph.Triple;
 
 import java.util.List;
@@ -10,12 +11,12 @@ import static io.telicent.backup.utils.JsonFileUtils.OBJECT_MAPPER;
 
 public class TripleLabels {
 
-    public TripleLabels(Triple triple, List<String> labels){
+    public TripleLabels(Triple triple, List<Label> labels){
         this.triple = triple;
         this.labels = labels;
     }
 
-    public List<String> labels;
+    public List<Label> labels;
     public Triple triple;
 
     public ObjectNode toJSONNode() {
@@ -24,7 +25,7 @@ public class TripleLabels {
         node.put("predicate", triple.getPredicate().toString());
         node.put("object", triple.getObject().toString());
         ArrayNode labelNode = OBJECT_MAPPER.createArrayNode();
-        labels.forEach(labelNode::add);
+        labels.forEach(l -> labelNode.add(l.getText()));
         node.set("labels", labelNode);
         return node;
     }

--- a/scg-system/src/test/java/io/telicent/TestFKProcessorSCG.java
+++ b/scg-system/src/test/java/io/telicent/TestFKProcessorSCG.java
@@ -31,6 +31,8 @@ import io.telicent.jena.abac.AttributeValueSet;
 import io.telicent.jena.abac.SysABAC;
 import io.telicent.jena.abac.attributes.Attribute;
 import io.telicent.jena.abac.attributes.AttributeValue;
+import io.telicent.jena.abac.attributes.ValueTerm;
+import io.telicent.jena.abac.attributes.syntax.AEX;
 import io.telicent.jena.abac.core.AttributesStore;
 import io.telicent.jena.abac.core.AttributesStoreLocal;
 import io.telicent.jena.abac.core.AttributesStoreModifiable;
@@ -322,7 +324,7 @@ class TestFKProcessorSCG {
             checkDatasetSize(dsgBase, 0);
             processorRequest(proc, """
                              A <http://ex/s2> <http://ex/p> "triple2" .
-                             """, WebContent.contentTypePatch, null);
+                             """, WebContent.contentTypePatch, AttributeValue.of("", ValueTerm.value(null)));
             checkDatasetSize(dsgBase, 1);
 
             long c1 = count(URLauthz, queryAll, userPermit);
@@ -572,10 +574,10 @@ class TestFKProcessorSCG {
         attributesStore.put(userOther,  AttributeValueSet.of("OTHER"));
 
         DatasetGraphABAC dsgz = ABAC.authzDataset(dsgBase,
-                                                  SysABAC.allowLabel,   // API access label
-                                                  labelsStore,
-                                                  SysABAC.denyLabel,    // Dataset data label default.
-                                                  attributesStore);
+                AEX.strALLOW,   // API access label
+                labelsStore,
+                SysABAC.denyLabel,    // Dataset data label default.
+                attributesStore);
         DataService dataSrv = DataService
                 .newBuilder(dsgz)
                 .addEndpoint(Operation.Query)

--- a/scg-system/src/test/java/io/telicent/TestYamlConfigParserAuthz.java
+++ b/scg-system/src/test/java/io/telicent/TestYamlConfigParserAuthz.java
@@ -19,6 +19,7 @@ package io.telicent;
 import io.telicent.jena.abac.core.Attributes;
 import io.telicent.jena.abac.core.AttributesStore;
 import io.telicent.jena.abac.fuseki.SysFusekiABAC;
+import io.telicent.jena.abac.labels.Label;
 import io.telicent.jena.abac.labels.LabelsStore;
 import io.telicent.jena.abac.labels.LabelsStoreRocksDB;
 import io.telicent.jena.abac.labels.StoreFmtByString;
@@ -155,12 +156,12 @@ class TestYamlConfigParserAuthz {
         if (iterator.hasNext()) {
             iterator.next();
             triple = iterator.nextStatement().asTriple();
-            assertEquals(labelsStore.labelsForTriples(triple).getFirst(), "manager");
+            assertEquals(labelsStore.labelsForTriples(triple).getFirst(), Label.fromText("manager"));
         }
         if (iterator.hasNext()) {
             iterator.next();
             triple = iterator.nextStatement().asTriple();
-            assertEquals(labelsStore.labelsForTriples(triple).getFirst(), "level-1");
+            assertEquals(labelsStore.labelsForTriples(triple).getFirst(), Label.fromText("level-1"));
         }
         iterator.close();
 

--- a/scg-system/src/test/java/io/telicent/backup/services/TestBackupAndRestore.java
+++ b/scg-system/src/test/java/io/telicent/backup/services/TestBackupAndRestore.java
@@ -2,6 +2,7 @@ package io.telicent.backup.services;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.telicent.jena.abac.ABAC;
+import io.telicent.jena.abac.SysABAC;
 import io.telicent.jena.abac.core.DatasetGraphABAC;
 import io.telicent.jena.abac.labels.LabelsStoreMem;
 import org.apache.jena.atlas.lib.FileOps;
@@ -41,7 +42,7 @@ public class TestBackupAndRestore {
         dsgABAC = ABAC.authzDataset(DatasetGraphFactory.createTxnMem(),
                 null,
                 LabelsStoreMem.create(),
-                "*",
+                SysABAC.allowLabel,
                 null);
     }
 

--- a/scg-system/src/test/java/io/telicent/core/TestInitialCompaction.java
+++ b/scg-system/src/test/java/io/telicent/core/TestInitialCompaction.java
@@ -3,6 +3,7 @@ package io.telicent.core;
 import io.telicent.LibTestsSCG;
 import io.telicent.jena.abac.ABAC;
 import io.telicent.jena.abac.SysABAC;
+import io.telicent.jena.abac.attributes.syntax.AEX;
 import io.telicent.jena.abac.core.Attributes;
 import io.telicent.jena.abac.core.AttributesStoreLocal;
 import io.telicent.jena.abac.core.DatasetGraphABAC;
@@ -158,7 +159,7 @@ public class TestInitialCompaction {
     public void test_ABACDSG_wrapped_memGraph() {
         // given
         DatasetGraphABAC dsgABAC = ABAC.authzDataset(DatasetGraphFactory.createTxnMem(),
-                SysABAC.allowLabel,
+                AEX.strALLOW,
                 Labels.createLabelsStoreMem(),
                 SysABAC.denyLabel,
                 new AttributesStoreLocal());
@@ -173,7 +174,7 @@ public class TestInitialCompaction {
         // given
         DatasetGraphSwitchable dsgPersists = new DatasetGraphSwitchable(Path.of("./"), null, DatasetGraphFactory.createTxnMem());
         DatasetGraphABAC dsgABAC = ABAC.authzDataset(dsgPersists,
-                SysABAC.allowLabel,
+                AEX.strALLOW,
                 Labels.createLabelsStoreMem(),
                 SysABAC.denyLabel,
                 new AttributesStoreLocal());
@@ -281,7 +282,7 @@ public class TestInitialCompaction {
     public void test_compactLabels_notRocksDB() {
         // given
         DatasetGraphABAC dsgABAC = ABAC.authzDataset(DatasetGraphFactory.createTxnMem(),
-                SysABAC.allowLabel,
+                AEX.strALLOW,
                 Labels.createLabelsStoreMem(),
                 SysABAC.denyLabel,
                 new AttributesStoreLocal());

--- a/scg-system/src/test/java/io/telicent/labels/services/TestLabelsQueryService.java
+++ b/scg-system/src/test/java/io/telicent/labels/services/TestLabelsQueryService.java
@@ -1,5 +1,6 @@
 package io.telicent.labels.services;
 
+import io.telicent.jena.abac.labels.Label;
 import io.telicent.jena.abac.labels.LabelsStore;
 import io.telicent.labels.TripleLabels;
 import org.apache.jena.graph.Node;
@@ -38,7 +39,7 @@ class TestLabelsQueryService {
 
     @BeforeAll
     public static void beforeAll() {
-        when(mockLabelsStore.labelsForTriples(any(Triple.class))).thenReturn(List.of("example"));
+        when(mockLabelsStore.labelsForTriples(any(Triple.class))).thenReturn(List.of(Label.fromText("example")));
     }
 
     @AfterEach

--- a/scg-system/src/test/java/io/telicent/labels/services/TestLabelsQueryServiceRocksDB.java
+++ b/scg-system/src/test/java/io/telicent/labels/services/TestLabelsQueryServiceRocksDB.java
@@ -1,9 +1,6 @@
 package io.telicent.labels.services;
 
-import io.telicent.jena.abac.labels.Labels;
-import io.telicent.jena.abac.labels.LabelsStore;
-import io.telicent.jena.abac.labels.LabelsStoreRocksDB;
-import io.telicent.jena.abac.labels.StoreFmtByString;
+import io.telicent.jena.abac.labels.*;
 import io.telicent.labels.TripleLabels;
 import org.apache.commons.io.FileUtils;
 import org.apache.jena.graph.NodeFactory;
@@ -38,7 +35,7 @@ public class TestLabelsQueryServiceRocksDB {
         );
         final LabelsStore rocksDbLabelsStore = Labels.createLabelsStoreRocksDB(
                 dbDir, LabelsStoreRocksDB.LabelMode.Overwrite, null, new StoreFmtByString());
-        rocksDbLabelsStore.add(triple, "example");
+        rocksDbLabelsStore.add(triple, Label.fromText("example"));
         final DatasetGraph emptyDsg = DatasetGraphFactory.create();
         final LabelsQueryService queryService = new LabelsQueryService(rocksDbLabelsStore, emptyDsg);
         final List<TripleLabels> labels = queryService.queryOnlyLabelStore(triple);
@@ -56,7 +53,7 @@ public class TestLabelsQueryServiceRocksDB {
         );
         final LabelsStore rocksDbLabelsStore = Labels.createLabelsStoreRocksDB(
                 dbDir, LabelsStoreRocksDB.LabelMode.Overwrite, null, new StoreFmtByString());
-        rocksDbLabelsStore.add(triple, "example");
+        rocksDbLabelsStore.add(triple, Label.fromText("example"));
         final DatasetGraph emptyDsg = DatasetGraphFactory.create();
         final LabelsQueryService queryService = new LabelsQueryService(rocksDbLabelsStore, emptyDsg);
         final List<TripleLabels> labels = queryService.queryOnlyLabelStore(triple);


### PR DESCRIPTION
And benchmarking for the explicit parsing change in FKProcessorSCG. 

Have also tested this in greater depth for preformance and backwards compatibility for bacup/restore within the RocksDB  (see https://github.com/telicent-oss/rdf-abac/pull/120 and https://github.com/telicent-oss/rdf-abac/pull/114 )