### PR TITLE
Updating API docs to match implementation

### DIFF
--- a/docs/labels-api.yaml
+++ b/docs/labels-api.yaml
@@ -6,6 +6,25 @@ info:
 servers:
   - url: http://localhost:3030/
     description: Base path for query operations.
+components:
+  securitySchemes:
+    BearerAuth:
+      description: Generic Bearer Authentication is supported using JWTs
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+    AwsBearerAuth:
+      description: |
+        For AWS usage we support JWTs that are injected into requests by the ELB.  
+        Since these come in a non-standard HTTP header we have to declare this as
+        an API Key scheme in OpenAPI spec as it doesn't have a notion of using a
+        HTTP scheme in a non-standard way (yay AWS weirdness!)
+      type: apiKey
+      in: header
+      name: X-Amzn-Oidc-Data
+security:
+  - BearerAuth: []
+  - AwsBearerAuth: []
 paths:
   /$/labels/query:
     post:
@@ -19,46 +38,54 @@ paths:
             schema:
               type: object
               properties:
-                subject:
-                  type: string
-                predicate:
-                  type: string
-                object:
-                  type: object
-                  properties:
-                    dataType:
-                      type: string
-                    value:
-                      type: string
-                    language:
-                      type: string
-                  required:
-                    - value
-              required:
-                - subject
-                - predicate
-                - object
+                triples:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      subject:
+                        type: string
+                      predicate:
+                        type: string
+                      object:
+                        type: object
+                        properties:
+                          dataType:
+                            type: string
+                          value:
+                            type: string
+                          language:
+                            type: string
+                        required:
+                          - value
+                    required:
+                      - subject
+                      - predicate
+                      - object
             examples:
               London_Population:
                 value:
-                  subject: http://dbpedia.org/resource/London
-                  predicate: http://dbpedia.org/ontology/populationTotal
-                  object:
-                    value: 8799800
-                    dataType: xsd:integer
+                  triples:
+                    - subject: http://dbpedia.org/resource/London
+                      predicate: http://dbpedia.org/ontology/populationTotal
+                      object:
+                        value: 8799800
+                        dataType: xsd:integer
               London_Country:
                 value:
-                  subject: http://dbpedia.org/resource/London
-                  predicate: http://dbpedia.org/ontology/country
-                  object:
-                    value: http://dbpedia.org/resource/United_Kingdom
+                  triples:
+                    - subject: http://dbpedia.org/resource/London
+                      predicate: http://dbpedia.org/ontology/country
+                      object:
+                        value: http://dbpedia.org/resource/United_Kingdom
               London_Name:
                 value:
-                  subject: http://dbpedia.org/resource/London
-                  predicate: http://dbpedia.org/ontology/name
-                  object:
-                    value: London
-                    language: en
+                  triples:
+                    - subject: http://dbpedia.org/resource/London
+                      predicate: http://dbpedia.org/ontology/name
+                      object:
+                        value: London
+                        language: en
       responses:
         '200':
           description: Request processed successfully.
@@ -67,11 +94,23 @@ paths:
               schema:
                 type: object
                 properties:
-                  labels:
+                  results:
                     type: array
                     items:
-                      type: string
-                    description: List of the labels.
+                      type: object
+                      properties:
+                        subject:
+                          type: string
+                        predicate:
+                          type: string
+                        object:
+                          type: string
+                        labels:
+                          type: array
+                          description: List of the labels.
+                          items:
+                            type: string
+                            description: List of the labels.
         '500':
           description: Internal server error.
           content:
@@ -82,3 +121,4 @@ paths:
                   error:
                     type: string
                     description: Error message.
+

--- a/scg-system/src/test/java/io/telicent/labels/services/TestLabelsQuery.java
+++ b/scg-system/src/test/java/io/telicent/labels/services/TestLabelsQuery.java
@@ -60,7 +60,6 @@ public class TestLabelsQuery {
                         "subject": "http://dbpedia.org/resource/London",
                         "predicate": "http://dbpedia.org/ontology/country",
                         "object": {
-                          "dataType" : "xsd:anyURI",
                           "value" : "http://dbpedia.org/resource/United_Kingdom"
                         }
                     }
@@ -114,7 +113,6 @@ public class TestLabelsQuery {
                             "subject": "http://dbpedia.org/resource/Rome",
                             "predicate": "http://dbpedia.org/ontology/country",
                              "object" : {
-                               "dataType" : "xsd:anyURI",
                                "value" : "http://dbpedia.org/resource/Italy"
                              }
                         }
@@ -141,7 +139,6 @@ public class TestLabelsQuery {
                           "subject": "http://dbpedia.org/resource/Rome",
                           "predicate": "http://dbpedia.org/ontology/country",
                           "object": {
-                            "dataType" : "xsd:anyURI",
                             "value" : "http://dbpedia.org/resource/Italy"
                           }
                         },
@@ -149,7 +146,6 @@ public class TestLabelsQuery {
                           "subject": "http://dbpedia.org/resource/Paris",
                           "predicate": "http://dbpedia.org/ontology/country",
                           "object": {
-                            "dataType" : "xsd:anyURI",
                             "value" : "http://dbpedia.org/resource/France"
                           }
                         }
@@ -208,10 +204,15 @@ public class TestLabelsQuery {
 
         final String jsonRequestBody = """
                 {
-                  "subject": "http://dbpedia.org/resource/Rome",
-                  "predicate": "http://dbpedia.org/ontology/country",
-                  "object": {
-                    "value": "http://dbpedia.org/resource/Italy"
+                  "triples":[
+                    {
+                      "subject": "http://dbpedia.org/resource/Rome",
+                      "predicate": "http://dbpedia.org/ontology/country",
+                      "object": {
+                        "value": "http://dbpedia.org/resource/Italy"
+                      }
+                    }
+                  ]
                 }""";
 
         final HttpRequest request = HttpRequest.newBuilder(new URI(BASE_URI + "/$/labels/query"))


### PR DESCRIPTION
This is a follow up to https://github.com/telicent-oss/smart-cache-graph/pull/229 (CORE-837) as the API docs and tests were still not fully aligned to the implementation. The previous PR modified the request triple `object` value to be a JSON object but it turns out we were also missing the `triples` array wrapper to allow for multiple triples to be queried at once. This PR corrects this. The tests cases have also been modified to remove the `dataType` when the object is a URI. 

We should consider using something like [swagger-core](https://github.com/swagger-api/swagger-core) to generate our API docs as part of the build process and save us having to remember to and do this manually. I realise these things take a while to set up, but I think it would save us time in the long run!