### PR TITLE
CORE-853: improving error handling for labels query

### DIFF
--- a/scg-system/src/test/java/io/telicent/labels/services/TestLabelsQuery.java
+++ b/scg-system/src/test/java/io/telicent/labels/services/TestLabelsQuery.java
@@ -178,7 +178,7 @@ public class TestLabelsQuery {
                 }""";
         final String expectedJsonResponse = """
                 {
-                  "results" : [ ]
+                  "error" : "Unable to interpret JSON request"
                 }""";
         callAndAssert(jsonRequestBody, expectedJsonResponse);
     }
@@ -190,7 +190,7 @@ public class TestLabelsQuery {
                 }""";
         final String expectedJsonResponse = """
                 {
-                  "results" : [ ]
+                  "error" : "Unable to interpret JSON request"
                 }""";
         callAndAssert(jsonRequestBody, expectedJsonResponse);
     }

--- a/scg-system/src/test/java/io/telicent/labels/services/TestLabelsQueryServiceMem.java
+++ b/scg-system/src/test/java/io/telicent/labels/services/TestLabelsQueryServiceMem.java
@@ -1,0 +1,66 @@
+package io.telicent.labels.services;
+
+import io.telicent.jena.abac.labels.*;
+import io.telicent.labels.TripleLabels;
+import org.apache.commons.io.FileUtils;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+
+public class TestLabelsQueryServiceMem {
+
+    private static File dbDir;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        dbDir = Files.createTempDirectory("tmpDir").toFile();
+    }
+
+    @Test
+    public void testLabelQuery() throws Exception {
+        final Triple triple = Triple.create(
+                NodeFactory.createURI("http://example.org/subject"),
+                NodeFactory.createURI("http://example.org/predicate"),
+                NodeFactory.createURI("http://example.org/object")
+        );
+        final LabelsStore labelsStoreMem = Labels.createLabelsStoreMem();
+        labelsStoreMem.add(triple, Label.fromText("example"));
+        final DatasetGraph emptyDsg = DatasetGraphFactory.create();
+        final LabelsQueryService queryService = new LabelsQueryService(labelsStoreMem, emptyDsg);
+        final List<TripleLabels> labels = queryService.queryOnlyLabelStore(triple);
+        Assertions.assertEquals(1, labels.size());
+        Assertions.assertEquals(1, labels.getFirst().labels.size());
+    }
+
+    @Test
+    public void testLabelQueryLiteral() throws Exception
+    {
+        final Triple triple = Triple.create(
+                NodeFactory.createURI("http://example.org/subject"),
+                NodeFactory.createURI("http://example.org/predicate"),
+                NodeFactory.createLiteralByValue("test")
+        );
+        final LabelsStore labelsStoreMem = Labels.createLabelsStoreMem();
+        labelsStoreMem.add(triple, Label.fromText("example"));
+        final DatasetGraph emptyDsg = DatasetGraphFactory.create();
+        final LabelsQueryService queryService = new LabelsQueryService(labelsStoreMem, emptyDsg);
+        final List<TripleLabels> labels = queryService.queryOnlyLabelStore(triple);
+        Assertions.assertEquals(1, labels.size());
+        Assertions.assertEquals(1, labels.getFirst().labels.size());
+    }
+
+    @AfterEach
+    public void tearDown() throws IOException {
+        FileUtils.deleteDirectory(dbDir);
+    }
+}


### PR DESCRIPTION
Now returns an error if the request is invalid whereas previously this was just being logged and user was receiving an empty result.

Also added a test suite for the labels query using in an in memory label store (previously only RocksDB was being tested).