### PR TITLE
Ensuring TestLabelsQuery cleans up after itself

### DIFF
--- a/scg-system/src/test/java/io/telicent/labels/services/TestLabelsQuery.java
+++ b/scg-system/src/test/java/io/telicent/labels/services/TestLabelsQuery.java
@@ -294,6 +294,8 @@ public class TestLabelsQuery {
     public static void afterAll() throws IOException {
         SERVER.stop();
         FileUtils.deleteDirectory(new File("labels"));
+        FileUtils.deleteDirectory(new File("labels1"));
+        FileUtils.deleteDirectory(new File("labels2"));
     }
 
 }


### PR DESCRIPTION
Just cleaning up some annoying test leftovers.