### PR TITLE
[Minor] Addressing some annoying WARNINGS in the maven build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -529,6 +529,7 @@
           </configuration>
           <executions>
             <execution>
+              <id>build-test-jar</id>
               <goals>
                 <goal>test-jar</goal>
               </goals>

--- a/scg-benchmark/pom.xml
+++ b/scg-benchmark/pom.xml
@@ -142,6 +142,17 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${plugin.jar}</version>
+                <executions>
+                    <execution>
+                        <id>build-test-jar</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/scg-benchmark/pom.xml
+++ b/scg-benchmark/pom.xml
@@ -126,6 +126,8 @@
                             <artifactSet>
                                 <excludes>
                                     <exclude>listenablefuture:listenablefuture</exclude>
+                                    <exclude>io.opentelemetry.javaagent:*</exclude>
+                                    <exclude>commons-logging:commons-logging</exclude>
                                 </excludes>
                             </artifactSet>
                         </configuration>

--- a/scg-server/pom.xml
+++ b/scg-server/pom.xml
@@ -121,6 +121,18 @@
         <artifactId>maven-source-plugin</artifactId>
       </plugin>
 
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${plugin.jar}</version>
+        <executions>
+          <execution>
+            <id>build-test-jar</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
 
   </build>

--- a/scg-server/pom.xml
+++ b/scg-server/pom.xml
@@ -79,6 +79,7 @@
             -->
             <excludes>
               <exclude>io.opentelemetry.javaagent:*</exclude>
+              <exclude>commons-logging:commons-logging</exclude>
             </excludes>
           </artifactSet>
 


### PR DESCRIPTION
```
[WARNING] JAR will be empty - no content was marked for inclusion!
```

We only build and use the test jar in SCG System so will disable it (and subsequently remove the warnings) in the affected submodules.

---

```
[WARNING] commons-logging-1.3.5.jar, jcl-over-slf4j-2.0.17.jar define 5 overlapping classes: 
[WARNING]   - org.apache.commons.logging.Log
[WARNING]   - org.apache.commons.logging.LogConfigurationException
[WARNING]   - org.apache.commons.logging.LogFactory
[WARNING]   - org.apache.commons.logging.impl.NoOpLog
[WARNING]   - org.apache.commons.logging.impl.SimpleLog
[WARNING] maven-shade-plugin has detected that some files are
[WARNING] present in two or more JARs. When this happens, only one
[WARNING] single version of the file is copied to the uber jar.
[WARNING] Usually this is not harmful and you can skip these warnings,
[WARNING] otherwise try to manually exclude artifacts based on
[WARNING] mvn dependency:tree -Ddetail=true and the above output.
[WARNING] See https://maven.apache.org/plugins/maven-shade-plugin/
```
By excluding the commons-logging from the shade plugin.

---

There are two that cannot be fixed (as yet). They are in Cyclone DX's (core java lib) to do with processing json in SBOM's. They've not been fixed in the 5 years since it was raised - probably not happening soon. They can be safely ignored though. 

```
[WARNING] Unknown keyword meta:enum - you should define your own Meta Schema. If the keyword is irrelevant for validation, just use a NonValidationKeyword or if it should generate annotations AnnotationKeyword
[WARNING] Unknown keyword deprecated - you should define your own Meta Schema. If the keyword is irrelevant for validation, just use a NonValidationKeyword or if it should generate annotations AnnotationKeyword
```
