### PR TITLE
Fixing some errors in API documentation

### DIFF
--- a/docs/access-api.yaml
+++ b/docs/access-api.yaml
@@ -150,8 +150,8 @@ paths:
                     - subject: http://dbpedia.org/resource/London
                       predicate: http://dbpedia.org/ontology/populationTotal
                       object:
-                        - dataType: xsd:integer
-                          value: "8799800"
+                        dataType: xsd:integer
+                        value: "8799800"
                     - subject: http://dbpedia.org/resource/London
                       predicate: http://dbpedia.org/ontology/country
                       object:
@@ -159,13 +159,13 @@ paths:
                     - subject: http://dbpedia.org/resource/London
                       predicate: http://xmlns.com/foaf/0.1/homepage
                       object:
-                        - dataType: xsd:anyURI
-                          value: "https://www.london.gov.uk/"
+                        dataType: xsd:anyURI
+                        value: "https://www.london.gov.uk/"
                     - subject: http://dbpedia.org/resource/London
                       predicate: http://dbpedia.org/ontology/name
                       object:
-                        - value: "London"
-                          language: "en"
+                        value: "London"
+                        language: "en"
       responses:
         '200':
           description: Request processed successfully.
@@ -201,8 +201,8 @@ paths:
                       - subject: http://dbpedia.org/resource/London
                         predicate: http://dbpedia.org/ontology/populationTotal
                         object:
-                          - dataType: xsd:integer
-                            value: "8799800"
+                          dataType: xsd:integer
+                          value: "8799800"
                       - subject: http://dbpedia.org/resource/London
                         predicate: http://dbpedia.org/ontology/country
                         object:
@@ -210,13 +210,13 @@ paths:
                       - subject: http://dbpedia.org/resource/London
                         predicate: http://xmlns.com/foaf/0.1/homepage
                         object:
-                          - dataType: xsd:anyURI
-                            value: "https://www.london.gov.uk/"
+                          dataType: xsd:anyURI
+                          value: "https://www.london.gov.uk/"
                       - subject: http://dbpedia.org/resource/London
                         predicate: http://dbpedia.org/ontology/name
                         object:
-                          - value: "London"
-                            language: "en"
+                          value: "London"
+                          language: "en"
                     visible: true
         '400':
           description: Bad Request.

--- a/docs/access-queries.md
+++ b/docs/access-queries.md
@@ -71,22 +71,18 @@ Example request body:
     {
       "subject": "http://dbpedia.org/resource/London",
       "predicate": "http://dbpedia.org/ontology/populationTotal",
-      "object": [
-        {
-          "dataType": "xsd:integer",
-          "value": "8799800"
-        }
-      ]
+      "object": {
+        "dataType": "xsd:integer",
+        "value": "8799800"
+      }
     },
     {
       "subject": "http://dbpedia.org/resource/London",
       "predicate": "http://dbpedia.org/ontology/country",
-      "object": [
-        {
-          "dataType": "xsd:anyURI",
-          "value": "http://dbpedia.org/resource/United_Kingdom"
-        }
-      ]
+      "object": {
+        "dataType": "xsd:anyURI",
+        "value": "http://dbpedia.org/resource/United_Kingdom"
+      }
     }
   ]
 }

--- a/docs/labels-api.yaml
+++ b/docs/labels-api.yaml
@@ -26,10 +26,17 @@ security:
   - BearerAuth: []
   - AwsBearerAuth: []
 paths:
-  /$/labels/query:
+  /$/labels/{datasetName}:
     post:
       summary: Find security labels for a given triple
       description: Retrieves a list of the security labels for a given triple.
+      parameters:
+        - name: datasetName
+          in: path
+          required: true
+          description: The name of the dataset to look in.
+          schema:
+            type: string
       requestBody:
         description: The subject, predicate and object of the triple to retrieve security labels for.
         required: true


### PR DESCRIPTION
Fixing some documentation errors where we have missed a change to the labels API, when the dataset name was added to the path, and also gotten the access query response and access triples request muddled up (the first returns a list of `objects` whereas the second expects a single `object`).