### PR TITLE
Avoid unnecessary compactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
       for more details
     - **BREAKING** State file format changed, legacy state files will be automatically upgraded provided [migration
       advice](#migrating-from-083x-releases) is followed.
+- Compaction Improvements
+    - We now track the size of the database after a compaction operation so that if asked to compact again, and size has
+      not changed, we now avoid unnecessary compaction work
 - Backup/Restore changes
     - Response to a restore operation now has an `offsets` object with all relevant offsets in place of a singular
       `offset` key.  This reflects the ability of Fuseki Kafka connectors to now operate upon multi-partition topics,


### PR DESCRIPTION
This commit resolves an intermittently seen issue in dev clusters where sometimes after restart when performing the initial compaction we can get into a crash/restart loop as compaction impacts responsiveness of the service.  Also, if the dataset is already compacted this compaction is unnecessary.

To avoid this we now store a `.last-compaction` file in the database directory which allows us to compare the current size with the previously compacted size to determine if the database has grown since last compaction.  If it hasn't grown we can skip the initial compaction entirely.

Related to this spotted and fixed a bug where the determination of database size was incorrectly sizing the entire database directory, rather than just the active `Data-NNNN` directory.  We now only size the current `Data-NNNN` directory which avoids sizing inactive database files and other metadata files in the root database directory.