### PR TITLE
[CORE-867] Tweaking size and time measurements to be human-readable

### DIFF
--- a/scg-system/src/main/java/io/telicent/backup/services/DatasetBackupService.java
+++ b/scg-system/src/main/java/io/telicent/backup/services/DatasetBackupService.java
@@ -26,6 +26,7 @@ import io.telicent.jena.abac.labels.node.LabelToNodeGenerator;
 import io.telicent.model.KeyPair;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.io.FileUtils;
 import org.apache.jena.atlas.lib.DateTimeUtils;
 import org.apache.jena.fuseki.mgt.Backup;
 import org.apache.jena.fuseki.server.DataAccessPoint;
@@ -596,7 +597,7 @@ public class DatasetBackupService {
                 // size
                 long sizeInBytes = Files.size(Path.of(detailsPathString + ZIP_SUFFIX));
                 resultNode.put("zip-size-in-bytes", sizeInBytes);
-                resultNode.put("zip-size", humanReadableByteCount(sizeInBytes));
+                resultNode.put("zip-size", FileUtils.byteCountToDisplaySize(sizeInBytes));
 
                 // kafka state
                 Optional<Integer> kafkaState = readKafkaStateOffsetZip(detailsPathString + ZIP_SUFFIX);
@@ -760,20 +761,6 @@ public class DatasetBackupService {
     }
 
     /**
-     * A utility method that takes the size of something in bytes and represents it in
-     * a more easy to grasp format.
-     * @param bytes size of file in question
-     * @return a string representation in KB, MB, GB, TB or PB
-     */
-    public static String humanReadableByteCount(long bytes) {
-        int unit = 1000;
-        if (bytes < unit) return bytes + "B";
-        int exp = (int) (Math.log(bytes) / Math.log(unit));
-        String pre = "kMGTP".charAt(exp - 1) + "";
-        return String.format("%.1f%sB", bytes / Math.pow(unit, exp), pre);
-    }
-
-    /**
      * A utility method that takes the duration and represents it in
      * a more easy to grasp format.
      * @param duration the number of milliseconds in question
@@ -782,7 +769,7 @@ public class DatasetBackupService {
     public static String humanReadableDuration(Duration duration) {
         long hours = duration.toHours();
         long minutes = duration.toMinutes() % 60;
-        long seconds = duration.getSeconds() % 60;
+        long seconds = duration.toSeconds() % 60;
         long millis = duration.toMillis() % 1000;
 
         StringBuilder sb = new StringBuilder();

--- a/scg-system/src/main/java/io/telicent/backup/services/DatasetBackupService.java
+++ b/scg-system/src/main/java/io/telicent/backup/services/DatasetBackupService.java
@@ -66,7 +66,6 @@ import static io.telicent.backup.utils.BackupUtils.checkPathExistsAndIsDir;
 import static io.telicent.backup.utils.CompressionUtils.*;
 import static io.telicent.backup.utils.JsonFileUtils.OBJECT_MAPPER;
 import static io.telicent.backup.utils.JsonFileUtils.writeObjectNodeToFile;
-import static io.telicent.otel.FMod_OpenTelemetry.fixupName;
 import static org.apache.jena.riot.Lang.NQUADS;
 
 public class DatasetBackupService {
@@ -595,7 +594,10 @@ public class DatasetBackupService {
         if (checkPathExistsAndIsFile(detailsPathString + ZIP_SUFFIX)) {
             try {
                 // size
-                resultNode.put("zip-size", Files.size(Path.of(detailsPathString + ZIP_SUFFIX)));
+                long sizeInBytes = Files.size(Path.of(detailsPathString + ZIP_SUFFIX));
+                resultNode.put("zip-size-in-bytes", sizeInBytes);
+                resultNode.put("zip-size", humanReadableByteCount(sizeInBytes));
+
                 // kafka state
                 Optional<Integer> kafkaState = readKafkaStateOffsetZip(detailsPathString + ZIP_SUFFIX);
                 kafkaState.ifPresent(integer -> resultNode.put("kafka-state", integer));
@@ -607,7 +609,8 @@ public class DatasetBackupService {
                 endTime.ifPresent(time -> resultNode.put("end-time", time.toString()));
                 if (startTime.isPresent() && endTime.isPresent()) {
                     Duration duration = Duration.between(startTime.get(), endTime.get());
-                    resultNode.put("backup-time", duration.toMillis() + "ms");
+                    resultNode.put("backup-duration", humanReadableDuration(duration));
+                    resultNode.put("backup-duration-in-ms", duration.toMillis() );
                 }
             } catch (IOException e) {
                 throw new RuntimeException(e);
@@ -755,5 +758,41 @@ public class DatasetBackupService {
         response.put("end-time", endTime.toString());
         writeObjectNodeToFile(response, dirPath + JSON_INFO_SUFFIX);
     }
+
+    /**
+     * A utility method that takes the size of something in bytes and represents it in
+     * a more easy to grasp format.
+     * @param bytes size of file in question
+     * @return a string representation in KB, MB, GB, TB or PB
+     */
+    public static String humanReadableByteCount(long bytes) {
+        int unit = 1000;
+        if (bytes < unit) return bytes + "B";
+        int exp = (int) (Math.log(bytes) / Math.log(unit));
+        String pre = "kMGTP".charAt(exp - 1) + "";
+        return String.format("%.1f%sB", bytes / Math.pow(unit, exp), pre);
+    }
+
+    /**
+     * A utility method that takes the duration and represents it in
+     * a more easy to grasp format.
+     * @param duration the number of milliseconds in question
+     * @return a string representation in hours. minutes, seconds and milliseconds
+     */
+    public static String humanReadableDuration(Duration duration) {
+        long hours = duration.toHours();
+        long minutes = duration.toMinutes() % 60;
+        long seconds = duration.getSeconds() % 60;
+        long millis = duration.toMillis() % 1000;
+
+        StringBuilder sb = new StringBuilder();
+        if (hours > 0) sb.append(hours).append("h ");
+        if (minutes > 0) sb.append(minutes).append("m ");
+        if (seconds > 0) sb.append(seconds).append("s ");
+        if (millis > 0 || sb.isEmpty()) sb.append(millis).append("ms");
+
+        return sb.toString().trim();
+    }
+
 
 }

--- a/scg-system/src/test/java/io/telicent/backup/TestBackupData.java
+++ b/scg-system/src/test/java/io/telicent/backup/TestBackupData.java
@@ -266,6 +266,8 @@ public class TestBackupData {
             JsonNode rootBackupNode = objectMapper.readTree(createBackupResponse.body());
             String zipSize = rootBackupNode.path("details").path("zip-size").asText();
             assertFalse(zipSize.isEmpty());
+            String zipSizeInBytes = rootBackupNode.path("details").path("zip-size-in-bytes").asText();
+            assertFalse(zipSizeInBytes.isEmpty());
         }
         catch (IOException ex) {
             Assertions.fail("Unexpected exception: " + ex.getMessage());

--- a/scg-system/src/test/java/io/telicent/backup/services/TestDataSetBackupServiceUtils.java
+++ b/scg-system/src/test/java/io/telicent/backup/services/TestDataSetBackupServiceUtils.java
@@ -25,24 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class TestDataSetBackupServiceUtils {
 
     @Test
-    void testHumanReadableByteCount_under1k() {
-        assertEquals("999B", DatasetBackupService.humanReadableByteCount(999));
-    }
-
-    @Test
-    void testHumanReadableByteCount_exact1k() {
-        assertEquals("1.0kB", DatasetBackupService.humanReadableByteCount(1000));
-    }
-
-    @Test
-    void testHumanReadableByteCount_multipleUnits() {
-        assertEquals("1.5MB", DatasetBackupService.humanReadableByteCount(1_500_000));
-        assertEquals("2.0GB", DatasetBackupService.humanReadableByteCount(2_000_000_000));
-        assertEquals("3.0TB", DatasetBackupService.humanReadableByteCount(3_000_000_000_000L));
-        assertEquals("4.0PB", DatasetBackupService.humanReadableByteCount(4_000_000_000_000_000L));
-    }
-
-    @Test
     void testHumanReadableDuration_allZero() {
         assertEquals("0ms", DatasetBackupService.humanReadableDuration(Duration.ZERO));
     }

--- a/scg-system/src/test/java/io/telicent/backup/services/TestDataSetBackupServiceUtils.java
+++ b/scg-system/src/test/java/io/telicent/backup/services/TestDataSetBackupServiceUtils.java
@@ -1,0 +1,85 @@
+/*
+ *  Copyright (c) Telicent Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.telicent.backup.services;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+public class TestDataSetBackupServiceUtils {
+
+    @Test
+    void testHumanReadableByteCount_under1k() {
+        assertEquals("999B", DatasetBackupService.humanReadableByteCount(999));
+    }
+
+    @Test
+    void testHumanReadableByteCount_exact1k() {
+        assertEquals("1.0kB", DatasetBackupService.humanReadableByteCount(1000));
+    }
+
+    @Test
+    void testHumanReadableByteCount_multipleUnits() {
+        assertEquals("1.5MB", DatasetBackupService.humanReadableByteCount(1_500_000));
+        assertEquals("2.0GB", DatasetBackupService.humanReadableByteCount(2_000_000_000));
+        assertEquals("3.0TB", DatasetBackupService.humanReadableByteCount(3_000_000_000_000L));
+        assertEquals("4.0PB", DatasetBackupService.humanReadableByteCount(4_000_000_000_000_000L));
+    }
+
+    @Test
+    void testHumanReadableDuration_allZero() {
+        assertEquals("0ms", DatasetBackupService.humanReadableDuration(Duration.ZERO));
+    }
+
+    @Test
+    void testHumanReadableDuration_onlyMillis() {
+        assertEquals("123ms", DatasetBackupService.humanReadableDuration(Duration.ofMillis(123)));
+    }
+
+    @Test
+    void testHumanReadableDuration_secondsAndMillis() {
+        assertEquals("2s 345ms", DatasetBackupService.humanReadableDuration(Duration.ofMillis(2345)));
+    }
+
+    @Test
+    void testHumanReadableDuration_minutesSecondsMillis() {
+        assertEquals("1m 2s 345ms", DatasetBackupService.humanReadableDuration(Duration.ofMillis(62_345)));
+    }
+
+    @Test
+    void testHumanReadableDuration_hoursMinutesSecondsMillis() {
+        assertEquals("1h 2m 3s 456ms", DatasetBackupService.humanReadableDuration(Duration.ofHours(1)
+                .plusMinutes(2).plusSeconds(3).plusMillis(456)));
+    }
+
+    @Test
+    void testHumanReadableDuration_justHours() {
+        assertEquals("2h", DatasetBackupService.humanReadableDuration(Duration.ofHours(2)));
+    }
+
+    @Test
+    void testHumanReadableDuration_justMinutes() {
+        assertEquals("5m", DatasetBackupService.humanReadableDuration(Duration.ofMinutes(5)));
+    }
+
+    @Test
+    void testHumanReadableDuration_justSeconds() {
+        assertEquals("7s", DatasetBackupService.humanReadableDuration(Duration.ofSeconds(7)));
+    }
+}

--- a/scg-system/src/test/java/io/telicent/backup/services/TestDatasetBackupService.java
+++ b/scg-system/src/test/java/io/telicent/backup/services/TestDatasetBackupService.java
@@ -195,7 +195,7 @@ public class TestDatasetBackupService {
             for (String field : existingFields) {
                 assertTrue(result.has(field));
             }
-            String[] missingFields = {"zip-size", "start-time", "end-time", "backup-time"};
+            String[] missingFields = {"zip-size-in-bytes", "zip-size-in-bytes", "start-time", "end-time", "backup-duration-in-ms", "backup-duration-in-ms"};
             for (String field : missingFields) {
                 assertFalse(result.has(field), field);
             }
@@ -232,7 +232,7 @@ public class TestDatasetBackupService {
         ObjectNode result = cut.getDetails(backupId);
 
         // then
-        String[] requiredFields = {"backup-id", "details-path", "zip-size", "start-time", "end-time", "backup-time"};
+        String[] requiredFields = {"backup-id", "details-path", "zip-size", "zip-size-in-bytes", "start-time", "end-time", "backup-duration-in-ms", "backup-duration-in-ms"};
         for (String field : requiredFields) {
             assertTrue(result.has(field));
         }
@@ -1674,7 +1674,7 @@ public class TestDatasetBackupService {
         newDir.deleteOnExit();
 
         String datasetName = "dataset-name";
-        File newDataset = new File(newDir.toString() + "/" + datasetName);
+        File newDataset = new File(newDir + "/" + datasetName);
         assertTrue(newDataset.mkdir());
         newDataset.deleteOnExit();
 
@@ -2429,8 +2429,6 @@ public class TestDatasetBackupService {
     @DisplayName("Restore label store when the path is wrong/missing")
     public void test_restoreLabelStore_wrongPath() {
         // given
-        String datasetName = "/dataset-name";
-
         DatasetGraphABAC dsgABAC = ABAC.authzDataset(DatasetGraphFactory.createTxnMem(),
                 null,
                 mock(LabelsStoreRocksDB.class),
@@ -2489,7 +2487,7 @@ public class TestDatasetBackupService {
             }
             // Wait for threads to complete
             executorService.shutdown();
-            executorService.awaitTermination(1, TimeUnit.SECONDS);
+            boolean ignored = executorService.awaitTermination(1, TimeUnit.SECONDS);
         }
         verify(response, times(1)).setStatus(409);
     }


### PR DESCRIPTION
Plus made it clear the original measurements are in bytes and milliseconds.


Hopefully we never use hours - didn't think days would be possible. Similarly, Petabytes seem like they would cause all manner of issues, so cut it off there. 