### PR TITLE
[Minor] Fixing docker scripts to run without maven.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It is a container that consists of:
 Smart Cache Graph is configured using a Fuseki configuration file
 ([documentation](docs/configuration-smart-cache-graph.md)). There is an [example config.ttl](docs/config.ttl) file.
 
-You can find further example configurations later under [Try It Out](#try-it-out).
+You can find further example configurations later under [Try It Out](#try-it-out-).
 
 ## System Configuration
 
@@ -30,7 +30,7 @@ The following environment variables can be used to control Smart Cache Graph:
 ### `USER_ATTRIBUTES_URL`
 
 This is the network location of [user attribute server](https://github.com/telicent-oss/telicent-access) which also
-includes the hierarchies management.
+includes the hierarchies' management.
 
 The URL value is a template including `{user}`. Example: `http://some-host/users/lookup/{user}`
 
@@ -178,7 +178,7 @@ and configuration files go into host `mnt/config/`.
 
 ### Try it out! 
 
-The provided script, [docker-run.sh](scg-docker/docker-run.sh), runs SCG in a docker container, with the contents of the
+The provided script, [latest-docker-run.sh](scg-docker/latest-docker-run.sh), runs the latest published image of SCG in a docker container, with the contents of the
 local [mnt/config](scg-docker/mnt/config) directory mounted into the newly generated docker image for ease of use.
 Similarly, the [mnt/databases](scg-docker/mnt/databases) and [mnt/logs](scg-docker/mnt/logs) are mounted for easier
 analysis.
@@ -186,7 +186,7 @@ analysis.
 #### Example configuration - *Default*
 
 ```bash
-   scg-docker/docker-run.sh
+   scg-docker/latest-docker-run.sh
 ```
 Passing no parameters means that it will default to (`"--mem /ds"`)
 
@@ -197,7 +197,7 @@ The Fuseki server is available at `http://localhost:3030/ds`.
 
 #### Example configuration - *ABAC*
 ```bash
-   scg-docker/docker-run.sh --config config/config-local-abac.ttl
+   scg-docker/latest-docker-run.sh --config config/config-local-abac.ttl
 ```
 This runs the server using the configuration file [config-abac-local.ttl](scg-docker/mnt/config/config-abac-local.ttl.
 It specifies an in-memory dataset at `/ds` and that Attribute Based Access Control is enabled.
@@ -208,7 +208,7 @@ It specifies an in-memory dataset at `/ds` and that Attribute Based Access Contr
 #### Example configuration - *Kafka Replay* 
 
 ```bash
-   scg-docker/docker-run.sh --config config/config-replay-abac.ttl
+   scg-docker/latest-docker-run.sh --config config/config-replay-abac.ttl
 ```
 As this suggests, this runs server using the configuration file `config/config-replay-abac.ttl` 
 or [config-replay-abac.ttl](scg-docker/mnt/config/config-replay-abac.ttl) as it's known locally. 
@@ -218,13 +218,20 @@ and running, prior to launch.
 
 The Fuseki server is available at `http://localhost:3030/ds`.
 
-#### More advanced testing - d-run
+#### More advanced testing - docker-run.sh & d-run
+To run the local instance you can use other scripts. You will need `mvn` installed in order to build the code (as described [above](#build)).
+
+You can then run `docker-run.sh` to use the newly built images.
+```bash
+   scg-docker/docker-run.sh
+```
+It uses the same parameters as the latest-docker-run. sh script above.
 
 Alternately, you can use the script `d-run` which will map the relevant config and database directories from the local
 filesystem, pulling down the given image and running it directly (not in `-d` mode). It requires a number of environment
 variables to be set as indicated in the script.   
 
-It can be run with exactly the same configuration as docker-run.sh except with no default configuration if nothing is
+It can be run with exactly the same configuration as latest-docker-run.sh except with no default configuration if nothing is
 provided.
 
 #### Open Telemetry

--- a/scg-docker/docker-run.sh
+++ b/scg-docker/docker-run.sh
@@ -14,7 +14,7 @@ function get_version() {
 
 # Fetch the project and Fuseki versions
 PROJECT_VERSION=$(get_version project.version)
-FUSEKI_SERVER_VERSION=$(get_version ver.fuseki-server)
+FUSEKI_SERVER_VERSION=$(get_version dependency.fuseki-server)
 
 # Check if versions were successfully extracted
 if [[ -z "$PROJECT_VERSION" || -z "$FUSEKI_SERVER_VERSION" ]]; then

--- a/scg-docker/latest-docker-run.sh
+++ b/scg-docker/latest-docker-run.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run the latest Smart Cache Graph image from Docker Hub.
+# Usage:
+#   ./latest-docker-run.sh                 # uses defaults; starts in-memory dataset at /ds
+#   ./latest-docker-run.sh -- --mem /ds    # explicitly pass Fuseki args after --
+#   SCG_IMAGE=telicent/smart-cache-graph:1.2.3 ./latest-docker-run.sh  # override image tag
+#   SCG_PORT=4040 ./latest-docker-run.sh   # change host port
+
+# --- Config (overridable via env) ------------------------------------------
+IMAGE="${SCG_IMAGE:-telicent/smart-cache-graph:latest}"
+CONTAINER_NAME="${SCG_CONTAINER_NAME:-smart-cache-graph-container}"
+HOST_PORT="${SCG_PORT:-3030}"
+
+# Common envs used by your image
+JAVA_OPTIONS="${JAVA_OPTIONS:--Xmx2048m -Xms2048m}"
+JWKS_URL="${JWKS_URL:-disabled}"
+ENABLE_LABELS_QUERY="${ENABLE_LABELS_QUERY:-true}"
+
+# Where to create mounts (same structure as before)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MNT_DIR="${SCRIPT_DIR}/mnt"
+
+# --- Checks ----------------------------------------------------------------
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Error: Docker is required but not installed." >&2
+  exit 1
+fi
+
+# Quick daemon check
+if ! docker info >/dev/null 2>&1; then
+  echo "Error: Docker daemon not running or not accessible." >&2
+  exit 1
+fi
+
+# --- Prepare mounts --------------------------------------------------------
+mkdir -p "${MNT_DIR}/logs" "${MNT_DIR}/databases" "${MNT_DIR}/config"
+
+# --- Choose Fuseki args ----------------------------------------------------
+FUSEKI_ARGS=()
+if [[ "${1:-}" == "--" ]]; then
+  shift
+  FUSEKI_ARGS=("$@")
+else
+  # Default if none provided
+  if [[ $# -eq 0 ]]; then
+    FUSEKI_ARGS=(--mem /ds)
+  else
+    FUSEKI_ARGS=("$@")
+  fi
+fi
+
+# --- Pull image (only updates if needed) -----------------------------------
+echo "Pulling ${IMAGE} ..."
+docker pull "${IMAGE}" >/dev/null
+
+# --- Stop/remove any existing container ------------------------------------
+EXISTING="$(docker ps -aq -f name=^${CONTAINER_NAME}$ || true)"
+if [[ -n "${EXISTING}" ]]; then
+  echo "Stopping and removing existing container ${CONTAINER_NAME} ..."
+  docker stop "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+  docker rm "${CONTAINER_NAME}"  >/dev/null 2>&1 || true
+fi
+
+# --- Run container ---------------------------------------------------------
+echo "Starting ${CONTAINER_NAME} on http://localhost:${HOST_PORT} ..."
+docker run -d \
+  --name "${CONTAINER_NAME}" \
+  -e JAVA_OPTIONS="${JAVA_OPTIONS}" \
+  -e JWKS_URL="${JWKS_URL}" \
+  -e ENABLE_LABELS_QUERY="${ENABLE_LABELS_QUERY}" \
+  -p "${HOST_PORT}:3030" \
+  -v "${MNT_DIR}/logs:/fuseki/logs" \
+  -v "${MNT_DIR}/databases:/fuseki/databases" \
+  -v "${MNT_DIR}/config:/fuseki/config" \
+  "${IMAGE}" "${FUSEKI_ARGS[@]}"
+
+echo "Container '${CONTAINER_NAME}' is up."
+echo "  Open:   http://localhost:${HOST_PORT}"
+echo "  Logs:   docker logs -f ${CONTAINER_NAME}"
+echo "  Stop:   docker stop ${CONTAINER_NAME}"
+echo "  Remove: docker rm ${CONTAINER_NAME}"

--- a/scg-system/src/test/java/io/telicent/core/TestInitialCompaction.java
+++ b/scg-system/src/test/java/io/telicent/core/TestInitialCompaction.java
@@ -97,19 +97,6 @@ public class TestInitialCompaction {
     }
 
     @Test
-    public void test_persistentDataset() {
-        // given
-        mockDatabaseMgr.when(() -> DatabaseMgr.compact(any(), anyBoolean())).thenAnswer(invocationOnMock -> null);
-        mockDatabaseMgr.clearInvocations();
-        String configFile = "config-persistent.ttl";
-        // when
-        server = launchServer(configFile);
-        // then
-        assertNotNull(server.serverURL());
-        mockDatabaseMgr.verify(() -> DatabaseMgr.compact(any(), anyBoolean()), times(1));
-    }
-
-    @Test
     public void test_persistentDataset_sizeSame_ignoredSecondCall() {
         // given
         mockDatabaseMgr.when(() -> DatabaseMgr.compact(any(), anyBoolean())).thenAnswer(invocationOnMock -> null);


### PR DESCRIPTION
I've removed a test that fails in the build due in part to it accidentally passing in the past (due to race conditions) and because of pre-existing configurations locally. 

Long story short - when the server starts up it compacts the jena DB. For obvious performance reasons, we do not carry out the compaction if (a) there is no size difference (b) if the folders don't yet exist. This test predates that and expects it to call compact() on start-up. 