### PR TITLE
Add and enforce Telicent Authorisation Policies (CORE-962)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Smart Cache Graph
 
+## 0.91.0
+
+- Added Telicent Authorization policy support into SCG when authentication is enabled
+    - Authorization policy is dynamically generated for `/<dataset>/<endpoint>` endpoints based upon the registered 
+      Fuseki `Operation`
+    - Appropriate authorization policies for other endpoints, e.g. `/$/backup/*`, is hardcoded
+- Build improvements:
+    - BouncyCastle upgraded to 1.82
+    - JWT Servlet Auth upgraded to 2.0.1
+    - Logback upgraded to 1.5.19
+    - RDF ABAC upgraded to 1.1.0
+    - Smart Caches Core upgraded to 0.30.1
+    - Various build and test dependencies upgraded to latest available
+
 ## 0.90.2
 
 - Picked up updated Fuseki Kafka Connector release that has improvements to event batching behaviour for high lag and

--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ It is a container that consists of:
 - [Fuseki-Kafka bridge](https://github.com/telicent-oss/jena-fuseki-kafka)
     - Please refer to the `README.md` in that repository if you require additional Kafka configuration e.g. for
       Kafka Authentication.
+- JSON Web Token (JWT) based [authentication](#jwks_url)
 - Telicent RDF ABAC data security
-- Telicent GraphQL
+- Telicent [Authorization policies](#authorization-policies)
+- Telicent [GraphQL](https://github.com/telicent-oss/graphql-jena) extensions
 
 ## Example configuration
 
@@ -39,20 +41,80 @@ The URL value is a template including `{user}`. Example: `http://some-host/users
 This specifies the JSON Web Key Set (JWKS) URL to use to obtain the public keys for verifying JSON Web Tokens (JWTs).
 The value "disabled" turns off token verification.
 
+### `USERINFO_URL`
+
+From `0.91.0` onwards configured the User Info lookup URL that is used to exchange the authenticated JWT for a User Info
+response, this is used to help enforce Telicent Authorization policies.  If authentication is [disabled](#jwks_url) then
+this has no effect.
+
+This should be set to the `/userinfo`, or equivalent endpoint, of your OAuth 2/OIDC compatible Identity Provider which
+is issuing the JWTs used to authenticate users to Smart Cache Graph.
+
+### `FEATURE_FLAG_AUTHZ`
+
+From `0.91.0` onwards if set to `false` then disables the Telicent Authorization policy features.  Note that this form
+of Authorization only applies if authentication is [enabled](#jwks_url).
+
+#### Authorization Policies
+
+Since `0.91.0` the Telicent Authorization policy feature enforces that authenticated users require specific roles and
+permissions in order to access different endpoints provided by the server.  With this being determined from both the
+information in the authenticated JWT and by the [User Info](#userinfo_url) obtained from the configured `/userinfo`
+endpoint of the OAuth 2/OIDC compliant identity provider.
+
+All endpoints require either the `USER` or `ADMIN_SYSTEM` roles, and additionally require specific permissions depending
+on the endpoint.
+
+For each dataset configured via the Fuseki configuration file all configured endpoints will have authorization policy
+dynamically defined for them:
+
+- If the endpoint has a known Fuseki `Operation` registered for it then permissions are `api.<dataset>.read` for
+  read-only operations, or `api.<dataset>.read` and `api.<dataset>.write` for read/write operations.
+- The catch all `/<dataset>` endpoint requires both `api.<dataset>.read` and `api.<dataset>.write` permissions since
+  with that endpoint the request is dynamically dispatched to the appropriate endpoint based upon the request method and
+  body.
+- If the operation is unknown no specific policy is applied, internally this causes these endpoints to default to the
+  `DENY_ALL` policy.
+
+Please refer to the `SCG_AuthPolicy` class for what Fuseki `Operation`s are considered read-only, versus read/write.
+
+For other endpoints provided by the various Telicent modules added to Fuseki the endpoints the following policies apply:
+
+| Endpoint               | Roles Required | Permissions Required                                |
+|------------------------|----------------|-----------------------------------------------------|
+| `/$/backups/create`    | `ADMIN_SYSTEM` | `backup.write`                                      |
+| `/$/backups/delete`    | `ADMIN_SYSTEM` | `backup.delete`                                     |
+| `/$/backups/restore`   | `ADMIN_SYSTEM` | `backup.restore`                                    |
+| `/$/backups/*`         | `ADMIN_SYSTEM` | `backup.read`                                       |
+| `/$/compactall`        | `ADMIN_SYSTEM` | `api.<dataset>.compact` for all configured datasets |
+| `/$/compact/<dataset>` | `ADMIN_SYSTEM` | `api.<dataset>.compact`                             |
+| `/$/labels/<dataset>`  | `USER`         | `api.<dataset>.read`                                |
+| `/<dataset>/access/*`  | `USER`         | `api.<dataset>.read`                                |
+
+If your Identity Provider is not able to manage roles and permissions information in a way compatible with Smart Cache
+Graph then you can disable this via the aforementioned [`FEATURE_FLAG_AUTHZ`](#feature_flag_authz) environment variable.
+If you disable this you may wish to limit access to these endpoints via other mechanisms available in your deployment
+environment, e.g. service mesh policy, proxy server rules etc.
+
 ### `ENABLE_LABELS_QUERY`
 
-Setting this to `true` will enable the security label query endpoint at `http://{hostname}/$/labels/{datasetName}`. More information
-about this endpoint can be found in the [API docs](docs/labels-api.yaml). You can also run a Docker container with the
-endpoint enabled which can be accessed from the API docs by running:
+Setting this to `true` will enable the security label query endpoint at `http://{hostname}/$/labels/{datasetName}`. More
+information about this endpoint can be found in the [API docs](docs/labels-api.yaml). You can also run a Docker
+container with the endpoint enabled which can be accessed from the API docs by running:
+
 ```commandline
 scg-docker/docker-run.sh --config config/config-labels-query-test.ttl
 ```
+
 To populate this instance with sample security labelled data you can run:
+
 ```commandline
 curl --location 'http://localhost:3030/securedDataset1/upload' --header 'Security-Label: !' --header 'Content-Type: application/trig' --data-binary '@scg-system/src/test/files/sample-data-labelled-1.trig'
 curl --location 'http://localhost:3030/securedDataset2/upload' --header 'Security-Label: !' --header 'Content-Type: application/trig' --data-binary '@scg-system/src/test/files/sample-data-labelled-2.trig'
 ```
+
 You can then query these endpoints for label data, e.g. for `securedDataset1`:
+
 ```commandline
 curl --location 'http://localhost:3030/$/labels/securedDataset1' \
 --header 'Content-Type: application/json' \
@@ -69,7 +131,9 @@ curl --location 'http://localhost:3030/$/labels/securedDataset1' \
     ]
 }'
 ```
+
 Which should return the following:
+
 ```json
 {
     "results": [
@@ -84,7 +148,9 @@ Which should return the following:
     ]
 }
 ```
+
 Or to query `securedDataset2`:
+
 ```commandline
 curl --location 'http://localhost:3030/$/labels/securedDataset2' \
 --header 'Content-Type: application/json' \
@@ -102,7 +168,9 @@ curl --location 'http://localhost:3030/$/labels/securedDataset2' \
     ]
 }'
 ```
+
 Which should return the following:
+
 ```json
 {
     "results": [
@@ -118,6 +186,7 @@ Which should return the following:
     ]
 }
 ```
+
 ## Build
 
 Building Smart Cache Graph is a two-step process.
@@ -178,10 +247,10 @@ and configuration files go into host `mnt/config/`.
 
 ### Try it out! 
 
-The provided script, [latest-docker-run.sh](scg-docker/latest-docker-run.sh), runs the latest published image of SCG in a docker container, with the contents of the
-local [mnt/config](scg-docker/mnt/config) directory mounted into the newly generated docker image for ease of use.
-Similarly, the [mnt/databases](scg-docker/mnt/databases) and [mnt/logs](scg-docker/mnt/logs) are mounted for easier
-analysis.
+The provided script, [latest-docker-run.sh](scg-docker/latest-docker-run.sh), runs the latest published image of SCG in
+a docker container, with the contents of the local [mnt/config](scg-docker/mnt/config) directory mounted into the newly
+generated docker image for ease of use. Similarly, the [mnt/databases](scg-docker/mnt/databases) and
+[mnt/logs](scg-docker/mnt/logs) are mounted for easier analysis.
 
 #### Example configuration - *Default*
 
@@ -219,7 +288,8 @@ and running, prior to launch.
 The Fuseki server is available at `http://localhost:3030/ds`.
 
 #### More advanced testing - docker-run.sh & d-run
-To run the local instance you can use other scripts. You will need `mvn` installed in order to build the code (as described [above](#build)).
+To run the local instance you can use other scripts. You will need `mvn` installed in order to build the code (as
+described [above](#build)).
 
 You can then run `docker-run.sh` to use the newly built images.
 ```bash
@@ -231,8 +301,8 @@ Alternately, you can use the script `d-run` which will map the relevant config a
 filesystem, pulling down the given image and running it directly (not in `-d` mode). It requires a number of environment
 variables to be set as indicated in the script.   
 
-It can be run with exactly the same configuration as latest-docker-run.sh except with no default configuration if nothing is
-provided.
+It can be run with exactly the same configuration as latest-docker-run.sh except with no default configuration if
+nothing is provided.
 
 #### Open Telemetry
 

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <dependency.fuseki-server>${dependency.jena}</dependency.fuseki-server>
     <dependency.graphql>0.10.6</dependency.graphql>
     <dependency.jwt-servlet-auth>2.0.1</dependency.jwt-servlet-auth>
-    <dependency.smart-caches-core>0.30.0</dependency.smart-caches-core>
+    <dependency.smart-caches-core>0.30.0-SNAPSHOT</dependency.smart-caches-core>
 
     <!-- External dependencies -->
     <dependency.jackson>2.20.0</dependency.jackson>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
 
     <!-- Dependency versions -->
     <!-- Internal dependencies -->
-    <dependency.rdf-abac>1.0.2</dependency.rdf-abac>
+    <dependency.rdf-abac>1.1.0</dependency.rdf-abac>
     <dependency.fuseki-kafka>2.1.0</dependency.fuseki-kafka>
     <dependency.jena>5.5.0</dependency.jena>
     <dependency.fuseki-server>${dependency.jena}</dependency.fuseki-server>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <dependency.fuseki-server>${dependency.jena}</dependency.fuseki-server>
     <dependency.graphql>0.10.6</dependency.graphql>
     <dependency.jwt-servlet-auth>2.0.1</dependency.jwt-servlet-auth>
-    <dependency.smart-caches-core>0.30.1-SNAPSHOT</dependency.smart-caches-core>
+    <dependency.smart-caches-core>0.30.1</dependency.smart-caches-core>
 
     <!-- External dependencies -->
     <dependency.jackson>2.20.0</dependency.jackson>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <groupId>io.telicent.smart-caches.graph</groupId>
   <artifactId>scg-base</artifactId>
   <packaging>pom</packaging>
-  <version>0.90.3-SNAPSHOT</version>
+  <version>0.91.0-SNAPSHOT</version>
 
   <name>Telicent Smart Cache Graph - Parent</name>
   <description>Telicent Smart Cache Graph</description>
@@ -56,7 +56,7 @@
   <properties>
     <!-- Build properties -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.build.outputTimestamp>2025-09-22T08:43:04Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2025-10-08T12:51:42Z</project.build.outputTimestamp>
     <java.version>21</java.version>
 
     <!-- Maven Plugin versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <dependency.fuseki-server>${dependency.jena}</dependency.fuseki-server>
     <dependency.graphql>0.10.6</dependency.graphql>
     <dependency.jwt-servlet-auth>2.0.1</dependency.jwt-servlet-auth>
-    <dependency.smart-caches-core>0.30.0-SNAPSHOT</dependency.smart-caches-core>
+    <dependency.smart-caches-core>0.30.1-SNAPSHOT</dependency.smart-caches-core>
 
     <!-- External dependencies -->
     <dependency.jackson>2.20.0</dependency.jackson>

--- a/scg-benchmark/pom.xml
+++ b/scg-benchmark/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.telicent.smart-caches.graph</groupId>
         <artifactId>scg-base</artifactId>
-        <version>0.90.3-SNAPSHOT</version>
+        <version>0.91.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>scg-benchmark</artifactId>

--- a/scg-docker/pom.xml
+++ b/scg-docker/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>io.telicent.smart-caches.graph</groupId>
     <artifactId>scg-base</artifactId>
-    <version>0.90.3-SNAPSHOT</version>
+    <version>0.91.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/scg-server/pom.xml
+++ b/scg-server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.telicent.smart-caches.graph</groupId>
     <artifactId>scg-base</artifactId>
-    <version>0.90.3-SNAPSHOT</version>
+    <version>0.91.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>io.telicent.smart-caches.graph</groupId>
       <artifactId>scg-system</artifactId>
-      <version>0.90.3-SNAPSHOT</version>
+      <version>0.91.0-SNAPSHOT</version>
     </dependency>
 
   </dependencies>

--- a/scg-system/pom.xml
+++ b/scg-system/pom.xml
@@ -15,360 +15,367 @@
     limitations under the License.
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
-  <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>io.telicent.smart-caches.graph</groupId>
-    <artifactId>scg-base</artifactId>
-    <version>0.90.3-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
-  </parent>
+    <parent>
+        <groupId>io.telicent.smart-caches.graph</groupId>
+        <artifactId>scg-base</artifactId>
+        <version>0.90.3-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
 
-  <artifactId>scg-system</artifactId>
-  <packaging>jar</packaging>
+    <artifactId>scg-system</artifactId>
+    <packaging>jar</packaging>
 
-  <name>Telicent Smart Cache Graph - System</name>
-  <description>System code - plugins, extensions, entrypoints etc. - for Smart Cache Graph</description>
+    <name>Telicent Smart Cache Graph - System</name>
+    <description>System code - plugins, extensions, entrypoints etc. - for Smart Cache Graph</description>
 
-  <dependencies>
+    <dependencies>
 
-    <!-- Internal dependencies -->
+        <!-- Internal dependencies -->
 
-    <dependency>
-      <groupId>org.apache.jena</groupId>
-      <artifactId>jena-arq</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.apache.jena</groupId>
+            <artifactId>jena-arq</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>org.apache.jena</groupId>
-      <artifactId>jena-base</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.apache.jena</groupId>
+            <artifactId>jena-base</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>org.apache.jena</groupId>
-      <artifactId>jena-cmds</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.apache.jena</groupId>
+            <artifactId>jena-cmds</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>org.apache.jena</groupId>
-      <artifactId>jena-core</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.apache.jena</groupId>
+            <artifactId>jena-core</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>org.apache.jena</groupId>
-      <artifactId>jena-dboe-base</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.apache.jena</groupId>
+            <artifactId>jena-dboe-base</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>org.apache.jena</groupId>
-      <artifactId>jena-fuseki-core</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.apache.jena</groupId>
+            <artifactId>jena-fuseki-core</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>org.apache.jena</groupId>
-      <artifactId>jena-fuseki-main</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.apache.jena</groupId>
+            <artifactId>jena-fuseki-main</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>org.apache.jena</groupId>
-      <artifactId>jena-rdfpatch</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.apache.jena</groupId>
+            <artifactId>jena-rdfpatch</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>org.apache.jena</groupId>
-      <artifactId>jena-shacl</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.apache.jena</groupId>
+            <artifactId>jena-shacl</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>org.apache.jena</groupId>
-      <artifactId>jena-tdb1</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.apache.jena</groupId>
+            <artifactId>jena-tdb1</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>org.apache.jena</groupId>
-      <artifactId>jena-tdb2</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>org.apache.jena</groupId>
+            <artifactId>jena-tdb2</artifactId>
+        </dependency>
 
-    <!-- ABAC engine -->
-    <dependency>
-      <groupId>io.telicent.jena</groupId>
-      <artifactId>rdf-abac-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.telicent.jena</groupId>
-      <artifactId>rdf-abac-fuseki</artifactId>
-    </dependency>
+        <!-- ABAC engine -->
+        <dependency>
+            <groupId>io.telicent.jena</groupId>
+            <artifactId>rdf-abac-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.telicent.jena</groupId>
+            <artifactId>rdf-abac-fuseki</artifactId>
+        </dependency>
 
-    <!-- Jena Fuseki Kafka -->
-    <dependency>
-      <groupId>io.telicent.jena</groupId>
-      <artifactId>jena-fuseki-kafka-module</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.telicent.jena</groupId>
-      <artifactId>jena-kafka-connector</artifactId>
-    </dependency>
+        <!-- Jena Fuseki Kafka -->
+        <dependency>
+            <groupId>io.telicent.jena</groupId>
+            <artifactId>jena-fuseki-kafka-module</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.telicent.jena</groupId>
+            <artifactId>jena-kafka-connector</artifactId>
+        </dependency>
 
-    <!-- Authentication -->
-    <dependency>
-      <groupId>io.telicent.public</groupId>
-      <artifactId>jwt-servlet-auth-aws</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.telicent.public</groupId>
-      <artifactId>jwt-servlet-auth-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.telicent.public</groupId>
-      <artifactId>jwt-servlet-auth-servlet5</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.telicent.smart-caches</groupId>
-      <artifactId>configurator</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.telicent.smart-caches</groupId>
-      <artifactId>jwt-auth-common</artifactId>
-    </dependency>
-    <!-- GraphQL -->
-    <dependency>
-      <groupId>io.telicent.jena.graphql</groupId>
-      <artifactId>graphql-jena-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.telicent.jena.graphql</groupId>
-      <artifactId>graphql-fuseki-module</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.telicent.jena.graphql</groupId>
-      <artifactId>telicent-graph-schema</artifactId>
-    </dependency>
+        <!-- Authentication -->
+        <dependency>
+            <groupId>io.telicent.public</groupId>
+            <artifactId>jwt-servlet-auth-aws</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.telicent.public</groupId>
+            <artifactId>jwt-servlet-auth-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.telicent.public</groupId>
+            <artifactId>jwt-servlet-auth-servlet5</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.telicent.smart-caches</groupId>
+            <artifactId>configurator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.telicent.smart-caches</groupId>
+            <artifactId>jwt-auth-common</artifactId>
+        </dependency>
+        <!-- GraphQL -->
+        <dependency>
+            <groupId>io.telicent.jena.graphql</groupId>
+            <artifactId>graphql-jena-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.telicent.jena.graphql</groupId>
+            <artifactId>graphql-fuseki-module</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.telicent.jena.graphql</groupId>
+            <artifactId>telicent-graph-schema</artifactId>
+        </dependency>
 
-    <!-- External dependencies -->
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpg-jdk18on</artifactId>
-      <version>${dependency.bouncycastle}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk18on</artifactId>
-      <version>${dependency.bouncycastle}</version>
-    </dependency>
-    <!-- Kafka for Event Sourcing -->
-    <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka-clients</artifactId>
-    </dependency>
+        <!-- External dependencies -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpg-jdk18on</artifactId>
+            <version>${dependency.bouncycastle}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>${dependency.bouncycastle}</version>
+        </dependency>
+        <!-- Kafka for Event Sourcing -->
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+        </dependency>
 
-    <!-- Logging Dependencies -->
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-    </dependency>
+        <!-- Logging Dependencies -->
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
 
-    <!-- OpenTelemetry dependencies -->
-    <dependency>
-      <groupId>io.opentelemetry</groupId>
-      <artifactId>opentelemetry-api</artifactId>
-    </dependency>
+        <!-- OpenTelemetry dependencies -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>io.opentelemetry.javaagent</groupId>
-      <artifactId>opentelemetry-javaagent</artifactId>
-      <scope>runtime</scope>
-    </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.javaagent</groupId>
+            <artifactId>opentelemetry-javaagent</artifactId>
+            <scope>runtime</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>io.opentelemetry</groupId>
-      <artifactId>opentelemetry-semconv</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-semconv</artifactId>
+        </dependency>
 
-    <!-- Testing dependencies -->
-    <dependency>
-      <groupId>io.telicent.public</groupId>
-      <artifactId>jwt-servlet-auth-core</artifactId>
-      <version>${dependency.jwt-servlet-auth}</version>
-      <classifier>tests</classifier>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.checkerframework</groupId>
-          <artifactId>checker-qual</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>uk.org.webcompere</groupId>
-      <artifactId>system-stubs-jupiter</artifactId>
-      <version>2.1.8</version>
-      <scope>test</scope>
-    </dependency>
+        <!-- Testing dependencies -->
+        <dependency>
+            <groupId>io.telicent.public</groupId>
+            <artifactId>jwt-servlet-auth-core</artifactId>
+            <version>${dependency.jwt-servlet-auth}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.checkerframework</groupId>
+                    <artifactId>checker-qual</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>uk.org.webcompere</groupId>
+            <artifactId>system-stubs-jupiter</artifactId>
+            <version>2.1.8</version>
+            <scope>test</scope>
+        </dependency>
 
-    <!-- Open Telemetry - testing -->
-    <dependency>
-      <groupId>io.opentelemetry</groupId>
-      <artifactId>opentelemetry-exporter-logging</artifactId>
-      <scope>test</scope>
-    </dependency>
+        <!-- Open Telemetry - testing -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-logging</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>io.opentelemetry</groupId>
-      <artifactId>opentelemetry-sdk</artifactId>
-      <scope>test</scope>
-    </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>io.opentelemetry</groupId>
-      <artifactId>opentelemetry-sdk-testing</artifactId>
-      <scope>test</scope>
-    </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-    <!-- Logging - testing -->
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j2-impl</artifactId>
-      <scope>test</scope>
-    </dependency>
+        <!-- Logging - testing -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-    <!-- Kafka - testing -->
-    <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>kafka</artifactId>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-compress</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>testcontainers</artifactId>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-compress</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
+        <!-- Kafka - testing -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>kafka</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-compress</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-compress</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
-    <!-- JUnit 5 -->
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <version>${dependency.junit5}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-suite</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-junit-jupiter</artifactId>
-      <scope>test</scope>
-    </dependency>
+        <!-- JUnit 5 -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>${dependency.junit5}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-suite</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${dependency.junit5}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>io.telicent.jena</groupId>
-      <artifactId>jena-fuseki-kafka-module</artifactId>
-      <version>${dependency.fuseki-kafka}</version>
-      <classifier>tests</classifier>
-      <scope>test</scope>
-    </dependency>
+        <dependency>
+            <groupId>io.telicent.jena</groupId>
+            <artifactId>jena-fuseki-kafka-module</artifactId>
+            <version>${dependency.fuseki-kafka}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>io.telicent.public</groupId>
-      <artifactId>fuseki-yaml-config</artifactId>
-    </dependency>
+        <dependency>
+            <groupId>io.telicent.public</groupId>
+            <artifactId>fuseki-yaml-config</artifactId>
+        </dependency>
 
-  </dependencies>
+    </dependencies>
 
-  <build>
-    <plugins>
-      <!--
-            Copy OTel Agent into a specific directory under target/ so developers can configure a run configuration that
-            utilises this
-            -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>copy-otel-agent</id>
-            <goals>
-              <goal>copy-dependencies</goal>
-            </goals>
-            <phase>package</phase>
-            <configuration>
-              <includeGroupIds>io.opentelemetry</includeGroupIds>
-              <includeArtifactIds>opentelemetry-javaagent</includeArtifactIds>
-              <stripVersion>true</stripVersion>
-              <outputDirectory>${project.build.directory}/agents</outputDirectory>
-            </configuration>
-          </execution>
-          <execution>
-            <id>properties</id>
-            <goals>
-              <goal>properties</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-      </plugin>
+    <build>
+        <plugins>
+            <!--
+                  Copy OTel Agent into a specific directory under target/ so developers can configure a run configuration that
+                  utilises this
+                  -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-otel-agent</id>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <includeGroupIds>io.opentelemetry</includeGroupIds>
+                            <includeArtifactIds>opentelemetry-javaagent</includeArtifactIds>
+                            <stripVersion>true</stripVersion>
+                            <outputDirectory>${project.build.directory}/agents</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>properties</id>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-resources-plugin</artifactId>
-      </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+            </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </build>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/scg-system/pom.xml
+++ b/scg-system/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.telicent.smart-caches.graph</groupId>
         <artifactId>scg-base</artifactId>
-        <version>0.90.3-SNAPSHOT</version>
+        <version>0.91.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/scg-system/src/main/java/io/telicent/core/SPARQL_Update_CQRS.java
+++ b/scg-system/src/main/java/io/telicent/core/SPARQL_Update_CQRS.java
@@ -16,7 +16,6 @@
 
 package io.telicent.core;
 
-import static java.lang.String.format;
 import static org.apache.jena.fuseki.server.CounterName.UpdateExecErrors;
 import static org.apache.jena.fuseki.servlets.ActionExecLib.incCounter;
 import static org.apache.jena.fuseki.servlets.SPARQLProtocol.messageForException;

--- a/scg-system/src/main/java/io/telicent/core/SmartCacheGraph.java
+++ b/scg-system/src/main/java/io/telicent/core/SmartCacheGraph.java
@@ -18,6 +18,7 @@ package io.telicent.core;
 
 import io.telicent.access.FMod_AccessQuery;
 import io.telicent.backup.FMod_BackupData;
+import io.telicent.core.auth.FMod_JwtServletAuth;
 import io.telicent.graphql.FMod_TelicentGraphQL;
 import io.telicent.jena.abac.fuseki.FMod_ABAC;
 import io.telicent.labels.FMod_LabelsQuery;

--- a/scg-system/src/main/java/io/telicent/core/auth/FusekiJwtAuthFilter.java
+++ b/scg-system/src/main/java/io/telicent/core/auth/FusekiJwtAuthFilter.java
@@ -1,0 +1,19 @@
+package io.telicent.core.auth;
+
+import io.telicent.servlet.auth.jwt.servlet5.JwtAuthFilter;
+import jakarta.servlet.FilterConfig;
+
+/**
+ * An extension to JWT Servlet Auth library's standard {@link JwtAuthFilter} for Servlet environments with automatic
+ * configuration disabled in the {@link #init(FilterConfig)} method since we handle pre-configuring things in
+ * {@link FMod_JwtServletAuth}
+ */
+final class FusekiJwtAuthFilter extends JwtAuthFilter {
+
+    @Override
+    public void init(FilterConfig filterConfig) {
+        // Do nothing
+        // We explicitly configure the filter at the server setup level so no need to use the default filter
+        // behaviour of trying to automatically configure itself from init parameters
+    }
+}

--- a/scg-system/src/main/java/io/telicent/core/auth/FusekiJwtConfigAdaptor.java
+++ b/scg-system/src/main/java/io/telicent/core/auth/FusekiJwtConfigAdaptor.java
@@ -1,0 +1,32 @@
+package io.telicent.core.auth;
+
+import io.telicent.smart.caches.configuration.auth.TelicentConfigurationAdaptor;
+import org.apache.jena.fuseki.main.FusekiServer;
+
+/**
+ * A configuration adaptor between Fuseki runtime and the Telicent Core's variant of the JWT Servlet Auth library's
+ * automatic configuration mechanism
+ */
+final class FusekiJwtConfigAdaptor extends TelicentConfigurationAdaptor {
+
+    private final FusekiServer.Builder serverBuilder;
+
+    /**
+     * Creates a new configuration adaptor
+     *
+     * @param serverBuilder Fuseki Server builder
+     */
+    public FusekiJwtConfigAdaptor(FusekiServer.Builder serverBuilder) {
+        this.serverBuilder = serverBuilder;
+    }
+
+    @Override
+    public void setAttribute(String attribute, Object value) {
+        this.serverBuilder.addServletAttribute(attribute, value);
+    }
+
+    @Override
+    public Object getAttribute(String attribute) {
+        return this.serverBuilder.getServletAttribute(attribute);
+    }
+}

--- a/scg-system/src/main/java/io/telicent/core/auth/SCG_AuthPolicy.java
+++ b/scg-system/src/main/java/io/telicent/core/auth/SCG_AuthPolicy.java
@@ -1,0 +1,161 @@
+package io.telicent.core.auth;
+
+import io.telicent.core.CQRS;
+import io.telicent.jena.graphql.fuseki.SysGraphQL;
+import io.telicent.servlet.auth.jwt.PathExclusion;
+import io.telicent.smart.caches.configuration.auth.policy.Policy;
+import org.apache.jena.fuseki.Fuseki;
+import org.apache.jena.fuseki.server.DataAccessPoint;
+import org.apache.jena.fuseki.server.Endpoint;
+import org.apache.jena.fuseki.server.Operation;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Helper class for generating authorization policies from a dynamically configured SCG instance
+ */
+public class SCG_AuthPolicy {
+
+    /**
+     * Default roles policy applied to all recognised dataset endpoints
+     */
+    public static final Policy DEFAULT_ROLES = Policy.requireAny("roles", new String[] { "USER", "SUPER_USER" });
+
+    /**
+     * Known Fuseki operations that are read-only operations
+     */
+    public static final Set<Operation> READ_OPERATIONS =
+            Set.of(Operation.Query, Operation.GSP_R, Operation.PREFIXES_R, Operation.Shacl, SysGraphQL.OP_GRAPHQL);
+    /**
+     * Known Fuseki operations that are read/write operations
+     */
+    public static final Set<Operation> READ_WRITE_OPERATIONS =
+            Set.of(Operation.Update, Operation.GSP_RW, Operation.Upload, Operation.Patch,
+                   CQRS.Vocab.operationUpdateCQRS);
+
+    private SCG_AuthPolicy() {
+    }
+
+    public static void addDatasetRolesPolicy(Map<PathExclusion, Policy> policies, DataAccessPoint dap) {
+        addPolicies(policies, dap, SCG_AuthPolicy::rolesPolicyForOperation);
+    }
+
+    public static void addDatasetPermissionsPolicy(Map<PathExclusion, Policy> policies, DataAccessPoint dap) {
+        addPolicies(policies, dap, SCG_AuthPolicy::permissionsPolicyForOperation);
+    }
+
+    private static void addPolicies(Map<PathExclusion, Policy> policies, DataAccessPoint dap,
+                                    PolicyGenerator generator) {
+        String pathPrefix = "/" + dap.getName() + "/";
+        for (Endpoint endpoint : dap.getDataService().getEndpoints()) {
+            Operation op = endpoint.getOperation();
+            String epName = endpoint.getName();
+            Policy policy = null;
+            if (op != null) {
+                policy = generator.generate(dap.getName(), op, epName);
+            }
+
+            if (policy != null) {
+                policies.put(new PathExclusion(pathPrefix + epName), policy);
+                Fuseki.configLog.info("Added policy for {}{}: {}", pathPrefix, epName, policy);
+            }
+        }
+    }
+
+    /**
+     * Helper interface for making policy generation logic reusable for both roles and permissions based policies
+     */
+    @FunctionalInterface
+    private interface PolicyGenerator {
+        /**
+         * Generates a policy
+         *
+         * @param datasetName  Dataset name
+         * @param operation    Operation
+         * @param endpointName Endpoint name
+         * @return Policy
+         */
+        Policy generate(String datasetName, Operation operation, String endpointName);
+    }
+
+    /**
+     * Gets the roles policy for a given operation
+     *
+     * @param datasetName  Dataset name
+     * @param op           Operation
+     * @param endpointName Endpoint name
+     * @return Roles policy
+     */
+    static Policy rolesPolicyForOperation(String datasetName, Operation op, String endpointName) {
+        // If a known read-only or read/write operation then return default roles policy
+        if (READ_OPERATIONS.contains(op) || READ_WRITE_OPERATIONS.contains(op)) {
+            return DEFAULT_ROLES;
+        }
+
+        // Not a recognised operation so default to null policy which will ultimately drop through to whatever the
+        // configured fallback policy is
+        return null;
+    }
+
+    /**
+     * Generates a policy that requires user to hold the {@code api.<dataset>.read} permission
+     *
+     * @param datasetName Dataset name
+     * @return Policy
+     */
+    private static Policy readPermissions(String datasetName) {
+        //@formatter:off
+        return Policy.requireAll("permissions", new String[] {
+                datasetPermission("api.%s.read", datasetName)
+        });
+        //@formatter:on
+    }
+
+    /**
+     * Generates a permission for a dataset
+     *
+     * @param template    Template, should contain a single {@code %s} placeholder
+     * @param datasetName Dataset name to inject into template
+     * @return Dataset permission
+     */
+    private static String datasetPermission(String template, String datasetName) {
+        return String.format(template, datasetName);
+    }
+
+    /**
+     * Generates a policy that requires users to hold both the {@code api.<dataset>.read} and
+     * {@code api.<dataset>.write} permissions
+     *
+     * @param datasetName Dataset name
+     * @return Policy
+     */
+    private static Policy readWritePermissions(String datasetName) {
+        //@formatter:off
+        return Policy.requireAll("permissions", new String[] {
+                datasetPermission("api.%s.read", datasetName),
+                datasetPermission("api.%s.write", datasetName)
+        });
+        //@formatter:on
+    }
+
+    /**
+     * Gets the permissions policy for a given operation
+     *
+     * @param datasetName  Dataset name
+     * @param op           Operation
+     * @param endpointName Endpoint name
+     * @return Permissions policy
+     */
+    static Policy permissionsPolicyForOperation(String datasetName, Operation op, String endpointName) {
+        if (READ_OPERATIONS.contains(op)) {
+            return readPermissions(datasetName);
+        } else if (READ_WRITE_OPERATIONS.contains(op)) {
+            return readWritePermissions(datasetName);
+        }
+
+        // Not a recognised operation so default to null policy which will ultimately drop through to whatever the
+        // configured fallback policy is
+        return null;
+    }
+}

--- a/scg-system/src/main/java/io/telicent/core/auth/SCG_AuthPolicy.java
+++ b/scg-system/src/main/java/io/telicent/core/auth/SCG_AuthPolicy.java
@@ -1,9 +1,12 @@
 package io.telicent.core.auth;
 
 import io.telicent.core.CQRS;
+import io.telicent.jena.abac.fuseki.ServerABAC;
 import io.telicent.jena.graphql.fuseki.SysGraphQL;
 import io.telicent.servlet.auth.jwt.PathExclusion;
 import io.telicent.smart.caches.configuration.auth.policy.Policy;
+import io.telicent.smart.caches.configuration.auth.policy.PolicyKind;
+import org.apache.commons.lang3.Strings;
 import org.apache.jena.fuseki.Fuseki;
 import org.apache.jena.fuseki.server.DataAccessPoint;
 import org.apache.jena.fuseki.server.Endpoint;
@@ -21,33 +24,87 @@ public class SCG_AuthPolicy {
      * Default roles policy applied to all recognised dataset endpoints
      */
     public static final Policy DEFAULT_ROLES = Policy.requireAny("roles", new String[] { "USER", "SUPER_USER" });
+    public static final Policy ADMIN_ROLES = Policy.requireAny("roles", new String[] { "ADMIN_SYSTEM", "SUPER_USER" });
+
+    public static final Policy BACKUP_READ_ONLY = Policy.requireAll("permissions", new String[] { "backup.read" });
+    public static final Policy BACKUP_READ_WRITE =
+            Policy.requireAll("permissions", new String[] { "backup.read", "backup.write" });
+    public static final Policy COMPACT = Policy.requireAll("permissions", new String[] { "compact" });
 
     /**
-     * Known Fuseki operations that are read-only operations
+     * Known Fuseki operations (either Core, or from Telicent modules) that are read-only operations
      */
+    //@formatter:off
     public static final Set<Operation> READ_OPERATIONS =
-            Set.of(Operation.Query, Operation.GSP_R, Operation.PREFIXES_R, Operation.Shacl, SysGraphQL.OP_GRAPHQL);
+            Set.of(Operation.Query,
+                   Operation.GSP_R,
+                   Operation.PREFIXES_R,
+                   Operation.Shacl,
+                   SysGraphQL.OP_GRAPHQL,
+                   ServerABAC.Vocab.operationGetLabels,
+                   ServerABAC.Vocab.operationGSPRLabels,
+                   ServerABAC.Vocab.operationQueryLabels);
+    //@formatter:on
     /**
-     * Known Fuseki operations that are read/write operations
+     * Known Fuseki operations (either Core, or from Telicent modules) that are read/write operations
      */
+    //@formatter:off
     public static final Set<Operation> READ_WRITE_OPERATIONS =
-            Set.of(Operation.Update, Operation.GSP_RW, Operation.Upload, Operation.Patch,
-                   CQRS.Vocab.operationUpdateCQRS);
+            Set.of(Operation.Update,
+                   Operation.GSP_RW,
+                   Operation.Upload,
+                   Operation.Patch,
+                   CQRS.Vocab.operationUpdateCQRS,
+                   ServerABAC.Vocab.operationUploadABAC);
+    //@formatter:on
 
     private SCG_AuthPolicy() {
     }
 
+    /**
+     * Generates the set of roles based authorization policies that should apply to the dataset represented by the given
+     * data access point
+     *
+     * @param policies Policies to populate
+     * @param dap      Data Access Point
+     */
     public static void addDatasetRolesPolicy(Map<PathExclusion, Policy> policies, DataAccessPoint dap) {
+        // Auto-generate policies based on configured endpoint operations
         addPolicies(policies, dap, SCG_AuthPolicy::rolesPolicyForOperation);
+
+        // Also add policy for the custom /<dataset>/access/* endpoints FMod_AccessQuery adds
+        policies.put(new PathExclusion(getPathPrefix(dap) + "access/*"), DEFAULT_ROLES);
+
+        // Labels Query - /$/labels/<dataset>
+        // Default roles
+        String datasetName = Strings.CI.removeStart(dap.getName(), "/");
+        addPolicy(policies, "/$/labels/" + datasetName, DEFAULT_ROLES);
     }
 
+    /**
+     * Generates the set of permissions based authorization policies that should apply to the dataset represented by the
+     * given data access point
+     *
+     * @param policies Policies to populate
+     * @param dap      Data Access Point
+     */
     public static void addDatasetPermissionsPolicy(Map<PathExclusion, Policy> policies, DataAccessPoint dap) {
+        // Auto-generate policies based on configured endpoint operations
         addPolicies(policies, dap, SCG_AuthPolicy::permissionsPolicyForOperation);
+
+        String datasetName = Strings.CI.removeStart(dap.getName(), "/");
+
+        // Also add policy for the custom /<dataset>/access/* endpoints FMod_AccessQuery adds
+        policies.put(new PathExclusion(getPathPrefix(dap) + "access/*"), readPermissions(datasetName));
+
+        // Labels Query - /$/labels/<dataset>
+        // Dataset read permissions
+        addPolicy(policies, "/$/labels/" + datasetName, readPermissions(datasetName));
     }
 
     private static void addPolicies(Map<PathExclusion, Policy> policies, DataAccessPoint dap,
                                     PolicyGenerator generator) {
-        String pathPrefix = "/" + dap.getName() + "/";
+        String pathPrefix = getPathPrefix(dap);
         for (Endpoint endpoint : dap.getDataService().getEndpoints()) {
             Operation op = endpoint.getOperation();
             String epName = endpoint.getName();
@@ -61,6 +118,49 @@ public class SCG_AuthPolicy {
                 Fuseki.configLog.info("Added policy for {}{}: {}", pathPrefix, epName, policy);
             }
         }
+    }
+
+    private static String getPathPrefix(DataAccessPoint dap) {
+        String datasetName = dap.getName();
+        StringBuilder prefix = new StringBuilder();
+        if (!Strings.CI.startsWith(datasetName, "/")) {
+            prefix.append("/");
+        }
+        prefix.append(datasetName);
+        if (!Strings.CI.endsWith(datasetName, "/")) {
+            prefix.append("/");
+        }
+        return prefix.toString();
+    }
+
+    /**
+     * Adds all the policies for static Telicent endpoints that are not dataset specific
+     *
+     * @param roles Roles policies to populate
+     * @param perms Permissions policies to populate
+     */
+    public static void addTelicentEndpointPolicies(Map<PathExclusion, Policy> roles, Map<PathExclusion, Policy> perms) {
+        // NB - Where we are using wildcard policies the * is transformed into a .* in a regular expression, any other
+        //      characters that have significance, e.g. $, need to be escaped which we do by injecting a \ prior to it
+        //      which will be interpreted as an escape sequence when the given path is translated into a regular
+        //      expression
+
+        // Compact All - /$/compactall
+        addPolicy(roles, "/$/compactall", ADMIN_ROLES);
+        addPolicy(perms, "/$/compactall", COMPACT);
+
+        // Backup/Restore - /$/backup/*
+        // All endpoints require an adminstrator role
+        // Endpoints require either backup.read and backup.write permissions as appropriate
+        addPolicy(roles, "/\\$/backup/*", ADMIN_ROLES);
+        addPolicy(perms, "/$/backup/create", BACKUP_READ_WRITE);
+        addPolicy(perms, "/$/backup/restore", BACKUP_READ_WRITE);
+        addPolicy(perms, "/\\$/backup/*", BACKUP_READ_ONLY);
+    }
+
+    private static void addPolicy(Map<PathExclusion, Policy> policies, String path, Policy policy) {
+        PathExclusion key = new PathExclusion(path);
+        policies.put(key, policy);
     }
 
     /**
@@ -120,7 +220,7 @@ public class SCG_AuthPolicy {
      * @return Dataset permission
      */
     private static String datasetPermission(String template, String datasetName) {
-        return String.format(template, datasetName);
+        return String.format(template, Strings.CI.removeStart(datasetName, "/"));
     }
 
     /**

--- a/scg-system/src/main/java/io/telicent/core/auth/SCG_AuthPolicy.java
+++ b/scg-system/src/main/java/io/telicent/core/auth/SCG_AuthPolicy.java
@@ -1,6 +1,5 @@
 package io.telicent.core.auth;
 
-import com.google.common.collect.Streams;
 import io.telicent.core.CQRS;
 import io.telicent.jena.abac.fuseki.ServerABAC;
 import io.telicent.jena.graphql.fuseki.SysGraphQL;
@@ -14,9 +13,7 @@ import org.apache.jena.fuseki.server.DataAccessPoint;
 import org.apache.jena.fuseki.server.Endpoint;
 import org.apache.jena.fuseki.server.Operation;
 
-import java.util.Arrays;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -27,12 +24,26 @@ public class SCG_AuthPolicy {
     /**
      * Default roles policy applied to all recognised dataset endpoints
      */
-    public static final Policy DEFAULT_ROLES = Policy.requireAny("roles", new String[] { TelicentRoles.USER });
-    public static final Policy ADMIN_ROLES = Policy.requireAny("roles", new String[] { TelicentRoles.ADMIN_SYSTEM });
-
+    public static final Policy DEFAULT_ROLES = Policy.requireAny("roles", TelicentRoles.USER, TelicentRoles.ADMIN_SYSTEM);
+    /**
+     * Admin roles policy applied to admin only endpoints
+     */
+    public static final Policy ADMIN_ROLES = Policy.requireAny("roles", TelicentRoles.ADMIN_SYSTEM);
+    /**
+     * Permissions policy for backup related read-only endpoints
+     */
     public static final Policy BACKUP_READ_ONLY = Policy.requireAll("permissions", TelicentPermissions.Backup.READ);
+    /**
+     * Permissions policy for backup creation endpoint
+     */
     public static final Policy BACKUP_CREATE = Policy.requireAll("permissions", TelicentPermissions.Backup.WRITE);
+    /**
+     * Permissions policy for backup restore endpoint
+     */
     public static final Policy BACKUP_RESTORE = Policy.requireAll("permissions", TelicentPermissions.Backup.RESTORE);
+    /**
+     * Permissions policy for backup delete endpoint
+     */
     public static final Policy BACKUP_DELETE = Policy.requireAll("permissions", TelicentPermissions.Backup.DELETE);
 
     /**

--- a/scg-system/src/main/java/io/telicent/core/auth/ServletAuthorizationContext.java
+++ b/scg-system/src/main/java/io/telicent/core/auth/ServletAuthorizationContext.java
@@ -1,0 +1,11 @@
+package io.telicent.core.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Record class for holding request context for authorization decisions
+ *
+ * @param request HTTP Request
+ */
+public record ServletAuthorizationContext(HttpServletRequest request) {
+}

--- a/scg-system/src/main/java/io/telicent/core/auth/ServletAuthorizationEngine.java
+++ b/scg-system/src/main/java/io/telicent/core/auth/ServletAuthorizationEngine.java
@@ -1,0 +1,97 @@
+package io.telicent.core.auth;
+
+import io.telicent.servlet.auth.jwt.PathExclusion;
+import io.telicent.servlet.auth.jwt.servlet5.AuthenticatedHttpServletRequest;
+import io.telicent.smart.caches.configuration.auth.UserInfo;
+import io.telicent.smart.caches.configuration.auth.policy.Policy;
+import io.telicent.smart.caches.server.auth.roles.TelicentAuthorizationEngine;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+class ServletAuthorizationEngine extends TelicentAuthorizationEngine<ServletAuthorizationContext> {
+    private final Map<PathExclusion, Policy> rolesPolicies, permissionsPolicies;
+    private final Policy rolesFallback, permissionsFallback;
+
+    /**
+     * Creates a new authorization engine
+     *
+     * @param rolesPolicies       Roles policy mappings
+     * @param permissionsPolicies Permissions policy mappings
+     * @param rolesFallback       Fallback roles policy, {@link Policy#ALLOW_ALL} if not set
+     * @param permissionsFallback Fallback permissions policy, {@link Policy#ALLOW_ALL} if not set
+     */
+    ServletAuthorizationEngine(Map<PathExclusion, Policy> rolesPolicies, Map<PathExclusion, Policy> permissionsPolicies,
+                               Policy rolesFallback, Policy permissionsFallback) {
+        this.rolesPolicies = new LinkedHashMap<>(Objects.requireNonNull(rolesPolicies, "rolesPolicies"));
+        this.permissionsPolicies =
+                new LinkedHashMap<>(Objects.requireNonNull(permissionsPolicies, "permissionsPolicies"));
+        this.rolesFallback = Objects.requireNonNullElse(rolesFallback, Policy.ALLOW_ALL);
+        this.permissionsFallback = Objects.requireNonNullElse(permissionsFallback, Policy.ALLOW_ALL);
+    }
+
+    @Override
+    protected boolean isAuthenticated(ServletAuthorizationContext context) {
+        // If the request was authenticated by the FusekiJwtAuthFilter then it will have the JWT Servlet Auth libraries
+        // wrapper around the request
+        return context.request() instanceof AuthenticatedHttpServletRequest;
+    }
+
+    @Override
+    protected boolean isValidPath(ServletAuthorizationContext servletAuthorizationContext) {
+        // In the context of SCG which is a pure Servlet application that has its own custom request dispatch mechanisms
+        // we don't know in advance whether a request is to a valid path or not.  Therefore, just have to assume the
+        // path is valid and apply authorization regardless of requested path.
+        //
+        // NB - Anything that was excluded from authentication would not pass the isAuthenticated() check so won't be
+        //      checked for authorization regardless
+        return true;
+    }
+
+    @Override
+    protected Policy getRolesPolicy(ServletAuthorizationContext context) {
+        return findPolicy(context, rolesPolicies, this.rolesFallback);
+    }
+
+    private Policy findPolicy(ServletAuthorizationContext context, Map<PathExclusion, Policy> policies,
+                              Policy fallback) {
+        String path = getEffectiveRequestPath(context);
+
+        for (Map.Entry<PathExclusion, Policy> entry : policies.entrySet()) {
+            if (entry.getKey().matches(path)) {
+                return entry.getValue();
+            }
+        }
+        return fallback;
+    }
+
+    private static String getEffectiveRequestPath(ServletAuthorizationContext context) {
+        // NB - Due to how Fuseki dispatches requests there are Servlet's that handle general path patterns which then
+        //      call into Fuseki's custom dispatch mechanism.  So the effective path for a request which we use for
+        //      matching our authorization policy is the servlet path plus the path info
+        return context.request().getServletPath() + (StringUtils.isNotBlank(context.request().getPathInfo()) ?
+                                                     context.request().getPathInfo() : "");
+    }
+
+    @Override
+    protected Policy getPermissionsPolicy(ServletAuthorizationContext context) {
+        return findPolicy(context, permissionsPolicies, this.permissionsFallback);
+    }
+
+    @Override
+    protected boolean isUserInRole(ServletAuthorizationContext context, String role) {
+        return context.request().isUserInRole(role);
+    }
+
+    @Override
+    protected boolean hasPermission(ServletAuthorizationContext context, String permission) {
+        UserInfo userInfo = (UserInfo) context.request().getAttribute(UserInfo.class.getCanonicalName());
+        if (userInfo == null) {
+            return false;
+        } else {
+            return userInfo.getPermissions().contains(permission);
+        }
+    }
+}

--- a/scg-system/src/main/java/io/telicent/core/auth/ServletAuthorizationEngine.java
+++ b/scg-system/src/main/java/io/telicent/core/auth/ServletAuthorizationEngine.java
@@ -11,6 +11,14 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
+/**
+ * A Servlet runtime specific implementation of the {@link TelicentAuthorizationEngine}
+ * <p>
+ * The authorization policies <strong>MUST</strong> be predefined when constructing the engine, see
+ * {@link SCG_AuthPolicy} for static helpers for generating policy automatically from Fuseki configuration and known
+ * static Telicent endpoints
+ * </p>
+ */
 class ServletAuthorizationEngine extends TelicentAuthorizationEngine<ServletAuthorizationContext> {
     private final Map<PathExclusion, Policy> rolesPolicies, permissionsPolicies;
     private final Policy rolesFallback, permissionsFallback;
@@ -44,6 +52,8 @@ class ServletAuthorizationEngine extends TelicentAuthorizationEngine<ServletAuth
         // In the context of SCG which is a pure Servlet application that has its own custom request dispatch mechanisms
         // we don't know in advance whether a request is to a valid path or not.  Therefore, just have to assume the
         // path is valid and apply authorization regardless of requested path.
+        // Since our fallback policy is DENY_ALL in real deployments anything that goes to an unexpected path would be
+        // rejected as unauthorized anyway.
         //
         // NB - Anything that was excluded from authentication would not pass the isAuthenticated() check so won't be
         //      checked for authorization regardless

--- a/scg-system/src/main/java/io/telicent/core/auth/ServletAuthorizationEngine.java
+++ b/scg-system/src/main/java/io/telicent/core/auth/ServletAuthorizationEngine.java
@@ -28,16 +28,16 @@ class ServletAuthorizationEngine extends TelicentAuthorizationEngine<ServletAuth
      *
      * @param rolesPolicies       Roles policy mappings
      * @param permissionsPolicies Permissions policy mappings
-     * @param rolesFallback       Fallback roles policy, {@link Policy#ALLOW_ALL} if not set
-     * @param permissionsFallback Fallback permissions policy, {@link Policy#ALLOW_ALL} if not set
+     * @param rolesFallback       Fallback roles policy, {@link Policy#DENY_ALL} if not set
+     * @param permissionsFallback Fallback permissions policy, {@link Policy#DENY_ALL} if not set
      */
     ServletAuthorizationEngine(Map<PathExclusion, Policy> rolesPolicies, Map<PathExclusion, Policy> permissionsPolicies,
                                Policy rolesFallback, Policy permissionsFallback) {
         this.rolesPolicies = new LinkedHashMap<>(Objects.requireNonNull(rolesPolicies, "rolesPolicies"));
         this.permissionsPolicies =
                 new LinkedHashMap<>(Objects.requireNonNull(permissionsPolicies, "permissionsPolicies"));
-        this.rolesFallback = Objects.requireNonNullElse(rolesFallback, Policy.ALLOW_ALL);
-        this.permissionsFallback = Objects.requireNonNullElse(permissionsFallback, Policy.ALLOW_ALL);
+        this.rolesFallback = Objects.requireNonNullElse(rolesFallback, Policy.DENY_ALL);
+        this.permissionsFallback = Objects.requireNonNullElse(permissionsFallback, Policy.DENY_ALL);
     }
 
     @Override

--- a/scg-system/src/main/java/io/telicent/core/auth/TelicentAuthorizationFilter.java
+++ b/scg-system/src/main/java/io/telicent/core/auth/TelicentAuthorizationFilter.java
@@ -1,6 +1,7 @@
 package io.telicent.core.auth;
 
 import io.telicent.smart.caches.server.auth.roles.AuthorizationResult;
+import io.telicent.smart.caches.server.auth.roles.TelicentAuthorizationEngine;
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -18,17 +19,6 @@ import java.util.Objects;
 final class TelicentAuthorizationFilter implements Filter {
     private static final Logger LOGGER = LoggerFactory.getLogger(TelicentAuthorizationFilter.class);
 
-    private final ServletAuthorizationEngine authorizationEngine;
-
-    /**
-     * Creates a new authorization filter
-     *
-     * @param authorizationEngine Authorization engine that makes authorization decisions
-     */
-    TelicentAuthorizationFilter(ServletAuthorizationEngine authorizationEngine) {
-        this.authorizationEngine = Objects.requireNonNull(authorizationEngine);
-    }
-
     @Override
     public void init(FilterConfig filterConfig) {
         // No init required, initialised via constructor parameters
@@ -37,16 +27,25 @@ final class TelicentAuthorizationFilter implements Filter {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException,
             ServletException {
-        ServletAuthorizationContext context = new ServletAuthorizationContext((HttpServletRequest) request);
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
         HttpServletResponse httpResponse = (HttpServletResponse) response;
-        AuthorizationResult result = this.authorizationEngine.authorize(context);
+
+        // Check that the authorization engine was configured
+        ServletAuthorizationEngine authorizationEngine = (ServletAuthorizationEngine) request.getServletContext().getAttribute(
+                TelicentAuthorizationEngine.class.getCanonicalName());
+        if (authorizationEngine == null) {
+            unauthorized(httpResponse, "Authorization enabled but no Authorization Engine was configured");
+            return;
+        }
+
+        ServletAuthorizationContext context = new ServletAuthorizationContext(httpRequest);
+        AuthorizationResult result = authorizationEngine.authorize(context);
         String allReasons = StringUtils.join(result.reasons(), ", ");
         switch (result.status()) {
             case DENIED:
                 // Send a 401 Unauthorized
                 LOGGER.warn("Request to {} rejected: {}", context.request().getRequestURI(), allReasons);
-                httpResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                httpResponse.getWriter().write("Rejected due to servers authorization policy: " + allReasons);
+                unauthorized(httpResponse, "Rejected due to servers authorization policy: " + allReasons);
                 break;
             case ALLOWED:
                 // Success, pass request onwards
@@ -62,10 +61,15 @@ final class TelicentAuthorizationFilter implements Filter {
                 LOGGER.warn(
                         "Request to {} rejected due to authorization engine returning unexpected authorization status: {}",
                         context.request().getRequestURI(), result.status());
-                httpResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                httpResponse.getWriter().write("Rejected due to unknown authorization status: " + result.status());
+                unauthorized(httpResponse, "Rejected due to unknown authorization status: " + result.status());
                 break;
         }
+    }
+
+    private static void unauthorized(HttpServletResponse httpResponse, String message) throws IOException {
+        httpResponse.setContentType("text/plain");
+        httpResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        httpResponse.getWriter().write(message);
     }
 
 }

--- a/scg-system/src/main/java/io/telicent/core/auth/TelicentAuthorizationFilter.java
+++ b/scg-system/src/main/java/io/telicent/core/auth/TelicentAuthorizationFilter.java
@@ -10,8 +10,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.util.Objects;
 
 /**
  * A filter that applies Telicent's roles and permissions based authorization policies
@@ -40,16 +38,17 @@ final class TelicentAuthorizationFilter implements Filter {
 
         ServletAuthorizationContext context = new ServletAuthorizationContext(httpRequest);
         AuthorizationResult result = authorizationEngine.authorize(context);
-        String allReasons = StringUtils.join(result.reasons(), ", ");
+        String clientReasons = StringUtils.join(result.reasons(), ", ");
+        String loggingReasons = StringUtils.join(result.loggingReasons(), ", ");
         switch (result.status()) {
             case DENIED:
                 // Send a 401 Unauthorized
-                LOGGER.warn("Request to {} rejected: {}", context.request().getRequestURI(), allReasons);
-                unauthorized(httpResponse, "Rejected due to servers authorization policy: " + allReasons);
+                LOGGER.warn("Request to {} rejected: {}", context.request().getRequestURI(), loggingReasons);
+                unauthorized(httpResponse, "Rejected due to servers authorization policy: " + clientReasons);
                 break;
             case ALLOWED:
                 // Success, pass request onwards
-                LOGGER.info("Request to {} successfully authorized: {}", context.request().getRequestURI(), allReasons);
+                LOGGER.info("Request to {} successfully authorized: {}", context.request().getRequestURI(), loggingReasons);
                 chain.doFilter(request, response);
                 break;
             case NOT_APPLICABLE:

--- a/scg-system/src/main/java/io/telicent/core/auth/TelicentAuthorizationFilter.java
+++ b/scg-system/src/main/java/io/telicent/core/auth/TelicentAuthorizationFilter.java
@@ -1,0 +1,71 @@
+package io.telicent.core.auth;
+
+import io.telicent.smart.caches.server.auth.roles.AuthorizationResult;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Objects;
+
+/**
+ * A filter that applies Telicent's roles and permissions based authorization policies
+ */
+final class TelicentAuthorizationFilter implements Filter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TelicentAuthorizationFilter.class);
+
+    private final ServletAuthorizationEngine authorizationEngine;
+
+    /**
+     * Creates a new authorization filter
+     *
+     * @param authorizationEngine Authorization engine that makes authorization decisions
+     */
+    TelicentAuthorizationFilter(ServletAuthorizationEngine authorizationEngine) {
+        this.authorizationEngine = Objects.requireNonNull(authorizationEngine);
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) {
+        // No init required, initialised via constructor parameters
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException,
+            ServletException {
+        ServletAuthorizationContext context = new ServletAuthorizationContext((HttpServletRequest) request);
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+        AuthorizationResult result = this.authorizationEngine.authorize(context);
+        String allReasons = StringUtils.join(result.reasons(), ", ");
+        switch (result.status()) {
+            case DENIED:
+                // Send a 401 Unauthorized
+                LOGGER.warn("Request to {} rejected: {}", context.request().getRequestURI(), allReasons);
+                httpResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                httpResponse.getWriter().write("Rejected due to servers authorization policy: " + allReasons);
+                break;
+            case ALLOWED:
+                // Success, pass request onwards
+                LOGGER.info("Request to {} successfully authorized: {}", context.request().getRequestURI(), allReasons);
+                chain.doFilter(request, response);
+                break;
+            case NOT_APPLICABLE:
+                // Not applicable, pass request onwards
+                chain.doFilter(request, response);
+                break;
+            default:
+                // Unexpected authorization status, fail-safe by rejecting the request
+                LOGGER.warn(
+                        "Request to {} rejected due to authorization engine returning unexpected authorization status: {}",
+                        context.request().getRequestURI(), result.status());
+                httpResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                httpResponse.getWriter().write("Rejected due to unknown authorization status: " + result.status());
+                break;
+        }
+    }
+
+}

--- a/scg-system/src/main/java/io/telicent/core/auth/UserInfoFilter.java
+++ b/scg-system/src/main/java/io/telicent/core/auth/UserInfoFilter.java
@@ -1,0 +1,58 @@
+package io.telicent.core.auth;
+
+import io.telicent.servlet.auth.jwt.JwtServletConstants;
+import io.telicent.smart.caches.configuration.auth.UserInfo;
+import io.telicent.smart.caches.configuration.auth.UserInfoLookup;
+import io.telicent.smart.caches.configuration.auth.UserInfoLookupException;
+import jakarta.servlet.*;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * A request filter that augments authenticated requests with {@link UserInfo} for use by subsequent filters e.g.
+ * {@link TelicentAuthorizationFilter}
+ */
+final class UserInfoFilter implements Filter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(UserInfoFilter.class);
+
+    private final UserInfoLookup userInfoLookup;
+
+    /**
+     * Creates a new filter
+     *
+     * @param userInfoLookup The {@link UserInfoLookup} to use to obtain User Info for authenticated users
+     */
+    public UserInfoFilter(UserInfoLookup userInfoLookup) {
+        this.userInfoLookup = Objects.requireNonNull(userInfoLookup);
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException,
+            ServletException {
+        // If this is an authenticated request then augment it with User Info (if available)
+        String jwt = (String) request.getAttribute(JwtServletConstants.REQUEST_ATTRIBUTE_RAW_JWT);
+        if (StringUtils.isNotBlank(jwt)) {
+            try {
+                UserInfo userInfo = this.userInfoLookup.lookup(jwt);
+                request.setAttribute(UserInfo.class.getCanonicalName(), userInfo);
+            } catch (UserInfoLookupException e) {
+                LOGGER.warn("Failed to obtain User Info: {}", e.getMessage());
+            }
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    @Override
+    public void destroy() {
+        try {
+            this.userInfoLookup.close();
+        } catch (Throwable t) {
+            LOGGER.warn("Failed to close UserInfoLookup: {}", t.getMessage());
+        }
+    }
+}

--- a/scg-system/src/main/java/io/telicent/core/auth/UserInfoFilter.java
+++ b/scg-system/src/main/java/io/telicent/core/auth/UserInfoFilter.java
@@ -1,15 +1,24 @@
 package io.telicent.core.auth;
 
+import io.telicent.jena.abac.AttributeValueSet;
+import io.telicent.jena.abac.attributes.AttributeValue;
+import io.telicent.jena.abac.attributes.ValueTerm;
+import io.telicent.jena.abac.core.AttributesStoreAuthServer;
+import io.telicent.jena.abac.fuseki.server.UserInfoEnrichmentFilter;
 import io.telicent.servlet.auth.jwt.JwtServletConstants;
 import io.telicent.smart.caches.configuration.auth.UserInfo;
 import io.telicent.smart.caches.configuration.auth.UserInfoLookup;
 import io.telicent.smart.caches.configuration.auth.UserInfoLookupException;
 import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -36,15 +45,67 @@ final class UserInfoFilter implements Filter {
         // If this is an authenticated request then augment it with User Info (if available)
         String jwt = (String) request.getAttribute(JwtServletConstants.REQUEST_ATTRIBUTE_RAW_JWT);
         if (StringUtils.isNotBlank(jwt)) {
+            // Also deal with the RDF-ABAC integration here, need to set the user so that the RDF-ABAC layer has the
+            // username, and user info, if available
+            // This is kinda clumsy but for now we're stuck with the API that RDF-ABAC gives us so have to jump through
+            // some hoops to make things work properly without creating circular dependencies between Smart Caches Core
+            // and RDF-ABAC
+            HttpServletRequest httpRequest = (HttpServletRequest) request;
+            AttributesStoreAuthServer.addIdAndUserName(jwt, httpRequest.getRemoteUser());
+            request.setAttribute(UserInfoEnrichmentFilter.ATTR_ABAC_USERNAME, httpRequest.getRemoteUser());
+
             try {
+                // Obtain the actual User Info, convert the attributes to an RDF-ABAC AttributeValueSet and make those
+                // available later
                 UserInfo userInfo = this.userInfoLookup.lookup(jwt);
                 request.setAttribute(UserInfo.class.getCanonicalName(), userInfo);
+                AttributesStoreAuthServer.addUserNameAndAttributes(httpRequest.getRemoteUser(), toAttributeValueSet(
+                        userInfo.getAttributes()));
             } catch (UserInfoLookupException e) {
                 LOGGER.warn("Failed to obtain User Info: {}", e.getMessage());
             }
         }
 
         chain.doFilter(request, response);
+    }
+
+    /**
+     * Converts users raw attributes into RDF-ABAC compatible attributes
+     *
+     * @param attributes Raw attributes
+     * @return RDF-ABAC Attribute Value set
+     */
+    private AttributeValueSet toAttributeValueSet(Map<String, Object> attributes) {
+        List<AttributeValue> attrs = new ArrayList<>();
+        convertMapToAttributes(attrs, "", attributes);
+        return AttributeValueSet.of(attrs);
+    }
+
+    private static void convertMapToAttributes(List<AttributeValue> attrs, String prefix,
+                                               Map<String, Object> map) {
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            convertValue(attrs, prefix + entry.getKey(), entry.getValue());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void convertValue(List<AttributeValue> attrs, String key, Object value) {
+        switch (value) {
+            case String strValue -> attrs.add(AttributeValue.of(key, ValueTerm.value(strValue)));
+            case Number numberValue -> attrs.add(AttributeValue.of(key, ValueTerm.value(numberValue.toString())));
+            case Boolean boolValue -> attrs.add(AttributeValue.of(key, ValueTerm.value(boolValue)));
+            case List<?> list -> {
+                List<Object> values = (List<Object>) list;
+                for (Object v : values) {
+                    convertValue(attrs, key, v);
+                }
+            }
+            case Map<?, ?> map -> {
+                Map<String, Object> values = (Map<String, Object>) map;
+                convertMapToAttributes(attrs, key, values);
+            }
+            default -> LOGGER.warn("Unsupported value type for attribute {} ignored: {}", key, value.getClass());
+        }
     }
 
     @Override

--- a/scg-system/src/test/java/io/telicent/LibTestsSCG.java
+++ b/scg-system/src/test/java/io/telicent/LibTestsSCG.java
@@ -16,6 +16,7 @@
 
 package io.telicent;
 
+import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -70,8 +71,9 @@ public class LibTestsSCG {
     }
 
     public static void uploadFile(String URL, String filename) {
+        String dsName = URL.split("/")[3];
         DSP.service(URL)
-           .httpHeader(tokenHeader(), tokenHeaderValue(tokenForUser("admin")))
+           .httpHeader(tokenHeader(), tokenHeaderValue(tokenForUser("admin", dsName)))
            .POST(filename);
     }
 
@@ -98,12 +100,29 @@ public class LibTestsSCG {
      * @return Signed JWT compacted into the Base64 representation per the JWT specifications
      */
     public static String tokenForUser(String user) {
+        return tokenForUser(user, "ds");
+    }
+
+    public static String tokenForUser(String user, String datasetName) {
         String keyId = MOCK_KEY_SERVER.selectKeyId();
+        //@formatter:off
         return Jwts.builder()
                    .header().keyId(keyId).and()
                    .claim("email", user)
+                   // Basic roles and permissions
+                   .claim("roles",
+                          List.of("USER", "ADMIN_SYSTEM")
+                   )
+                   .claim("permissions",
+                          List.of("api." + datasetName + ".read",
+                                  "api." + datasetName + ".write",
+                                  "backup.read",
+                                  "backup.write",
+                                  "compact")
+                   )
                    .signWith(MOCK_KEY_SERVER.getPrivateKey(keyId))
                    .compact();
+        //@formatter:on
     }
 
     public static JwtBuilder tokenBuilder(String user) {
@@ -168,13 +187,17 @@ public class LibTestsSCG {
         } else {
             properties.put(AuthConstants.ENV_JWKS_URL, MOCK_KEY_SERVER.getJwksUrl());
         }
+        // Also register mock /userinfo endpoint
+        properties.put(AuthConstants.ENV_USERINFO_URL, MOCK_KEY_SERVER.getUserInfoUrl());
         return properties;
     }
 
     // Fine-grained logging control.
     // See also LogCtl in jena-base for log4j implementation.
 
-    /** Execute with a given logging level. */
+    /**
+     * Execute with a given logging level.
+     */
     public static void withLevel(Logger logger, String execLevel, Runnable action) {
         CtlLogback.withLevel(logger, execLevel, action);
     }

--- a/scg-system/src/test/java/io/telicent/LibTestsSCG.java
+++ b/scg-system/src/test/java/io/telicent/LibTestsSCG.java
@@ -29,6 +29,7 @@ import io.telicent.servlet.auth.jwt.verifier.aws.AwsElbKeyUrlRegistry;
 import io.telicent.smart.cache.configuration.Configurator;
 import io.telicent.smart.cache.configuration.sources.PropertiesSource;
 import io.telicent.smart.caches.configuration.auth.AuthConstants;
+import io.telicent.smart.caches.configuration.auth.policy.TelicentPermissions;
 import org.apache.jena.sparql.exec.RowSet;
 import org.apache.jena.sparql.exec.http.DSP;
 import org.apache.jena.sparql.exec.http.QueryExecHTTPBuilder;
@@ -114,11 +115,17 @@ public class LibTestsSCG {
                           List.of("USER", "ADMIN_SYSTEM")
                    )
                    .claim("permissions",
-                          List.of("api." + datasetName + ".read",
-                                  "api." + datasetName + ".write",
-                                  "backup.read",
-                                  "backup.write",
-                                  "compact")
+                          List.of(
+                              // Dataset read/write permissions
+                              TelicentPermissions.readPermission(datasetName),
+                              TelicentPermissions.writePermission(datasetName),
+                              // Backup specific permissions
+                              TelicentPermissions.Backup.READ,
+                              TelicentPermissions.Backup.WRITE,
+                              TelicentPermissions.Backup.RESTORE,
+                              TelicentPermissions.Backup.DELETE,
+                              // Compact specific permissions
+                              TelicentPermissions.compactPermission(datasetName))
                    )
                    .signWith(MOCK_KEY_SERVER.getPrivateKey(keyId))
                    .compact();

--- a/scg-system/src/test/java/io/telicent/MockKeyServer.java
+++ b/scg-system/src/test/java/io/telicent/MockKeyServer.java
@@ -1,18 +1,21 @@
 package io.telicent;
 
-import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.jackson.io.JacksonSerializer;
-import io.jsonwebtoken.security.Jwk;
-import io.jsonwebtoken.security.JwkSet;
-import io.jsonwebtoken.security.JwkSetBuilder;
-import io.jsonwebtoken.security.Jwks;
+import io.jsonwebtoken.security.*;
+import io.telicent.servlet.auth.jwt.JwtHttpConstants;
+import io.telicent.servlet.auth.jwt.verification.SignedJwtVerifier;
+import io.telicent.smart.caches.configuration.auth.AuthConstants;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.lang3.Strings;
 import org.apache.jena.fuseki.main.JettyServer;
 import org.apache.jena.riot.WebContent;
 import org.apache.jena.sys.JenaSystem;
+import org.junit.platform.commons.util.StringUtils;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.security.Key;
@@ -56,6 +59,7 @@ public class MockKeyServer {
                                  .contextPath("/")
                                  .addServlet("/jwks.json", new JwksServlet(this.publicKeys))
                                  .addServlet("/aws/*", new AwsElbServlet(this.publicKeys))
+                                 .addServlet("/userinfo", new UserInfoServlet(this.publicKeys))
                                  .build();
     }
 
@@ -77,6 +81,10 @@ public class MockKeyServer {
 
     public String getAwsElbUrlFormat() {
         return String.format("http://localhost:%d/aws/", this.port) + "%s";
+    }
+
+    public String getUserInfoUrl() {
+        return String.format("http://localhost:%d/userinfo", this.port);
     }
 
     public String selectKeyId() {
@@ -132,6 +140,60 @@ public class MockKeyServer {
                 resp.getOutputStream().println("---END PUBLIC KEY---");
                 resp.getOutputStream().close();
             }
+        }
+    }
+
+    private static final class UserInfoServlet extends HttpServlet {
+        private final JwkSet jwks;
+        private final SignedJwtVerifier verifier;
+        private final ObjectMapper json = new ObjectMapper();
+
+        public UserInfoServlet(JwkSet jwks) {
+            this.jwks = jwks;
+            this.verifier = new SignedJwtVerifier(new LocatorAdapter<Key>() {
+                @Override
+                protected Key locate(JwsHeader header) {
+                    Key key = jwks.getKeys()
+                                  .stream()
+                                  .filter(k -> Objects.equals(k.getId(), header.getKeyId()))
+                                  .findFirst()
+                                  .map(Jwk::toKey)
+                                  .orElse(null);
+                    if (key == null) {
+                        throw new InvalidKeyException(
+                                "Failed to locate key " + header.getKeyId() + " which was used to sign the presented JWT");
+                    } else {
+                        return key;
+                    }
+                }
+            });
+        }
+
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+            String authHeader = req.getHeader(JwtHttpConstants.HEADER_AUTHORIZATION);
+            if (StringUtils.isBlank(authHeader)) {
+                resp.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                resp.setContentType(WebContent.contentTypeTextPlain);
+                resp.getWriter().write("No JWT presented");
+                return;
+            }
+
+            String token = Strings.CI.removeStart(authHeader, JwtHttpConstants.AUTH_SCHEME_BEARER).strip();
+            Jws<Claims> jws = this.verifier.verify(token);
+            Claims claims = jws.getPayload();
+
+            // Create a mock response, similar to Auth Server
+            Map<String, Object> userInfo = new HashMap<>();
+            userInfo.put("sub", claims.getSubject());
+            userInfo.put("preferred_name", claims.get("preferred_name", String.class));
+            userInfo.put("roles", claims.getOrDefault("roles", new String[] { "USER" }));
+            userInfo.put("permissions", claims.getOrDefault("permissions", new String[] { "api.read" }));
+            userInfo.put("attributes", claims.getOrDefault("attributes", Map.of()));
+
+            resp.setContentType(WebContent.contentTypeJSON);
+            resp.setStatus(HttpServletResponse.SC_OK);
+            this.json.writeValue(resp.getOutputStream(), userInfo);
         }
     }
 }

--- a/scg-system/src/test/java/io/telicent/MockKeyServer.java
+++ b/scg-system/src/test/java/io/telicent/MockKeyServer.java
@@ -5,7 +5,6 @@ import io.jsonwebtoken.jackson.io.JacksonSerializer;
 import io.jsonwebtoken.security.*;
 import io.telicent.servlet.auth.jwt.JwtHttpConstants;
 import io.telicent.servlet.auth.jwt.verification.SignedJwtVerifier;
-import io.telicent.smart.caches.configuration.auth.AuthConstants;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;

--- a/scg-system/src/test/java/io/telicent/TestJwtServletAuth.java
+++ b/scg-system/src/test/java/io/telicent/TestJwtServletAuth.java
@@ -99,8 +99,7 @@ public class TestJwtServletAuth {
         List<PathExclusion> expectedList = List.of(
                 new PathExclusion("/$/ping"),
                 new PathExclusion("/$/metrics"),
-                new PathExclusion("/\\$/stats/*"),
-                new PathExclusion("/$/compactall")
+                new PathExclusion("/\\$/stats/*")
         );
         FMod_JwtServletAuth jwtServletAuth = new FMod_JwtServletAuth();
         FusekiServer.Builder builder = SmartCacheGraph.serverBuilder().addServletAttribute(ATTRIBUTE_JWT_VERIFIER, new TestJwtVerifier());
@@ -134,10 +133,6 @@ public class TestJwtServletAuth {
         // Correct path
         HttpResponse<InputStream> metricsResponse = makePOSTCallWithPath(server, "$/metrics");
         assertEquals(200, metricsResponse.statusCode());
-
-        // Correct path
-        HttpResponse<InputStream> compactResponse = makePOSTCallWithPath(server, "$/compactall");
-        assertEquals(200, compactResponse.statusCode());
 
         // Fails - due to missing path but NOT due to Auth.
         HttpResponse<InputStream> statsResponse = makePOSTCallWithPath(server, "$/stats/unrecognised");

--- a/scg-system/src/test/java/io/telicent/TestJwtServletAuth.java
+++ b/scg-system/src/test/java/io/telicent/TestJwtServletAuth.java
@@ -3,7 +3,7 @@ package io.telicent;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.telicent.core.FMod_InitialCompaction;
-import io.telicent.core.FMod_JwtServletAuth;
+import io.telicent.core.auth.FMod_JwtServletAuth;
 import io.telicent.core.SmartCacheGraph;
 import io.telicent.jena.abac.core.Attributes;
 import io.telicent.servlet.auth.jwt.PathExclusion;

--- a/scg-system/src/test/java/io/telicent/TestJwtServletAuth.java
+++ b/scg-system/src/test/java/io/telicent/TestJwtServletAuth.java
@@ -185,6 +185,15 @@ public class TestJwtServletAuth {
         return makeAuthCallWithPathForMethod(server, path, user, METHOD_GET);
     }
 
+    public static HttpResponse<InputStream> makeAuthCallWithCustomToken(FusekiServer server, String path, String jwt, String method) {
+        HttpRequest.Builder builder =
+                HttpLib.requestBuilderFor(server.serverURL())
+                       .uri(toRequestURI(server.serverURL() + path))
+                       .headers(AwsConstants.HEADER_DATA, jwt)
+                       .method(method, HttpRequest.BodyPublishers.noBody());
+        return execute(HttpEnv.getDftHttpClient(), builder.build());
+    }
+
     public static HttpResponse<InputStream> makeAuthCallWithPathForMethod(FusekiServer server, String path, String user, String method) {
         HttpRequest.Builder builder =
                 HttpLib.requestBuilderFor(server.serverURL())
@@ -193,4 +202,5 @@ public class TestJwtServletAuth {
                         .method(method, HttpRequest.BodyPublishers.noBody());
         return execute(HttpEnv.getDftHttpClient(), builder.build());
     }
+
 }

--- a/scg-system/src/test/java/io/telicent/TestPersistentSetup.java
+++ b/scg-system/src/test/java/io/telicent/TestPersistentSetup.java
@@ -188,7 +188,7 @@ public class TestPersistentSetup {
             printAttrs(user, attributeStore);
         }
 
-        String bearerToken = LibTestsSCG.tokenForUser(user);
+        String bearerToken = LibTestsSCG.tokenForUser(user, URL.split("/")[3]);
         tokenHeader();
         tokenHeaderValue(bearerToken);
 

--- a/scg-system/src/test/java/io/telicent/access/TestAccessBase.java
+++ b/scg-system/src/test/java/io/telicent/access/TestAccessBase.java
@@ -76,7 +76,7 @@ public class TestAccessBase {
 
     protected String callServiceEndpoint(final String requestBody, final String user, final String serviceName, final String endpoint, final String queryParams) throws Exception {
         final String accessQueryUrl = server.serverURL() + serviceName + endpoint + queryParams;
-        final String bearerToken = LibTestsSCG.tokenForUser(user);
+        final String bearerToken = LibTestsSCG.tokenForUser(user, serviceName);
         final HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(accessQueryUrl))
                 .header("Content-type", "application/json")

--- a/scg-system/src/test/java/io/telicent/backup/utils/TestBackupUtils.java
+++ b/scg-system/src/test/java/io/telicent/backup/utils/TestBackupUtils.java
@@ -33,7 +33,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.ZonedDateTime;
 import java.util.*;
 

--- a/scg-system/src/test/java/io/telicent/core/TestInitialCompaction.java
+++ b/scg-system/src/test/java/io/telicent/core/TestInitialCompaction.java
@@ -32,6 +32,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
 
+import static io.telicent.TestJwtServletAuth.makeAuthCallWithPathForMethod;
 import static io.telicent.TestJwtServletAuth.makePOSTCallWithPath;
 import static io.telicent.TestSmartCacheGraphIntegration.launchServer;
 import static io.telicent.core.FMod_InitialCompaction.compactLabels;
@@ -40,7 +41,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 public class TestInitialCompaction {
-    private static final MockedStatic<DatabaseMgr> mockDatabaseMgr  = mockStatic(DatabaseMgr.class, Mockito.CALLS_REAL_METHODS);
+    private static final MockedStatic<DatabaseMgr> mockDatabaseMgr =
+            mockStatic(DatabaseMgr.class, Mockito.CALLS_REAL_METHODS);
     private static FusekiServer server;
 
     @BeforeAll
@@ -54,8 +56,8 @@ public class TestInitialCompaction {
 
     @AfterEach
     void clearDown() {
-       mockDatabaseMgr.clearInvocations();
-       mockDatabaseMgr.reset();
+        mockDatabaseMgr.clearInvocations();
+        mockDatabaseMgr.reset();
 
         removePreviousCompactionResults();
     }
@@ -158,10 +160,10 @@ public class TestInitialCompaction {
     public void test_ABACDSG_wrapped_memGraph() {
         // given
         DatasetGraphABAC dsgABAC = ABAC.authzDataset(DatasetGraphFactory.createTxnMem(),
-                AEX.strALLOW,
-                Labels.createLabelsStoreMem(),
-                SysABAC.denyLabel,
-                new AttributesStoreLocal());
+                                                     AEX.strALLOW,
+                                                     Labels.createLabelsStoreMem(),
+                                                     SysABAC.denyLabel,
+                                                     new AttributesStoreLocal());
         // when
         DatasetGraph actualDSG = FMod_InitialCompaction.getTDB2(dsgABAC);
         // then
@@ -171,12 +173,13 @@ public class TestInitialCompaction {
     @Test
     public void test_ABACDSG_wrapped_persistedGraph() {
         // given
-        DatasetGraphSwitchable dsgPersists = new DatasetGraphSwitchable(Path.of("./"), null, DatasetGraphFactory.createTxnMem());
+        DatasetGraphSwitchable dsgPersists =
+                new DatasetGraphSwitchable(Path.of("./"), null, DatasetGraphFactory.createTxnMem());
         DatasetGraphABAC dsgABAC = ABAC.authzDataset(dsgPersists,
-                AEX.strALLOW,
-                Labels.createLabelsStoreMem(),
-                SysABAC.denyLabel,
-                new AttributesStoreLocal());
+                                                     AEX.strALLOW,
+                                                     Labels.createLabelsStoreMem(),
+                                                     SysABAC.denyLabel,
+                                                     new AttributesStoreLocal());
         // when
         DatasetGraph actualDSG = FMod_InitialCompaction.getTDB2(dsgABAC);
         // then
@@ -262,7 +265,8 @@ public class TestInitialCompaction {
     }
 
     @Test
-    public void givenMalformedCompactionResultsFile_whenLoadingPreviousSize_thenDefaultValueReturned() throws IOException {
+    public void givenMalformedCompactionResultsFile_whenLoadingPreviousSize_thenDefaultValueReturned() throws
+            IOException {
         // Given
         File tempDir = Files.createTempDirectory("test").toFile();
         DatasetGraphSwitchable mockDSG = mock(DatasetGraphSwitchable.class);
@@ -290,9 +294,10 @@ public class TestInitialCompaction {
     }
 
     @Test
-    public void test_compactWithExistingLock()  {
+    public void test_compactWithExistingLock() {
         // given
-        DatasetGraphSwitchable dsgPersists = new DatasetGraphSwitchable(Path.of("./"), null, DatasetGraphFactory.createTxnMem());
+        DatasetGraphSwitchable dsgPersists =
+                new DatasetGraphSwitchable(Path.of("./"), null, DatasetGraphFactory.createTxnMem());
         DatasetGraphSwitchable mockedDsg = Mockito.spy(dsgPersists);
 
         when(mockedDsg.tryExclusiveMode(false)).thenReturn(false);
@@ -300,7 +305,8 @@ public class TestInitialCompaction {
         server = SmartCacheGraph.smartCacheGraphBuilder().add("test", mockedDsg).build().start();
 
         // when
-        HttpResponse<InputStream> compactResponse = makePOSTCallWithPath(server, "$/compactall");
+        HttpResponse<InputStream> compactResponse =
+                makeAuthCallWithPathForMethod(server, "$/compactall", "test", "POST");
         // then
         assertEquals(200, compactResponse.statusCode());
         mockDatabaseMgr.verify(() -> DatabaseMgr.compact(any(), anyBoolean()), times(0));
@@ -313,7 +319,8 @@ public class TestInitialCompaction {
         String configFile = "config-persistent.ttl";
         server = launchServer(configFile);
         // when
-        HttpResponse<InputStream> compactResponse = makePOSTCallWithPath(server, "$/compactall");
+        HttpResponse<InputStream> compactResponse =
+                makeAuthCallWithPathForMethod(server, "$/compactall", "test", "POST");
         // then
         assertEquals(200, compactResponse.statusCode());
     }
@@ -350,10 +357,10 @@ public class TestInitialCompaction {
     public void test_compactLabels_notRocksDB() {
         // given
         DatasetGraphABAC dsgABAC = ABAC.authzDataset(DatasetGraphFactory.createTxnMem(),
-                AEX.strALLOW,
-                Labels.createLabelsStoreMem(),
-                SysABAC.denyLabel,
-                new AttributesStoreLocal());
+                                                     AEX.strALLOW,
+                                                     Labels.createLabelsStoreMem(),
+                                                     SysABAC.denyLabel,
+                                                     new AttributesStoreLocal());
         // when
         // then
         compactLabels(dsgABAC);
@@ -380,6 +387,6 @@ public class TestInitialCompaction {
         when(request.getMethod()).thenReturn("POST");
 
         HttpServletResponse response = mock(HttpServletResponse.class);
-        assertThrows(ActionErrorException.class, () ->capturedServlet.service(request, response));
+        assertThrows(ActionErrorException.class, () -> capturedServlet.service(request, response));
     }
 }

--- a/scg-system/src/test/java/io/telicent/core/auth/TestSCGAuthPolicyGeneration.java
+++ b/scg-system/src/test/java/io/telicent/core/auth/TestSCGAuthPolicyGeneration.java
@@ -75,6 +75,7 @@ public class TestSCGAuthPolicyGeneration {
         verifyPermissions(policies, "/" + datasetName + "/graphql", readPermission);
         verifyPermissions(policies, "/" + datasetName + "/cqrs", readPermission, writePermission);
         verifyNoPolicy(policies, "/" + datasetName + "/custom");
+        verifyPermissions(policies, "/" + datasetName, readPermission, writePermission);
 
         // Verify permissions generated for Telicent custom endpoints
         verifyPermissions(policies, "/" + datasetName + "/access/*", readPermission);
@@ -100,6 +101,7 @@ public class TestSCGAuthPolicyGeneration {
         verifyRoles(policies, "/" + datasetName + "/graphql", SCG_AuthPolicy.DEFAULT_ROLES.values());
         verifyRoles(policies, "/" + datasetName + "/cqrs", SCG_AuthPolicy.DEFAULT_ROLES.values());
         verifyNoPolicy(policies, "/" + datasetName + "/custom");
+        verifyRoles(policies, "/" + datasetName, SCG_AuthPolicy.DEFAULT_ROLES.values());
 
         // Verify roles generated for Telicent custom endpoints
         verifyRoles(policies, "/" + datasetName + "/access/*", SCG_AuthPolicy.DEFAULT_ROLES.values());

--- a/scg-system/src/test/java/io/telicent/core/auth/TestSCGAuthPolicyGeneration.java
+++ b/scg-system/src/test/java/io/telicent/core/auth/TestSCGAuthPolicyGeneration.java
@@ -30,7 +30,7 @@ public class TestSCGAuthPolicyGeneration {
 
     protected static final Operation CUSTOM_OP = Operation.alloc("https.//example.org/custom-op", "custom", "custom");
 
-    private static DataAccessPoint mockDataset(String datasetName) {
+    public static DataAccessPoint mockDataset(String datasetName) {
         DataAccessPoint dap = Mockito.mock(DataAccessPoint.class);
         when(dap.getName()).thenReturn(datasetName);
         List<Endpoint> endpoints = new ArrayList<>();
@@ -133,8 +133,8 @@ public class TestSCGAuthPolicyGeneration {
         SCG_AuthPolicy.addDatasetPermissionsPolicy(perms, catalog);
 
         // Then
-        Assertions.assertEquals(12, roles.size());
-        Assertions.assertEquals(12, perms.size());
+        Assertions.assertEquals(14, roles.size());
+        Assertions.assertEquals(14, perms.size());
         verifyDatasetRoles(roles, "knowledge");
         verifyDatasetPermissions(perms, "knowledge");
         verifyDatasetRoles(roles, "catalog");
@@ -171,9 +171,9 @@ public class TestSCGAuthPolicyGeneration {
         Assertions.assertFalse(perms.isEmpty());
         verifyRoles(roles, "/$/compactall", SCG_AuthPolicy.ADMIN_ROLES.values());
         verifyPermissions(perms, "/$/compactall", SCG_AuthPolicy.COMPACT.values());
-        verifyRoles(roles, "/\\$/backup/*", SCG_AuthPolicy.ADMIN_ROLES.values());
-        verifyPermissions(perms, "/$/backup/create", SCG_AuthPolicy.BACKUP_READ_WRITE.values());
-        verifyPermissions(perms, "/$/backup/restore", SCG_AuthPolicy.BACKUP_READ_WRITE.values());
-        verifyPermissions(perms, "/\\$/backup/*", SCG_AuthPolicy.BACKUP_READ_ONLY.values());
+        verifyRoles(roles, "/\\$/backups/*", SCG_AuthPolicy.ADMIN_ROLES.values());
+        verifyPermissions(perms, "/$/backups/create", SCG_AuthPolicy.BACKUP_READ_WRITE.values());
+        verifyPermissions(perms, "/$/backups/restore", SCG_AuthPolicy.BACKUP_READ_WRITE.values());
+        verifyPermissions(perms, "/\\$/backups/*", SCG_AuthPolicy.BACKUP_READ_ONLY.values());
     }
 }

--- a/scg-system/src/test/java/io/telicent/core/auth/TestSCGAuthPolicyGeneration.java
+++ b/scg-system/src/test/java/io/telicent/core/auth/TestSCGAuthPolicyGeneration.java
@@ -1,0 +1,75 @@
+package io.telicent.core.auth;
+
+import io.telicent.core.CQRS;
+import io.telicent.jena.graphql.fuseki.SysGraphQL;
+import io.telicent.servlet.auth.jwt.PathExclusion;
+import io.telicent.smart.caches.configuration.auth.policy.Policy;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.jena.fuseki.server.DataAccessPoint;
+import org.apache.jena.fuseki.server.DataService;
+import org.apache.jena.fuseki.server.Endpoint;
+import org.apache.jena.fuseki.server.Operation;
+import org.apache.jena.sys.JenaSystem;
+import org.bouncycastle.util.Arrays;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.when;
+
+public class TestSCGAuthPolicyGeneration {
+
+    static {
+        JenaSystem.init();
+    }
+
+    // TODO PathExclusion needs to implement equals() and hashCode() for use as a Map key
+
+    private void verifyPermissions(Map<PathExclusion, Policy> policies, String path, String... expected) {
+        PathExclusion pathExclusion = new PathExclusion(path);
+        Policy policy = policies.get(pathExclusion);
+        Assertions.assertNotNull(policy, "Missing expected policy for path " + path);
+        for (String permission : expected) {
+            Assertions.assertTrue(ArrayUtils.contains(policy.values(), permission),
+                                  "Missing expected permission " + permission + " for path " + path);
+        }
+    }
+
+    private void verifyNoPolicy(Map<PathExclusion, Policy> policies, String path) {
+        PathExclusion pathExclusion = new PathExclusion(path);
+        Policy policy = policies.get(pathExclusion);
+        Assertions.assertNull(policy, "No policy expected for path " + path);
+    }
+
+    @Test
+    public void givenBasicDataset_whenGeneratingPolicy_thenExpectedPoliciesGenerated() {
+        // Given
+        DataAccessPoint dap = Mockito.mock(DataAccessPoint.class);
+        when(dap.getName()).thenReturn("/knowledge");
+        List<Endpoint> endpoints = new ArrayList<>();
+        endpoints.add(Endpoint.create(Operation.Query, "query"));
+        endpoints.add(Endpoint.create(Operation.Upload, "upload"));
+        endpoints.add(Endpoint.create(SysGraphQL.OP_GRAPHQL, "graphql"));
+        endpoints.add(Endpoint.create(CQRS.Vocab.operationUpdateCQRS, "cqrs"));
+        endpoints.add(Endpoint.create(Operation.alloc("https://example.org/custom-op", "custom", "custom"), "custom"));
+        DataService ds = Mockito.mock(DataService.class);
+        when(ds.getEndpoints()).thenReturn(endpoints);
+        when(dap.getDataService()).thenReturn(ds);
+
+        // When
+        Map<PathExclusion, Policy> policies = new HashMap<>();
+        SCG_AuthPolicy.addDatasetPermissionsPolicy(policies, dap);
+
+        // Then
+        verifyPermissions(policies, "/knowledge/query", "api:knowledge:read");
+        verifyPermissions(policies, "/knowledge/upload", "api:knowledge:read", "api:knowledge:write");
+        verifyPermissions(policies, "/knowledge/graphql", "api:knowledge:read");
+        verifyPermissions(policies, "/knowledge/cqrs", "api:knowledge:read", "api:knowledge:write");
+        verifyNoPolicy(policies, "/knowledge/custom");
+    }
+}

--- a/scg-system/src/test/java/io/telicent/core/auth/TestServletAuthorizationEngine.java
+++ b/scg-system/src/test/java/io/telicent/core/auth/TestServletAuthorizationEngine.java
@@ -1,0 +1,143 @@
+package io.telicent.core.auth;
+
+import io.telicent.servlet.auth.jwt.PathExclusion;
+import io.telicent.smart.caches.configuration.auth.policy.Policy;
+import jakarta.servlet.http.HttpServletRequest;
+import org.apache.jena.fuseki.server.DataAccessPoint;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.mockito.Mockito.when;
+
+public class TestServletAuthorizationEngine {
+
+    private static final Map<PathExclusion, Policy> ROLES = new LinkedHashMap<>();
+    private static final Map<PathExclusion, Policy> PERMS = new LinkedHashMap<>();
+
+    @BeforeAll
+    public static void setup() {
+        // Generate an example set of policies
+        DataAccessPoint knowledge = TestSCGAuthPolicyGeneration.mockDataset("/knowledge");
+        DataAccessPoint catalog = TestSCGAuthPolicyGeneration.mockDataset("/catalog");
+        SCG_AuthPolicy.addTelicentEndpointPolicies(ROLES, PERMS);
+        SCG_AuthPolicy.addDatasetRolesPolicy(ROLES, knowledge);
+        SCG_AuthPolicy.addDatasetRolesPolicy(ROLES, catalog);
+        SCG_AuthPolicy.addDatasetPermissionsPolicy(PERMS, knowledge);
+        SCG_AuthPolicy.addDatasetPermissionsPolicy(PERMS, catalog);
+    }
+
+    private final class InspectableServletAuthorizationEngine extends ServletAuthorizationEngine {
+
+        /**
+         * Creates a new authorization engine
+         *
+         * @param rolesPolicies       Roles policy mappings
+         * @param permissionsPolicies Permissions policy mappings
+         * @param rolesFallback       Fallback roles policy, {@link Policy#ALLOW_ALL} if not set
+         * @param permissionsFallback Fallback permissions policy, {@link Policy#ALLOW_ALL} if not set
+         */
+        InspectableServletAuthorizationEngine(Map<PathExclusion, Policy> rolesPolicies,
+                                              Map<PathExclusion, Policy> permissionsPolicies, Policy rolesFallback,
+                                              Policy permissionsFallback) {
+            super(rolesPolicies, permissionsPolicies, rolesFallback, permissionsFallback);
+        }
+
+        public Policy findRoles(ServletAuthorizationContext context) {
+            return super.getRolesPolicy(context);
+        }
+
+        public Policy findPermissions(ServletAuthorizationContext context) {
+            return super.getPermissionsPolicy(context);
+        }
+    }
+
+    private InspectableServletAuthorizationEngine createEngine() {
+        return new InspectableServletAuthorizationEngine(ROLES, PERMS, Policy.DENY_ALL, Policy.DENY_ALL);
+    }
+
+    private static Stream<Arguments> protectedPaths() {
+        //@formatter:off
+        return Stream.of(
+                // Various dataset endpoints
+                Arguments.of("/knowledge/", "query"),
+                Arguments.of("/knowledge/", "cqrs"),
+                Arguments.of("/knowledge/access/query", null),
+                Arguments.of("/$/labels/knowledge", null),
+                Arguments.of("/knowledge", null),
+                // Administrative endpoints
+                Arguments.of("/$/backups/create", null),
+                Arguments.of("/$/backups/restore", null),
+                Arguments.of("/$/compactall", null)
+        );
+        //@formatter:on
+    }
+
+    @ParameterizedTest
+    @MethodSource("protectedPaths")
+    public void givenRequestToProtectedPath_whenFindingPolicy_thenNonFallbackPolicyIsFound(String servletPath,
+                                                                                           String pathInfo) {
+        // Given
+        ServletAuthorizationContext context = prepareContext(servletPath, pathInfo);
+        InspectableServletAuthorizationEngine engine = createEngine();
+
+        // When
+        Policy roles = engine.findRoles(context);
+        Policy permissions = engine.findPermissions(context);
+
+        // Then
+        Assertions.assertNotNull(roles);
+        Assertions.assertNotNull(permissions);
+        Assertions.assertNotEquals(Policy.DENY_ALL, roles);
+        Assertions.assertNotEquals(Policy.DENY_ALL, permissions);
+    }
+
+    private static ServletAuthorizationContext prepareContext(String servletPath, String pathInfo) {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        when(request.getServletPath()).thenReturn(servletPath);
+        when(request.getPathInfo()).thenReturn(pathInfo);
+        return new ServletAuthorizationContext(request);
+    }
+
+    private static Stream<Arguments> otherPaths() {
+        //@formatter:off
+        return Stream.of(
+                // The /$/ping endpoint has no policy, this is because in normal use it's excluded from Authentication
+                // so AuthZ would never apply anyway
+                Arguments.of("/$/ping", null),
+                // Some random unrecognised paths
+                Arguments.of(null, "/no-such-path"),
+                Arguments.of(null, "/deeply/nested/path/to/nothing.txt"),
+                // Blank endpoint under a dataset
+                Arguments.of("/knowledge/", null),
+                // Unknown endpoint under a dataset
+                Arguments.of("/knowledge/", "unknown"));
+        //@formatter:on
+    }
+
+    @ParameterizedTest
+    @MethodSource("otherPaths")
+    public void givenRequestToOtherPaths_whenFindingPolicy_thenFallbackPolicyIsFound(String servletPath,
+                                                                                     String pathInfo) {
+        // Given
+        ServletAuthorizationContext context = prepareContext(servletPath, pathInfo);
+        InspectableServletAuthorizationEngine engine = createEngine();
+
+        // When
+        Policy roles = engine.findRoles(context);
+        Policy permissions = engine.findPermissions(context);
+
+        // Then
+        Assertions.assertNotNull(roles);
+        Assertions.assertNotNull(permissions);
+        Assertions.assertEquals(Policy.DENY_ALL, roles);
+        Assertions.assertEquals(Policy.DENY_ALL, permissions);
+    }
+}

--- a/scg-system/src/test/java/io/telicent/core/auth/TestUserInfoFilter.java
+++ b/scg-system/src/test/java/io/telicent/core/auth/TestUserInfoFilter.java
@@ -1,0 +1,233 @@
+package io.telicent.core.auth;
+
+import io.telicent.jena.abac.AttributeValueSet;
+import io.telicent.jena.abac.attributes.Attribute;
+import io.telicent.jena.abac.attributes.ValueTerm;
+import io.telicent.jena.abac.core.AttributesStoreAuthServer;
+import io.telicent.servlet.auth.jwt.JwtServletConstants;
+import io.telicent.smart.caches.configuration.auth.UserInfo;
+import io.telicent.smart.caches.configuration.auth.UserInfoLookup;
+import io.telicent.smart.caches.configuration.auth.UserInfoLookupException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+public class TestUserInfoFilter {
+
+    private UserInfoLookup mockLookup(UserInfo info) throws UserInfoLookupException {
+        UserInfoLookup lookup = Mockito.mock(UserInfoLookup.class);
+        when(lookup.lookup(any())).thenReturn(info);
+        return lookup;
+    }
+
+    private static HttpServletRequest mockRequest(String username) {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        if (username != null) {
+            when(request.getAttribute(eq(JwtServletConstants.REQUEST_ATTRIBUTE_RAW_JWT))).thenReturn("token");
+            when(request.getRemoteUser()).thenReturn(username);
+        }
+        return request;
+    }
+
+    private static AttributeValueSet findAttributes(String username) {
+        AttributesStoreAuthServer attrStore = new AttributesStoreAuthServer(null);
+        return attrStore.attributes(username);
+    }
+
+    private static HttpServletRequest applyFilter(UserInfoLookup lookup, String username) throws IOException,
+            ServletException {
+        // Given
+        UserInfoFilter filter = new UserInfoFilter(lookup);
+        HttpServletRequest request = mockRequest(username);
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+        FilterChain filterChain = Mockito.mock(FilterChain.class);
+
+        // When
+        filter.doFilter(request, response, filterChain);
+
+        // Then
+        verify(filterChain, times(1)).doFilter(any(), any());
+        return request;
+    }
+
+    @Test
+    public void givenMinimalUserInfo_whenConvertingToUserAttributes_thenNoAttributes() throws UserInfoLookupException,
+            ServletException, IOException {
+        // Given
+        UserInfo info = UserInfo.builder().preferredName("Mr T. Test").build();
+        UserInfoLookup lookup = mockLookup(info);
+
+        // When
+        applyFilter(lookup, "test");
+
+        // Then
+        AttributeValueSet attrs = findAttributes("test");
+        Assertions.assertNotNull(attrs);
+        Assertions.assertTrue(attrs.isEmpty());
+    }
+
+    private void verifyMissingAttributes(AttributeValueSet attrs, String... missingAttributes) {
+        for (String missing : missingAttributes) {
+            Attribute a = Attribute.create(missing);
+            Assertions.assertFalse(attrs.hasAttribute(a));
+        }
+    }
+
+    private void verifyAttributes(AttributeValueSet attrs, Map<String, Object> attributes) {
+        for (Map.Entry<String, Object> entry : attributes.entrySet()) {
+            Attribute a = Attribute.create(entry.getKey());
+            Assertions.assertTrue(attrs.hasAttribute(a));
+            Collection<ValueTerm> values = attrs.get(a);
+
+            if (entry.getValue() instanceof Collection<?> expected) {
+                Assertions.assertEquals(expected.size(), values.size());
+                List<String> expectedValues = expected.stream().map(Object::toString).sorted().toList();
+                List<String> actualValues = values.stream().map(ValueTerm::getString).sorted().toList();
+                Assertions.assertEquals(expectedValues, actualValues);
+            } else {
+                Assertions.assertNotEquals(0, values.size());
+                verifyValue(entry.getValue(), values.iterator().next());
+            }
+        }
+    }
+
+    private static void verifyValue(Object expected, ValueTerm actual) {
+        if (expected instanceof Boolean b) {
+            Assertions.assertEquals(b, actual.getBoolean());
+        } else {
+            Assertions.assertEquals(expected.toString(), actual.getString());
+        }
+    }
+
+    @Test
+    public void givenBasicUserInfo_whenConvertingToUserAttributes_thenAttributes() throws UserInfoLookupException,
+            ServletException, IOException {
+        // Given
+        Map<String, Object> attributes =
+                Map.of("email", "test@example.org", "age", 42, "nationality", "GBR", "active", true);
+        UserInfo info = UserInfo.builder().preferredName("Mr T. Test").attributes(attributes).build();
+        UserInfoLookup lookup = mockLookup(info);
+
+        // When
+        applyFilter(lookup, "tester");
+
+        // Then
+        AttributeValueSet attrs = findAttributes("tester");
+        Assertions.assertNotNull(attrs);
+        Assertions.assertFalse(attrs.isEmpty());
+        verifyAttributes(attrs, attributes);
+    }
+
+    @Test
+    public void givenUserInfoWithListAttribute_whenConvertingToUserAttributes_thenAllAttributesMaterialised() throws
+            UserInfoLookupException, ServletException, IOException {
+        // Given
+        Map<String, Object> attributes =
+                Map.of("email", List.of("test@example.org", "test@personal.org"), "age", 42, "nationality",
+                       List.of("GBR", "US"), "active", true);
+        UserInfo info = UserInfo.builder().preferredName("Mr T. Test").attributes(attributes).build();
+        UserInfoLookup lookup = mockLookup(info);
+
+        // When
+        applyFilter(lookup, "tester");
+
+        // Then
+        AttributeValueSet attrs = findAttributes("tester");
+        Assertions.assertNotNull(attrs);
+        Assertions.assertFalse(attrs.isEmpty());
+        verifyAttributes(attrs, attributes);
+    }
+
+    @Test
+    public void givenUserInfoWithNonConvertibleAttributes_whenConvertingToUserAttributes_thenAttributesIgnored() throws
+            UserInfoLookupException, ServletException, IOException {
+        // Given
+        Map<String, Object> attributes = Map.of("ignored", new Object());
+        UserInfo info = UserInfo.builder().preferredName("Mr T. Test").attributes(attributes).build();
+        UserInfoLookup lookup = mockLookup(info);
+
+        // When
+        applyFilter(lookup, "tester");
+
+        // Then
+        AttributeValueSet attrs = findAttributes("tester");
+        Assertions.assertNotNull(attrs);
+        Assertions.assertTrue(attrs.isEmpty());
+        verifyMissingAttributes(attrs, "ignored");
+    }
+
+    @Test
+    public void givenUserInfoWithMapAttribute_whenConvertingToUserAttributes_thenAttributesFlattened() throws
+            UserInfoLookupException, ServletException, IOException {
+        // Given
+        Map<String, Object> attributes = Map.of("email", "test@example.org", "employment",
+                                                Map.of("company", "Telicent Ltd", "title", "QA Engineer", "department",
+                                                       "R&D", "manages", List.of("Adam", "Bob", "Eve")));
+        UserInfo info = UserInfo.builder().preferredName("Mr T. Test").attributes(attributes).build();
+        UserInfoLookup lookup = mockLookup(info);
+
+        // When
+        applyFilter(lookup, "tester");
+
+        // Then
+        AttributeValueSet attrs = findAttributes("tester");
+        Assertions.assertNotNull(attrs);
+        Assertions.assertFalse(attrs.isEmpty());
+        Map<String, Object> expected =
+                Map.of("email", "test@example.org", "employment.company", "Telicent Ltd", "employment.title",
+                       "QA Engineer", "employment.department", "R&D", "employment.manages",
+                       List.of("Adam", "Bob", "Eve"));
+        verifyAttributes(attrs, expected);
+    }
+
+    @Test
+    public void givenNonRetrievableUserInfo_whenFiltering_thenNoAttributes() throws UserInfoLookupException,
+            ServletException, IOException {
+        // Given
+        UserInfoLookup lookup = Mockito.mock(UserInfoLookup.class);
+        when(lookup.lookup(any())).thenThrow(new UserInfoLookupException("failed"));
+
+        // When
+        applyFilter(lookup, "test");
+
+        // Then
+        AttributeValueSet attrs = findAttributes("test");
+        Assertions.assertTrue(attrs.isEmpty());
+    }
+
+    @Test
+    public void givenNoAuthentication_whenFiltering_thenNoAttributes() throws ServletException, IOException {
+        // Given
+        UserInfoLookup lookup = Mockito.mock(UserInfoLookup.class);
+
+        // When
+        HttpServletRequest request = applyFilter(lookup, null);
+
+        // Then
+        verify(request, never()).setAttribute(eq(UserInfo.class.getCanonicalName()), any());
+    }
+
+    @Test
+    public void givenFailsOnCloseLookup_whenDestroyingFilter_thenOk() throws IOException {
+        // Given
+        UserInfoLookup lookup = Mockito.mock(UserInfoLookup.class);
+        doThrow(new RuntimeException("failed")).when(lookup).close();
+
+        // When and Then
+        UserInfoFilter filter = new UserInfoFilter(lookup);
+        filter.destroy();
+    }
+}


### PR DESCRIPTION
This PR used the new functionality from telicent-oss/smart-caches-core#196 to implement roles and permissions based authorisation for SCG.

`FMod_JwtServletAuth` will not also register additional filters for User Info enrichment of requests and authorisation policy enforcement.  Since SCG can be dynamically configured with different datasets the policies are automatically generated based upon the datasets configured for the Fuseki instance.  Dataset endpoints are mapped to roles and permissions based upon their registered Fuseki `Operation`.  Telicent specific endpoints provided by our various Fuseki modules also have suitable policies generated.  Requests to unknown endpoints fallback to a default policy with is `DENY_ALL`.

Unit and integration tests are updated so that the fake JWTs we generate include all the necessary roles and permissions needed for those tests to pass.

# Outstanding Work

- [x] Pin to Smart Caches Core 0.30.1 release once available
- [x] Documentation updates
- [x] Test coverage for AuthZ failures