### PR TITLE
[CORE-890] Adding async option to existing create/restore back-up operations

### DIFF
--- a/docs/backups-api.yaml
+++ b/docs/backups-api.yaml
@@ -7,6 +7,46 @@ servers:
   - url: http://localhost:3030/
     description: Base path for dataset backup operations.
 components:
+  schemas:
+    AsyncJobSubmission:
+      type: object
+      properties:
+        job-id:
+          type: string
+        operation:
+          type: string
+        status:
+          type: string
+        status-path:
+          type: string
+        message:
+          type: string
+    AsyncJobStatus:
+      type: object
+      properties:
+        job-id:
+          type: string
+        operation:
+          type: string
+        status:
+          type: string
+        status-path:
+          type: string
+        message:
+          type: string
+        submitted-at:
+          type: string
+          format: date-time
+        started-at:
+          type: string
+          format: date-time
+        completed-at:
+          type: string
+          format: date-time
+        http-status:
+          type: integer
+        result:
+          type: object
   responses:
     RestoreResponse:
       description: Dataset restored successfully.
@@ -78,6 +118,13 @@ paths:
           description: A description of the back-up (i.e. "Daily backup")
           schema:
             type: string
+        - name: async
+          in: query
+          required: false
+          description: When `true`, submit the backup as an asynchronous job and poll `/$/backups/jobs/{jobId}` for completion.
+          schema:
+            type: boolean
+            default: false
       responses:
         '200':
           description: Backup created successfully.
@@ -96,6 +143,12 @@ paths:
                   backup:
                     type: object
                     description: Details of the backup operation.
+        '202':
+          description: Backup job accepted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AsyncJobSubmission'
         '500':
           description: Internal server error.
           content:
@@ -117,6 +170,13 @@ paths:
           description: A description of the back-up (i.e. "Daily backup")
           schema:
             type: string
+        - name: async
+          in: query
+          required: false
+          description: When `true`, submit the backup as an asynchronous job and poll `/$/backups/jobs/{jobId}` for completion.
+          schema:
+            type: boolean
+            default: false
       responses:
         '200':
           description: Backup created successfully.
@@ -135,6 +195,12 @@ paths:
                   backup:
                     type: object
                     description: Details of the backup operation.
+        '202':
+          description: Backup job accepted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AsyncJobSubmission'
         '500':
           description: Internal server error.
           content:
@@ -245,9 +311,23 @@ paths:
     post:
       summary: Restore the latest backup
       description: Restores the latest snapshot.
+      parameters:
+        - name: async
+          in: query
+          required: false
+          description: When `true`, submit the restore as an asynchronous job and poll `/$/backups/jobs/{jobId}` for completion.
+          schema:
+            type: boolean
+            default: false
       responses:
         '200':
           $ref: '#/components/responses/RestoreResponse'
+        '202':
+          description: Restore job accepted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AsyncJobSubmission'
         '404':
           $ref: '#/components/responses/NotFoundError'
         '500':
@@ -264,13 +344,77 @@ paths:
           description: ID of the backup to restore.
           schema:
             type: string
+        - name: async
+          in: query
+          required: false
+          description: When `true`, submit the restore as an asynchronous job and poll `/$/backups/jobs/{jobId}` for completion.
+          schema:
+            type: boolean
+            default: false
       responses:
         '200':
           $ref: '#/components/responses/RestoreResponse'
+        '202':
+          description: Restore job accepted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AsyncJobSubmission'
         '404':
           $ref: '#/components/responses/NotFoundError'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /$/backups/jobs:
+    get:
+      summary: List asynchronous backup jobs
+      description: Retrieves running and completed async backup/restore jobs known to this server instance.
+      responses:
+        '200':
+          description: Backup jobs retrieved successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  date:
+                    type: string
+                    format: date-time
+                  jobs:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/AsyncJobStatus'
+  /$/backups/jobs/{jobId}:
+    get:
+      summary: Get asynchronous backup job status
+      description: Retrieves the current status of one async backup/restore job.
+      parameters:
+        - name: jobId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Backup job retrieved successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  date:
+                    type: string
+                    format: date-time
+                  job:
+                    $ref: '#/components/schemas/AsyncJobStatus'
+        '404':
+          description: Backup job not found.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
 
   /$/backups/restore/{datasetName}:
     post:

--- a/docs/compaction-api.yaml
+++ b/docs/compaction-api.yaml
@@ -43,6 +43,76 @@ components:
               - SKIPPED_PREVIOUSLY_COMPACTED
               - SKIPPED_LOCK_CONTENTION
               - SKIPPED_NOT_TDB2
+    AsyncCompactionSubmission:
+      type: object
+      required:
+        - job-id
+        - operation
+        - status
+        - status-path
+        - message
+      properties:
+        job-id:
+          type: string
+        operation:
+          type: string
+          enum:
+            - COMPACT_DATASET
+            - COMPACT_ALL_DATASETS
+        status:
+          type: string
+          enum:
+            - PENDING
+            - RUNNING
+            - SUCCEEDED
+            - FAILED
+        status-path:
+          type: string
+        message:
+          type: string
+    CompactionJobStatus:
+      type: object
+      required:
+        - job-id
+        - operation
+        - status
+        - status-path
+        - message
+        - submitted-at
+      properties:
+        job-id:
+          type: string
+        operation:
+          type: string
+        status:
+          type: string
+          enum:
+            - PENDING
+            - RUNNING
+            - SUCCEEDED
+            - FAILED
+        status-path:
+          type: string
+        message:
+          type: string
+        submitted-at:
+          type: string
+          format: date-time
+        started-at:
+          type: string
+          format: date-time
+        completed-at:
+          type: string
+          format: date-time
+        http-status:
+          type: integer
+        result:
+          oneOf:
+            - $ref: '#/components/schemas/CompactionSummaryResponse'
+            - type: object
+              properties:
+                error:
+                  type: string
 security:
   - BearerAuth: []
   - AwsBearerAuth: []
@@ -60,6 +130,12 @@ paths:
           description: Dataset name (without leading slash), for example `knowledge`.
           schema:
             type: string
+        - name: async
+          in: query
+          required: false
+          description: When `true`, submit compaction as an asynchronous job and poll the returned `status-path`.
+          schema:
+            type: boolean
       responses:
         '200':
           description: Compaction request handled successfully.
@@ -67,6 +143,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CompactionSummaryResponse'
+        '202':
+          description: Compaction job accepted for asynchronous execution.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AsyncCompactionSubmission'
         '401':
           description: Unauthorized due to missing role/permission.
         '500':
@@ -83,6 +165,13 @@ paths:
       description: |
         Attempts compaction for each configured dataset and returns per-dataset outcomes.
         If one or more dataset compactions fail with exceptions, the endpoint returns 500.
+      parameters:
+        - name: async
+          in: query
+          required: false
+          description: When `true`, submit compaction as an asynchronous job and poll the returned `status-path`.
+          schema:
+            type: boolean
       responses:
         '200':
           description: Compaction request handled successfully.
@@ -90,6 +179,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CompactionSummaryResponse'
+        '202':
+          description: Compaction job accepted for asynchronous execution.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AsyncCompactionSubmission'
         '401':
           description: Unauthorized due to missing role/permission.
         '500':
@@ -99,3 +194,98 @@ paths:
               schema:
                 type: string
                 example: Compaction failed for one or more datasets: /knowledge=<reason>
+
+  /$/compaction/jobs/{datasetName}:
+    get:
+      summary: List asynchronous jobs for a dataset compaction endpoint
+      parameters:
+        - name: datasetName
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Known asynchronous jobs for this dataset.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobs:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/CompactionJobStatus'
+        '401':
+          description: Unauthorized due to missing role/permission.
+
+  /$/compaction/jobs/{datasetName}/{jobId}:
+    get:
+      summary: Get asynchronous dataset compaction job status
+      parameters:
+        - name: datasetName
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: jobId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Current state of the asynchronous compaction job.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  job:
+                    $ref: '#/components/schemas/CompactionJobStatus'
+        '401':
+          description: Unauthorized due to missing role/permission.
+        '404':
+          description: Unknown job id.
+
+  /$/compaction/jobs/all:
+    get:
+      summary: List asynchronous jobs for compact-all requests
+      responses:
+        '200':
+          description: Known asynchronous compact-all jobs.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobs:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/CompactionJobStatus'
+        '401':
+          description: Unauthorized due to missing role/permission.
+
+  /$/compaction/jobs/all/{jobId}:
+    get:
+      summary: Get asynchronous compact-all job status
+      parameters:
+        - name: jobId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Current state of the asynchronous compact-all job.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  job:
+                    $ref: '#/components/schemas/CompactionJobStatus'
+        '401':
+          description: Unauthorized due to missing role/permission.
+        '404':
+          description: Unknown job id.

--- a/scg-system/pom.xml
+++ b/scg-system/pom.xml
@@ -246,12 +246,6 @@
             <artifactId>log4j-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j2-impl</artifactId>
-            <scope>test</scope>
-        </dependency>
-
         <!-- Kafka - testing -->
         <dependency>
             <groupId>org.testcontainers</groupId>
@@ -337,6 +331,12 @@
         <dependency>
             <groupId>io.telicent.public</groupId>
             <artifactId>fuseki-yaml-config</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j2-impl</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
     </dependencies>

--- a/scg-system/src/main/java/io/telicent/backup/FMod_BackupData.java
+++ b/scg-system/src/main/java/io/telicent/backup/FMod_BackupData.java
@@ -15,6 +15,7 @@
  */
 package io.telicent.backup;
 
+import io.telicent.backup.services.BackupJobManager;
 import io.telicent.backup.services.DatasetBackupService;
 import io.telicent.backup.servlets.*;
 import io.telicent.model.KeyPair;
@@ -83,11 +84,13 @@ public class FMod_BackupData implements FusekiAutoModule {
         if (isBackupEnabled()) {
             try {
                 DatasetBackupService backupService = getBackupService(dapRegistry);
-                serverBuilder.addServlet("/$/backups/create/*", new BackupServlet(backupService));
+                BackupJobManager jobManager = new BackupJobManager();
+                serverBuilder.addServlet("/$/backups/create/*", new BackupServlet(backupService, jobManager));
                 serverBuilder.addServlet("/$/backups/datasets/list/*", new ListDatasetsServlet(backupService));
                 serverBuilder.addServlet("/$/backups/list/*", new ListBackupsServlet(backupService));
-                serverBuilder.addServlet("/$/backups/restore/*", new RestoreServlet(backupService));
+                serverBuilder.addServlet("/$/backups/restore/*", new RestoreServlet(backupService, jobManager));
                 serverBuilder.addServlet("/$/backups/delete/*", new DeleteServlet(backupService));
+                serverBuilder.addServlet("/$/backups/jobs/*", new BackupJobsServlet(jobManager));
                 serverBuilder.addServlet("/$/backups/validate/*", new ValidateServlet(backupService));
                 serverBuilder.addServlet("/$/backups/report/*", new ReportServlet(backupService));
                 serverBuilder.addServlet("/$/backups/details/*", new DetailsServlet(backupService));

--- a/scg-system/src/main/java/io/telicent/backup/services/BackupJobManager.java
+++ b/scg-system/src/main/java/io/telicent/backup/services/BackupJobManager.java
@@ -1,0 +1,165 @@
+/*
+ *  Copyright (c) Telicent Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.telicent.backup.services;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static io.telicent.backup.utils.JsonFileUtils.OBJECT_MAPPER;
+
+public class BackupJobManager {
+
+    public static final String STATUS_PENDING = "PENDING";
+    public static final String STATUS_RUNNING = "RUNNING";
+    public static final String STATUS_SUCCEEDED = "SUCCEEDED";
+    public static final String STATUS_FAILED = "FAILED";
+
+    private static final Logger LOG = LoggerFactory.getLogger(BackupJobManager.class);
+
+    private final Map<String, BackupJob> jobs = new ConcurrentHashMap<>();
+    private final ExecutorService executor = Executors.newSingleThreadExecutor(r -> {
+        final Thread thread = new Thread(r, "scg-backup-jobs");
+        thread.setDaemon(true);
+        return thread;
+    });
+
+    public ObjectNode submit(final String operation,
+                             final String statusPathPrefix,
+                             final Callable<BackupOperationResponse> task) {
+        final BackupJob job = new BackupJob(UUID.randomUUID().toString(), operation, statusPathPrefix);
+        this.jobs.put(job.jobId, job);
+        this.executor.submit(() -> {
+            try {
+                job.markRunning();
+                final BackupOperationResponse response = task.call();
+                if (response.statusCode() >= 200 && response.statusCode() < 300) {
+                    job.markSucceeded(response);
+                } else {
+                    job.markFailed(response);
+                }
+            } catch (Exception e) {
+                LOG.error("Unhandled backup job failure for {}", operation, e);
+                final ObjectNode body = OBJECT_MAPPER.createObjectNode();
+                body.put("error", e.getMessage());
+                job.markFailed(new BackupOperationResponse(500, body));
+            }
+        });
+        return job.submission();
+    }
+
+    public ArrayNode listJobs() {
+        final ArrayNode jobsArray = OBJECT_MAPPER.createArrayNode();
+        this.jobs.values()
+                 .stream()
+                 .sorted(Comparator.comparing((BackupJob job) -> job.submittedAt).reversed())
+                 .map(BackupJob::status)
+                 .forEach(jobsArray::add);
+        return jobsArray;
+    }
+
+    public Optional<ObjectNode> getJob(final String jobId) {
+        return Optional.ofNullable(this.jobs.get(jobId)).map(BackupJob::status);
+    }
+
+    private static final class BackupJob {
+        private final String jobId;
+        private final String operation;
+        private final String statusPath;
+        private final Instant submittedAt = Instant.now();
+        private volatile String status = STATUS_PENDING;
+        private volatile String message = "Waiting to run.";
+        private volatile Instant startedAt;
+        private volatile Instant completedAt;
+        private volatile Integer httpStatus;
+        private volatile ObjectNode result;
+
+        private BackupJob(final String jobId, final String operation, final String statusPathPrefix) {
+            this.jobId = jobId;
+            this.operation = operation;
+            this.statusPath = statusPathPrefix + jobId;
+        }
+
+        private void markRunning() {
+            this.status = STATUS_RUNNING;
+            this.message = "Job is running.";
+            this.startedAt = Instant.now();
+        }
+
+        private void markSucceeded(final BackupOperationResponse response) {
+            this.status = STATUS_SUCCEEDED;
+            this.completedAt = Instant.now();
+            this.httpStatus = response.statusCode();
+            this.result = response.body().deepCopy();
+            this.message = response.body().has("error") ? response.body().get("error").asText() :
+                           "Job completed successfully.";
+        }
+
+        private void markFailed(final BackupOperationResponse response) {
+            this.status = STATUS_FAILED;
+            this.completedAt = Instant.now();
+            this.httpStatus = response.statusCode();
+            this.result = response.body().deepCopy();
+            this.message = response.body().has("error") ? response.body().get("error").asText() :
+                           "Job failed.";
+        }
+
+        private ObjectNode submission() {
+            final ObjectNode node = OBJECT_MAPPER.createObjectNode();
+            node.put("job-id", this.jobId);
+            node.put("operation", this.operation);
+            node.put("status", this.status);
+            node.put("status-path", this.statusPath);
+            node.put("message", "Job accepted for asynchronous execution.");
+            return node;
+        }
+
+        private ObjectNode status() {
+            final ObjectNode node = OBJECT_MAPPER.createObjectNode();
+            node.put("job-id", this.jobId);
+            node.put("operation", this.operation);
+            node.put("status", this.status);
+            node.put("status-path", this.statusPath);
+            node.put("message", this.message);
+            node.put("submitted-at", this.submittedAt.toString());
+            if (this.startedAt != null) {
+                node.put("started-at", this.startedAt.toString());
+            }
+            if (this.completedAt != null) {
+                node.put("completed-at", this.completedAt.toString());
+            }
+            if (this.httpStatus != null) {
+                node.put("http-status", this.httpStatus);
+            }
+            if (this.result != null) {
+                node.set("result", this.result.deepCopy());
+            }
+            return node;
+        }
+    }
+}

--- a/scg-system/src/main/java/io/telicent/backup/services/BackupOperationRequest.java
+++ b/scg-system/src/main/java/io/telicent/backup/services/BackupOperationRequest.java
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (c) Telicent Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.telicent.backup.services;
+
+public record BackupOperationRequest(String pathInfo, String remoteUser, String description, String backupName) {
+}

--- a/scg-system/src/main/java/io/telicent/backup/services/BackupOperationResponse.java
+++ b/scg-system/src/main/java/io/telicent/backup/services/BackupOperationResponse.java
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (c) Telicent Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.telicent.backup.services;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public record BackupOperationResponse(int statusCode, ObjectNode body) {
+}

--- a/scg-system/src/main/java/io/telicent/backup/services/DatasetBackupService.java
+++ b/scg-system/src/main/java/io/telicent/backup/services/DatasetBackupService.java
@@ -57,6 +57,7 @@ import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -115,39 +116,70 @@ public class DatasetBackupService {
      * @param backup   flag indicating backup or restore
      */
     public void process(HttpServletRequest request, HttpServletResponse response, boolean backup) {
-        // Try to acquire the lock without blocking
+        final BackupOperationResponse operationResponse = execute(() -> captureRequest(request), backup, false);
+        response.setStatus(operationResponse.statusCode());
+        processResponse(response, operationResponse.body());
+    }
+
+    public BackupOperationRequest captureRequest(final HttpServletRequest request) {
+        return new BackupOperationRequest(request.getPathInfo(),
+                                          request.getRemoteUser(),
+                                          request.getParameter("description"),
+                                          request.getParameter("backup-name"));
+    }
+
+    public BackupOperationResponse execute(final BackupOperationRequest request, final boolean backup,
+                                           final boolean waitForLock) {
+        return execute(() -> request, backup, waitForLock);
+    }
+
+    private BackupOperationResponse execute(final Supplier<BackupOperationRequest> requestSupplier,
+                                            final boolean backup,
+                                            final boolean waitForLock) {
         final ObjectNode resultNode = OBJECT_MAPPER.createObjectNode();
-        if (!lock.tryLock()) {
-            response.setStatus(HttpServletResponse.SC_CONFLICT);
-            resultNode.put("error", "Another conflicting operation is already in progress. Please try again later.");
-            processResponse(response, resultNode);
-        } else {
-            try {
-                String id = sanitiseName(request.getPathInfo());
-                if (!id.isEmpty()) {
-                    resultNode.put("backup-type", id);
-                } else {
-                    resultNode.put("backup-type", "FULL");
-                }
-                resultNode.put("date", DateTimeUtils.nowAsString(DATE_FORMAT));
-                resultNode.put("user", request.getRemoteUser());
-                String description = request.getParameter("description");
-                if (description != null) {
-                    resultNode.put("description", description);
-                }
-                String backupName = request.getParameter("backup-name");
-                if (backupName != null) {
-                    resultNode.put("backup-name", backupName);
-                }
-                if (backup) {
-                    backupDataset(id, resultNode);
-                } else {
-                    restoreDatasets(id, resultNode);
-                }
-                processResponse(response, resultNode);
-            } catch (Exception exception) {
-                handleError(response, resultNode, exception);
-            } finally {
+        boolean lockAcquired = false;
+        try {
+            if (waitForLock) {
+                lock.lockInterruptibly();
+                lockAcquired = true;
+            } else {
+                lockAcquired = lock.tryLock();
+            }
+            if (!lockAcquired) {
+                resultNode.put("error", "Another conflicting operation is already in progress. Please try again later.");
+                return new BackupOperationResponse(HttpServletResponse.SC_CONFLICT, resultNode);
+            }
+
+            final BackupOperationRequest request = requestSupplier.get();
+            final String id = sanitiseName(request.pathInfo());
+            if (!id.isEmpty()) {
+                resultNode.put("backup-type", id);
+            } else {
+                resultNode.put("backup-type", "FULL");
+            }
+            resultNode.put("date", DateTimeUtils.nowAsString(DATE_FORMAT));
+            resultNode.put("user", request.remoteUser());
+            if (request.description() != null) {
+                resultNode.put("description", request.description());
+            }
+            if (request.backupName() != null) {
+                resultNode.put("backup-name", request.backupName());
+            }
+            if (backup) {
+                backupDataset(id, resultNode);
+            } else {
+                restoreDatasets(id, resultNode);
+            }
+            return new BackupOperationResponse(HttpServletResponse.SC_OK, resultNode);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            resultNode.put("error", "Interrupted while waiting to perform backup operation.");
+            return new BackupOperationResponse(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, resultNode);
+        } catch (Exception exception) {
+            resultNode.put("error", exception.getMessage());
+            return new BackupOperationResponse(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, resultNode);
+        } finally {
+            if (lockAcquired) {
                 lock.unlock();
             }
         }

--- a/scg-system/src/main/java/io/telicent/backup/services/DatasetBackupService.java
+++ b/scg-system/src/main/java/io/telicent/backup/services/DatasetBackupService.java
@@ -431,7 +431,7 @@ public class DatasetBackupService {
     boolean restoreDataset(String restorePath, String datasetName, ObjectNode responseNode) {
         ObjectNode response = OBJECT_MAPPER.createObjectNode();
         response.put("dataset-name", datasetName);
-        responseNode.put(datasetName, response);
+        responseNode.set(datasetName, response);
         DataAccessPoint dataAccessPoint = getDataAccessPoint(datasetName);
         if (dataAccessPoint == null || dataAccessPoint.getDataService() == null) {
             response.put("reason", datasetName + " does not exist");

--- a/scg-system/src/main/java/io/telicent/backup/servlets/AsyncBackupServletSupport.java
+++ b/scg-system/src/main/java/io/telicent/backup/servlets/AsyncBackupServletSupport.java
@@ -1,0 +1,76 @@
+/*
+ *  Copyright (c) Telicent Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.telicent.backup.servlets;
+
+import io.telicent.backup.services.DatasetBackupService;
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+final class AsyncBackupServletSupport {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AsyncBackupServletSupport.class);
+    private static final ExecutorService EXECUTOR = Executors.newCachedThreadPool(r -> {
+        final Thread thread = new Thread(r, "scg-backup-async");
+        thread.setDaemon(true);
+        return thread;
+    });
+
+    private AsyncBackupServletSupport() {
+    }
+
+    static void processAsync(final DatasetBackupService backupService,
+                             final HttpServletRequest request,
+                             final HttpServletResponse response,
+                             final boolean backup) {
+        final AsyncContext asyncContext = request.startAsync();
+        final String remoteUser = request.getRemoteUser();
+        asyncContext.setTimeout(0);
+        EXECUTOR.execute(() -> {
+            try {
+                final HttpServletRequest asyncRequest = (HttpServletRequest) asyncContext.getRequest();
+                backupService.process(new HttpServletRequestWrapper(asyncRequest) {
+                                          @Override
+                                          public String getRemoteUser() {
+                                              return remoteUser;
+                                          }
+                                      },
+                                      (HttpServletResponse) asyncContext.getResponse(),
+                                      backup);
+            } catch (Throwable e) {
+                LOG.error("Unhandled error processing {} request asynchronously", backup ? "backup" : "restore", e);
+                final HttpServletResponse asyncResponse = (HttpServletResponse) asyncContext.getResponse();
+                if (!asyncResponse.isCommitted()) {
+                    try {
+                        asyncResponse.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+                    } catch (IOException ioException) {
+                        LOG.warn("Failed to write async error response", ioException);
+                    }
+                }
+            } finally {
+                asyncContext.complete();
+            }
+        });
+    }
+}

--- a/scg-system/src/main/java/io/telicent/backup/servlets/BackupJobsServlet.java
+++ b/scg-system/src/main/java/io/telicent/backup/servlets/BackupJobsServlet.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) Telicent Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.telicent.backup.servlets;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.telicent.backup.services.BackupJobManager;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.jena.atlas.lib.DateTimeUtils;
+
+import static io.telicent.backup.utils.BackupConstants.DATE_FORMAT;
+import static io.telicent.backup.utils.JsonFileUtils.OBJECT_MAPPER;
+import static io.telicent.utils.ServletUtils.processResponse;
+
+public class BackupJobsServlet extends HttpServlet {
+
+    private final BackupJobManager jobManager;
+
+    public BackupJobsServlet(final BackupJobManager jobManager) {
+        this.jobManager = jobManager;
+    }
+
+    @Override
+    protected void doGet(final HttpServletRequest request, final HttpServletResponse response) {
+        final ObjectNode resultNode = OBJECT_MAPPER.createObjectNode();
+        resultNode.put("date", DateTimeUtils.nowAsString(DATE_FORMAT));
+        final String pathInfo = request.getPathInfo();
+        if (pathInfo == null || pathInfo.isBlank() || "/".equals(pathInfo)) {
+            resultNode.set("jobs", this.jobManager.listJobs());
+            processResponse(response, resultNode);
+            return;
+        }
+
+        final String jobId = pathInfo.startsWith("/") ? pathInfo.substring(1) : pathInfo;
+        this.jobManager.getJob(jobId).ifPresentOrElse(job -> {
+            resultNode.set("job", job);
+            processResponse(response, resultNode);
+        }, () -> {
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            resultNode.put("error", "Unknown backup job id: " + jobId);
+            processResponse(response, resultNode);
+        });
+    }
+}

--- a/scg-system/src/main/java/io/telicent/backup/servlets/BackupServlet.java
+++ b/scg-system/src/main/java/io/telicent/backup/servlets/BackupServlet.java
@@ -16,23 +16,48 @@
 
 package io.telicent.backup.servlets;
 
+import io.telicent.backup.services.BackupJobManager;
+import io.telicent.backup.services.BackupOperationRequest;
 import io.telicent.backup.services.DatasetBackupService;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
+import static io.telicent.backup.utils.JsonFileUtils.OBJECT_MAPPER;
+import static io.telicent.utils.ServletUtils.processResponse;
 
 /**
  * Servlet class responsible for the creation of backups.
  */
 public class BackupServlet extends HttpServlet {
     private final DatasetBackupService backupService;
+    private final BackupJobManager jobManager;
 
-    public BackupServlet(DatasetBackupService backupService) {
+    public BackupServlet(DatasetBackupService backupService, BackupJobManager jobManager) {
         this.backupService = backupService;
+        this.jobManager = jobManager;
     }
 
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) {
-        backupService.process(request, response, true);
+        if (Boolean.parseBoolean(request.getParameter("async"))) {
+            final BackupOperationRequest operationRequest;
+            try {
+                operationRequest = this.backupService.captureRequest(request);
+            } catch (RuntimeException e) {
+                response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+                var resultNode = OBJECT_MAPPER.createObjectNode();
+                resultNode.put("error", e.getMessage());
+                processResponse(response, resultNode);
+                return;
+            }
+            response.setStatus(HttpServletResponse.SC_ACCEPTED);
+            processResponse(response,
+                            this.jobManager.submit("CREATE_BACKUP",
+                                                   "/$/backups/jobs/",
+                                                   () -> this.backupService.execute(operationRequest, true, true)));
+            return;
+        }
+        AsyncBackupServletSupport.processAsync(backupService, request, response, true);
     }
 }

--- a/scg-system/src/main/java/io/telicent/backup/servlets/RestoreServlet.java
+++ b/scg-system/src/main/java/io/telicent/backup/servlets/RestoreServlet.java
@@ -16,22 +16,48 @@
 
 package io.telicent.backup.servlets;
 
+import io.telicent.backup.services.BackupJobManager;
+import io.telicent.backup.services.BackupOperationRequest;
 import io.telicent.backup.services.DatasetBackupService;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
+import static io.telicent.backup.utils.JsonFileUtils.OBJECT_MAPPER;
+import static io.telicent.utils.ServletUtils.processResponse;
 
 /**
  * Servlet class responsible for the loading of a given backup.
  */
 public class RestoreServlet extends HttpServlet {
     private final DatasetBackupService backupService;
-    public RestoreServlet(DatasetBackupService backupService) {
+    private final BackupJobManager jobManager;
+
+    public RestoreServlet(DatasetBackupService backupService, BackupJobManager jobManager) {
         this.backupService = backupService;
+        this.jobManager = jobManager;
     }
 
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) {
-        backupService.process(request, response, false);
+        if (Boolean.parseBoolean(request.getParameter("async"))) {
+            final BackupOperationRequest operationRequest;
+            try {
+                operationRequest = this.backupService.captureRequest(request);
+            } catch (RuntimeException e) {
+                response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+                var resultNode = OBJECT_MAPPER.createObjectNode();
+                resultNode.put("error", e.getMessage());
+                processResponse(response, resultNode);
+                return;
+            }
+            response.setStatus(HttpServletResponse.SC_ACCEPTED);
+            processResponse(response,
+                            this.jobManager.submit("RESTORE_BACKUP",
+                                                   "/$/backups/jobs/",
+                                                   () -> this.backupService.execute(operationRequest, false, true)));
+            return;
+        }
+        AsyncBackupServletSupport.processAsync(backupService, request, response, false);
     }
 }

--- a/scg-system/src/main/java/io/telicent/backup/utils/BackupUtils.java
+++ b/scg-system/src/main/java/io/telicent/backup/utils/BackupUtils.java
@@ -36,10 +36,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.PathMatcher;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -635,7 +631,7 @@ public class BackupUtils extends ServletUtils {
 
             ObjectNode datasetSuccess = JsonNodeFactory.instance.objectNode();
 
-            Iterator<Map.Entry<String, JsonNode>> fields = dataset.fields();
+            Iterator<Map.Entry<String, JsonNode>> fields = dataset.properties().iterator();
             while (fields.hasNext()) {
                 Map.Entry<String, JsonNode> entry = fields.next();
                 String sectionName = entry.getKey();
@@ -650,7 +646,7 @@ public class BackupUtils extends ServletUtils {
                     if (success) isAnyTrue = true;
                 }
 
-                Iterator<Map.Entry<String, JsonNode>> nestedFields = section.fields();
+                Iterator<Map.Entry<String, JsonNode>> nestedFields = section.properties().iterator();
                 while (nestedFields.hasNext()) {
                     Map.Entry<String, JsonNode> nestedEntry = nestedFields.next();
                     String nestedKey = nestedEntry.getKey();

--- a/scg-system/src/main/java/io/telicent/backup/utils/EncryptionUtils.java
+++ b/scg-system/src/main/java/io/telicent/backup/utils/EncryptionUtils.java
@@ -158,7 +158,7 @@ public class EncryptionUtils {
         final Iterator<PGPEncryptedData> encryptedDataItr = pgpEncryptedDataList.getEncryptedDataObjects();
         while (pgpPrivateKey == null && encryptedDataItr.hasNext()) {
             publicKeyEncryptedData = (PGPPublicKeyEncryptedData) encryptedDataItr.next();
-            pgpPrivateKey = findSecretKey(publicKeyEncryptedData.getKeyID());
+            pgpPrivateKey = findSecretKey(publicKeyEncryptedData.getKeyIdentifier().getKeyId());
         }
 
         if (Objects.isNull(publicKeyEncryptedData)) {

--- a/scg-system/src/main/java/io/telicent/core/FMod_InitialCompaction.java
+++ b/scg-system/src/main/java/io/telicent/core/FMod_InitialCompaction.java
@@ -1,5 +1,7 @@
 package io.telicent.core;
 
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.telicent.jena.abac.core.DatasetGraphABAC;
 import io.telicent.jena.abac.labels.LabelsStore;
 import io.telicent.jena.abac.labels.LabelsStoreRocksDB;
@@ -35,17 +37,27 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.time.Instant;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static io.telicent.backup.utils.JsonFileUtils.OBJECT_MAPPER;
+import static io.telicent.utils.ServletUtils.processResponse;
 
 public class FMod_InitialCompaction implements FusekiAutoModule {
 
     public static final Logger LOG = LoggerFactory.getLogger(FMod_InitialCompaction.class);
+    private static final String ALL_DATASETS_SCOPE = "__ALL_DATASETS__";
+    private final CompactionJobManager jobManager = new CompactionJobManager();
     final Set<String> datasets = new HashSet<>();
     static final boolean DELETE_OLD = true;
     public static final String DISABLE_INITIAL_COMPACTION = "DISABLE_INITIAL_COMPACTION";
@@ -74,6 +86,143 @@ public class FMod_InitialCompaction implements FusekiAutoModule {
                                       String updatedAt, long sizeBefore, long sizeAfter, String error) {
     }
 
+    record CompactionOperationResponse(int statusCode, ObjectNode body) {
+    }
+
+    private static final class CompactionJobManager {
+
+        private static final String STATUS_PENDING = "PENDING";
+        private static final String STATUS_RUNNING = "RUNNING";
+        private static final String STATUS_SUCCEEDED = "SUCCEEDED";
+        private static final String STATUS_FAILED = "FAILED";
+
+        private final Map<String, CompactionJob> jobs = new ConcurrentHashMap<>();
+        private final ExecutorService executor = Executors.newSingleThreadExecutor(r -> {
+            final Thread thread = new Thread(r, "scg-compaction-jobs");
+            thread.setDaemon(true);
+            return thread;
+        });
+
+        ObjectNode submit(final String scope,
+                          final String operation,
+                          final String statusPathPrefix,
+                          final Callable<CompactionOperationResponse> task) {
+            final CompactionJob job = new CompactionJob(scope, UUID.randomUUID().toString(), operation, statusPathPrefix);
+            this.jobs.put(job.jobId, job);
+            this.executor.submit(() -> {
+                try {
+                    job.markRunning();
+                    final CompactionOperationResponse response = task.call();
+                    if (response.statusCode() >= 200 && response.statusCode() < 300) {
+                        job.markSucceeded(response);
+                    } else {
+                        job.markFailed(response);
+                    }
+                } catch (Exception e) {
+                    LOG.error("Unhandled compaction job failure for {}", operation, e);
+                    job.markFailed(compactionFailureResponse(e.getMessage() != null ? e.getMessage() : e.getClass().getName()));
+                }
+            });
+            return job.submission();
+        }
+
+        ArrayNode listJobs(final String scope) {
+            final ArrayNode jobsArray = OBJECT_MAPPER.createArrayNode();
+            this.jobs.values()
+                     .stream()
+                     .filter(job -> job.scope.equals(scope))
+                     .sorted(Comparator.comparing((CompactionJob job) -> job.submittedAt).reversed())
+                     .map(CompactionJob::status)
+                     .forEach(jobsArray::add);
+            return jobsArray;
+        }
+
+        Optional<ObjectNode> getJob(final String scope, final String jobId) {
+            return Optional.ofNullable(this.jobs.get(jobId))
+                           .filter(job -> job.scope.equals(scope))
+                           .map(CompactionJob::status);
+        }
+
+        private static final class CompactionJob {
+            private final String scope;
+            private final String jobId;
+            private final String operation;
+            private final String statusPath;
+            private final Instant submittedAt = Instant.now();
+            private volatile String status = STATUS_PENDING;
+            private volatile String message = "Waiting to run.";
+            private volatile Instant startedAt;
+            private volatile Instant completedAt;
+            private volatile Integer httpStatus;
+            private volatile ObjectNode result;
+
+            private CompactionJob(final String scope,
+                                  final String jobId,
+                                  final String operation,
+                                  final String statusPathPrefix) {
+                this.scope = scope;
+                this.jobId = jobId;
+                this.operation = operation;
+                this.statusPath = statusPathPrefix + jobId;
+            }
+
+            private void markRunning() {
+                this.status = STATUS_RUNNING;
+                this.message = "Job is running.";
+                this.startedAt = Instant.now();
+            }
+
+            private void markSucceeded(final CompactionOperationResponse response) {
+                this.status = STATUS_SUCCEEDED;
+                this.completedAt = Instant.now();
+                this.httpStatus = response.statusCode();
+                this.result = response.body().deepCopy();
+                this.message = "Job completed successfully.";
+            }
+
+            private void markFailed(final CompactionOperationResponse response) {
+                this.status = STATUS_FAILED;
+                this.completedAt = Instant.now();
+                this.httpStatus = response.statusCode();
+                this.result = response.body().deepCopy();
+                this.message = response.body().has("error") ? response.body().get("error").asText() : "Job failed.";
+            }
+
+            private ObjectNode submission() {
+                final ObjectNode node = OBJECT_MAPPER.createObjectNode();
+                node.put("job-id", this.jobId);
+                node.put("operation", this.operation);
+                node.put("status", this.status);
+                node.put("status-path", this.statusPath);
+                node.put("message", "Job accepted for asynchronous execution.");
+                return node;
+            }
+
+            private ObjectNode status() {
+                final ObjectNode node = OBJECT_MAPPER.createObjectNode();
+                node.put("job-id", this.jobId);
+                node.put("operation", this.operation);
+                node.put("status", this.status);
+                node.put("status-path", this.statusPath);
+                node.put("message", this.message);
+                node.put("submitted-at", this.submittedAt.toString());
+                if (this.startedAt != null) {
+                    node.put("started-at", this.startedAt.toString());
+                }
+                if (this.completedAt != null) {
+                    node.put("completed-at", this.completedAt.toString());
+                }
+                if (this.httpStatus != null) {
+                    node.put("http-status", this.httpStatus);
+                }
+                if (this.result != null) {
+                    node.set("result", this.result.deepCopy());
+                }
+                return node;
+            }
+        }
+    }
+
     @Override
     public String name() {
         return "Initial Compaction";
@@ -88,7 +237,8 @@ public class FMod_InitialCompaction implements FusekiAutoModule {
     @Override
     public void configured(FusekiServer.Builder serverBuilder, DataAccessPointRegistry dapRegistry, Model configModel) {
         // Create a new dataset endpoint for compacting all datasets
-        serverBuilder.addServlet("/$/compactall", new CompactAllServlet(dapRegistry));
+        serverBuilder.addServlet("/$/compactall", new CompactAllServlet(dapRegistry, this.jobManager));
+        serverBuilder.addServlet("/$/compaction/jobs/all/*", new CompactionJobsServlet(this.jobManager, ALL_DATASETS_SCOPE));
 
         if (dapRegistry != null) {
             // Create a new endpoint for compacting a single dataset
@@ -96,7 +246,9 @@ public class FMod_InitialCompaction implements FusekiAutoModule {
                 DataService dataService = dataAccessPoint.getDataService();
 
                 serverBuilder.addServlet("/$/compact" + dataAccessPoint.getName(),
-                                         new CompactOneServlet(dataService.getDataset(), dataAccessPoint.getName()));
+                                         new CompactOneServlet(dataService.getDataset(), dataAccessPoint.getName(), this.jobManager));
+                serverBuilder.addServlet("/$/compaction/jobs" + dataAccessPoint.getName() + "/*",
+                                         new CompactionJobsServlet(this.jobManager, dataAccessPoint.getName()));
             }
         }
     }
@@ -430,102 +582,157 @@ public class FMod_InitialCompaction implements FusekiAutoModule {
     private static class CompactOneServlet extends HttpServlet {
         private final DatasetGraph dsg;
         private final String datasetName;
+        private final CompactionJobManager jobManager;
 
-        public CompactOneServlet(DatasetGraph dsg, String datasetName) {
+        public CompactOneServlet(DatasetGraph dsg, String datasetName, CompactionJobManager jobManager) {
             this.dsg = dsg;
             this.datasetName = datasetName;
+            this.jobManager = jobManager;
         }
 
         @Override
         public void doPost(HttpServletRequest req, HttpServletResponse res) {
-            try {
-                CompactionStatus outcome = compactDatasetGraphDatabase(this.dsg, this.datasetName);
-                writeCompactionSummaryResponse(res, Map.of(this.datasetName, outcome));
-            } catch (Throwable t) {
-                FmtLog.error(Fuseki.configLog, "Error while compacting dataset " + this.datasetName, t);
-                String details = compactionFailureDetails(this.datasetName, t);
-                ServletOps.errorOccurred(details);
+            if (Boolean.parseBoolean(req.getParameter("async"))) {
+                res.setStatus(HttpServletResponse.SC_ACCEPTED);
+                processResponse(res,
+                                this.jobManager.submit(this.datasetName,
+                                                       "COMPACT_DATASET",
+                                                       "/$/compaction/jobs" + this.datasetName + "/",
+                                                       () -> executeCompactOne(this.dsg, this.datasetName)));
+                return;
             }
+            writeSyncResponse(res, executeCompactOne(this.dsg, this.datasetName));
         }
     }
 
     private static class CompactAllServlet extends HttpServlet {
         private final DataAccessPointRegistry dapRegistry;
+        private final CompactionJobManager jobManager;
 
-        public CompactAllServlet(DataAccessPointRegistry dapRegistry) {
+        public CompactAllServlet(DataAccessPointRegistry dapRegistry, CompactionJobManager jobManager) {
             this.dapRegistry = dapRegistry;
+            this.jobManager = jobManager;
         }
 
         @Override
         public void doPost(HttpServletRequest req, HttpServletResponse res) {
-            if (dapRegistry == null) {
-                ServletOps.errorOccurred("No DataAccessPoint registry configured");
+            if (Boolean.parseBoolean(req.getParameter("async"))) {
+                res.setStatus(HttpServletResponse.SC_ACCEPTED);
+                processResponse(res,
+                                this.jobManager.submit(ALL_DATASETS_SCOPE,
+                                                       "COMPACT_ALL_DATASETS",
+                                                       "/$/compaction/jobs/all/",
+                                                       () -> executeCompactAll(this.dapRegistry)));
                 return;
             }
-            Map<String, CompactionStatus> outcomes = new LinkedHashMap<>();
-            Map<String, String> failures = new LinkedHashMap<>();
-            // Iterate over all registered datasets
-            for (DataAccessPoint dataAccessPoint : dapRegistry.accessPoints()) {
-                DataService dataService = dataAccessPoint.getDataService();
-                String datasetName = dataAccessPoint.getName();
-                try {
-                    CompactionStatus outcome = compactDatasetGraphDatabase(dataService.getDataset(), datasetName);
-                    outcomes.put(datasetName, outcome);
-                } catch (Throwable t) {
-                    failures.put(datasetName, t.getMessage() != null ? t.getMessage() : t.getClass().getName());
-                    FmtLog.error(Fuseki.configLog, "Error while compacting dataset " + datasetName, t);
-                }
-            }
-
-            if (!failures.isEmpty()) {
-                StringBuilder details = new StringBuilder("Compaction failed for one or more datasets: ");
-                boolean first = true;
-                for (Map.Entry<String, String> entry : failures.entrySet()) {
-                    if (!first) {
-                        details.append("; ");
-                    }
-                    first = false;
-                    details.append(entry.getKey()).append("=").append(entry.getValue());
-                }
-                FmtLog.error(Fuseki.configLog, details.toString());
-                ServletOps.errorOccurred(details.toString());
-                return;
-            }
-
-            writeCompactionSummaryResponse(res, outcomes);
+            writeSyncResponse(res, executeCompactAll(this.dapRegistry));
         }
 
     }
 
-    private static void writeCompactionSummaryResponse(HttpServletResponse res, Map<String, CompactionStatus> outcomes) {
-        res.setStatus(HttpServletResponse.SC_OK);
+    private static final class CompactionJobsServlet extends HttpServlet {
+        private final CompactionJobManager jobManager;
+        private final String scope;
+
+        private CompactionJobsServlet(final CompactionJobManager jobManager, final String scope) {
+            this.jobManager = jobManager;
+            this.scope = scope;
+        }
+
+        @Override
+        protected void doGet(final HttpServletRequest req, final HttpServletResponse res) {
+            final ObjectNode resultNode = OBJECT_MAPPER.createObjectNode();
+            final String pathInfo = req.getPathInfo();
+            if (pathInfo == null || pathInfo.isBlank() || "/".equals(pathInfo)) {
+                resultNode.set("jobs", this.jobManager.listJobs(this.scope));
+                processResponse(res, resultNode);
+                return;
+            }
+
+            final String jobId = pathInfo.startsWith("/") ? pathInfo.substring(1) : pathInfo;
+            this.jobManager.getJob(this.scope, jobId).ifPresentOrElse(job -> {
+                resultNode.set("job", job);
+                processResponse(res, resultNode);
+            }, () -> {
+                res.setStatus(HttpServletResponse.SC_NOT_FOUND);
+                resultNode.put("error", "Unknown compaction job id: " + jobId);
+                processResponse(res, resultNode);
+            });
+        }
+    }
+
+    private static CompactionOperationResponse executeCompactOne(final DatasetGraph dsg, final String datasetName) {
+        try {
+            final CompactionStatus outcome = compactDatasetGraphDatabase(dsg, datasetName);
+            return new CompactionOperationResponse(HttpServletResponse.SC_OK,
+                                                   toCompactionSummaryJson(Map.of(datasetName, outcome)));
+        } catch (Throwable t) {
+            FmtLog.error(Fuseki.configLog, "Error while compacting dataset " + datasetName, t);
+            return compactionFailureResponse(compactionFailureDetails(datasetName, t));
+        }
+    }
+
+    private static CompactionOperationResponse executeCompactAll(final DataAccessPointRegistry dapRegistry) {
+        if (dapRegistry == null) {
+            return compactionFailureResponse("No DataAccessPoint registry configured");
+        }
+
+        final Map<String, CompactionStatus> outcomes = new LinkedHashMap<>();
+        final Map<String, String> failures = new LinkedHashMap<>();
+        for (DataAccessPoint dataAccessPoint : dapRegistry.accessPoints()) {
+            final DataService dataService = dataAccessPoint.getDataService();
+            final String datasetName = dataAccessPoint.getName();
+            try {
+                final CompactionStatus outcome = compactDatasetGraphDatabase(dataService.getDataset(), datasetName);
+                outcomes.put(datasetName, outcome);
+            } catch (Throwable t) {
+                failures.put(datasetName, t.getMessage() != null ? t.getMessage() : t.getClass().getName());
+                FmtLog.error(Fuseki.configLog, "Error while compacting dataset " + datasetName, t);
+            }
+        }
+
+        if (!failures.isEmpty()) {
+            StringBuilder details = new StringBuilder("Compaction failed for one or more datasets: ");
+            boolean first = true;
+            for (Map.Entry<String, String> entry : failures.entrySet()) {
+                if (!first) {
+                    details.append("; ");
+                }
+                first = false;
+                details.append(entry.getKey()).append("=").append(entry.getValue());
+            }
+            FmtLog.error(Fuseki.configLog, details.toString());
+            return compactionFailureResponse(details.toString());
+        }
+        return new CompactionOperationResponse(HttpServletResponse.SC_OK, toCompactionSummaryJson(outcomes));
+    }
+
+    private static CompactionOperationResponse compactionFailureResponse(final String details) {
+        final ObjectNode body = OBJECT_MAPPER.createObjectNode();
+        body.put("error", details != null ? details : "Compaction failed.");
+        return new CompactionOperationResponse(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, body);
+    }
+
+    private static void writeSyncResponse(final HttpServletResponse res, final CompactionOperationResponse response) {
+        if (response.statusCode() >= 400) {
+            ServletOps.errorOccurred(response.body().path("error").asText("Compaction failed."));
+            return;
+        }
+        res.setStatus(response.statusCode());
         res.setContentType("application/json");
         res.setCharacterEncoding(StandardCharsets.UTF_8.name());
         try {
-            res.getWriter().write(toCompactionSummaryJson(outcomes));
+            res.getWriter().write(OBJECT_MAPPER.writeValueAsString(response.body()));
         } catch (IOException e) {
             FmtLog.warn(Fuseki.configLog, "Error writing compaction response", e);
         }
     }
 
-    private static String toCompactionSummaryJson(Map<String, CompactionStatus> outcomes) {
-        StringBuilder builder = new StringBuilder();
-        builder.append("{\"status\":\"ok\",\"datasets\":{");
-        boolean first = true;
-        for (Map.Entry<String, CompactionStatus> entry : outcomes.entrySet()) {
-            if (!first) {
-                builder.append(',');
-            }
-            first = false;
-            builder.append('"')
-                   .append(entry.getKey())
-                   .append('"')
-                   .append(':')
-                   .append('"')
-                   .append(entry.getValue().name())
-                   .append('"');
-        }
-        builder.append("}}");
-        return builder.toString();
+    private static ObjectNode toCompactionSummaryJson(final Map<String, CompactionStatus> outcomes) {
+        final ObjectNode body = OBJECT_MAPPER.createObjectNode();
+        body.put("status", "ok");
+        final ObjectNode datasetsNode = body.putObject("datasets");
+        outcomes.forEach((datasetName, outcome) -> datasetsNode.put(datasetName, outcome.name()));
+        return body;
     }
 }

--- a/scg-system/src/main/java/io/telicent/core/SmartCacheGraph.java
+++ b/scg-system/src/main/java/io/telicent/core/SmartCacheGraph.java
@@ -21,22 +21,22 @@ import io.telicent.backup.FMod_BackupData;
 import io.telicent.core.auth.FMod_JwtServletAuth;
 import io.telicent.graphql.FMod_TelicentGraphQL;
 import io.telicent.jena.abac.fuseki.FMod_ABAC;
+import io.telicent.jena.fuseki.config.yaml.ConfigStruct;
+import io.telicent.jena.fuseki.config.yaml.RDFConfigGenerator;
+import io.telicent.jena.fuseki.config.yaml.YAMLConfigParser;
 import io.telicent.labels.FMod_LabelsQuery;
 import io.telicent.otel.FMod_OpenTelemetry;
 import io.telicent.smart.cache.configuration.Configurator;
 import io.telicent.smart.caches.configuration.auth.AuthConstants;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.jena.atlas.lib.Version;
-import org.apache.jena.fuseki.main.FusekiServer;
 import org.apache.jena.fuseki.main.FusekiMain;
+import org.apache.jena.fuseki.main.FusekiServer;
 import org.apache.jena.fuseki.main.sys.FusekiModule;
 import org.apache.jena.fuseki.main.sys.FusekiModules;
 import org.apache.jena.rdf.model.Model;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import io.telicent.jena.fuseki.config.yaml.ConfigStruct;
-import io.telicent.jena.fuseki.config.yaml.RDFConfigGenerator;
-import io.telicent.jena.fuseki.config.yaml.YAMLConfigParser;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -157,7 +157,7 @@ public class SmartCacheGraph {
         String pattern = ".*\\.(yaml|yml)$";
         Pattern regex = Pattern.compile(pattern);
         for (int i = 0; i < args.length; i++) {
-            if (StringUtils.equalsAnyIgnoreCase(args[i], "--config", "--conf") && i + 1 < args.length ) {
+            if (Strings.CI.equalsAny(args[i], "--config", "--conf") && i + 1 < args.length ) {
                 configPath = args[i + 1];
                 Matcher matcher = regex.matcher(configPath);
                 if (matcher.matches()) {

--- a/scg-system/src/main/java/io/telicent/core/SmartCacheGraphSink.java
+++ b/scg-system/src/main/java/io/telicent/core/SmartCacheGraphSink.java
@@ -70,7 +70,7 @@ public class SmartCacheGraphSink extends FusekiSink<DatasetGraphABAC> {
                 return;
             }
             if (routeToNamedGraphs) {
-                Quad rerouted = new Quad(targetGraph, q.getSubject(), q.getPredicate(), q.getObject());
+                Quad rerouted = Quad.create(targetGraph, q.getSubject(), q.getPredicate(), q.getObject());
                 this.dataset.add(rerouted);
                 if (eventSecurityLabel != null) {
                     // Currently works only on the default graph, needs updating once labels store supports named graph labelling

--- a/scg-system/src/main/java/io/telicent/core/auth/SCG_AuthPolicy.java
+++ b/scg-system/src/main/java/io/telicent/core/auth/SCG_AuthPolicy.java
@@ -100,6 +100,8 @@ public class SCG_AuthPolicy {
 
         // Compact endpoint for this dataset
         addPolicy(policies, "/$/compact/" + datasetName, ADMIN_ROLES);
+        addPolicy(policies, "/$/compaction/jobs/" + datasetName, ADMIN_ROLES);
+        addPolicy(policies, "/$/compaction/jobs/" + datasetName + "/*", ADMIN_ROLES);
 
         // Fuseki will also capture requests to the root dataset path and try to dynamically route them based on the
         // request method and body, allow this provided users have the default roles
@@ -130,7 +132,11 @@ public class SCG_AuthPolicy {
         Policy compactPolicy =
                 Policy.requireAll("permissions", TelicentPermissions.compactPermission(datasetName));
         addPolicy(policies, "/$/compact/" + datasetName, compactPolicy);
+        addPolicy(policies, "/$/compaction/jobs/" + datasetName, compactPolicy);
+        addPolicy(policies, "/$/compaction/jobs/" + datasetName + "/*", compactPolicy);
         addOrUpdatePolicy(policies, "/$/compactall", compactPolicy);
+        addOrUpdatePolicy(policies, "/$/compaction/jobs/all", compactPolicy);
+        addOrUpdatePolicy(policies, "/$/compaction/jobs/all/*", compactPolicy);
 
         // Fuseki will also capture requests to the root dataset path and try to dynamically route them based on the
         // request method and body, since we won't know what kind of request is arriving in advance have to enforce both
@@ -179,6 +185,8 @@ public class SCG_AuthPolicy {
 
         // Compact All - /$/compactall
         addPolicy(roles, "/$/compactall", ADMIN_ROLES);
+        addPolicy(roles, "/$/compaction/jobs/all", ADMIN_ROLES);
+        addPolicy(roles, "/$/compaction/jobs/all/*", ADMIN_ROLES);
 
         // Backup/Restore - /$/backups/*
         // All endpoints require an adminstrator role

--- a/scg-system/src/test/java/io/telicent/CtlLogback.java
+++ b/scg-system/src/test/java/io/telicent/CtlLogback.java
@@ -32,24 +32,24 @@ public class CtlLogback {
     }
 
     private static Level name2level(String levelName) {
-        Level level = Level.ALL;
-        if ( levelName == null )
-            level = null;
-        else if ( levelName.equalsIgnoreCase("info") )
-            level = Level.INFO;
-        else if ( levelName.equalsIgnoreCase("debug") )
-            level = Level.DEBUG;
-        else if ( levelName.equalsIgnoreCase("warn") || levelName.equalsIgnoreCase("warning") )
-            level = Level.WARN;
-        else if ( levelName.equalsIgnoreCase("error") || levelName.equalsIgnoreCase("severe") )
-            level = Level.ERROR;
-        else if ( levelName.equalsIgnoreCase("trace") )
-            level = Level.TRACE;
-        else if ( levelName.equalsIgnoreCase("fatal") )
-            // Logback-ism.
-            level = Level.OFF;
-        else if ( levelName.equalsIgnoreCase("OFF") )
-            level = Level.OFF;
+        Level level = null;
+        if ( levelName != null ) {
+            if (levelName.equalsIgnoreCase("info"))
+                level = Level.INFO;
+            else if (levelName.equalsIgnoreCase("debug"))
+                level = Level.DEBUG;
+            else if (levelName.equalsIgnoreCase("warn") || levelName.equalsIgnoreCase("warning"))
+                level = Level.WARN;
+            else if (levelName.equalsIgnoreCase("error") || levelName.equalsIgnoreCase("severe"))
+                level = Level.ERROR;
+            else if (levelName.equalsIgnoreCase("trace"))
+                level = Level.TRACE;
+            else if (levelName.equalsIgnoreCase("fatal"))
+                // Logback-ism.
+                level = Level.OFF;
+            else if (levelName.equalsIgnoreCase("OFF"))
+                level = Level.OFF;
+        }
         return level;
     }
 

--- a/scg-system/src/test/java/io/telicent/TestYamlConfigParserAuthz.java
+++ b/scg-system/src/test/java/io/telicent/TestYamlConfigParserAuthz.java
@@ -65,6 +65,8 @@ class TestYamlConfigParserAuthz {
     public static RowSetRewindable expectedRSRtdl;
     public static String queryStr = "SELECT * { ?s ?p ?o }";
 
+    public boolean debug = false;
+
     @BeforeAll
     public static void before() {
         Model comparisonModel = ModelFactory.createDefaultModel();
@@ -118,7 +120,8 @@ class TestYamlConfigParserAuthz {
                 .httpHeader(LibTestsSCG.tokenHeader(),
                         LibTestsSCG.tokenHeaderValue(validToken))
                 .select().rewindable();
-        RowSetOps.out(System.out, actualResponseRSR);
+        if (debug)
+            RowSetOps.out(System.out, actualResponseRSR);
         boolean equals = isomorphic(expectedRSR, actualResponseRSR);
         assertTrue(equals);
     }
@@ -135,7 +138,8 @@ class TestYamlConfigParserAuthz {
                 .httpHeader(LibTestsSCG.tokenHeader(),
                         LibTestsSCG.tokenHeaderValue(validToken))
                 .select().rewindable();
-        RowSetOps.out(System.out, actualResponseRSR);
+        if (debug)
+            RowSetOps.out(System.out, actualResponseRSR);
         boolean equals = isomorphic(expectedRSR, actualResponseRSR);
         assertTrue(equals);
     }
@@ -170,7 +174,8 @@ class TestYamlConfigParserAuthz {
                 .httpHeader(LibTestsSCG.tokenHeader(),
                         LibTestsSCG.tokenHeaderValue(validToken))
                 .select().rewindable();
-        RowSetOps.out(System.out, actualResponseRSR);
+        if (debug)
+            RowSetOps.out(System.out, actualResponseRSR);
         boolean equals = isomorphic(expectedRSR, actualResponseRSR);
         assertTrue(equals);
     }
@@ -207,7 +212,8 @@ class TestYamlConfigParserAuthz {
                 .httpHeader(LibTestsSCG.tokenHeader(),
                         LibTestsSCG.tokenHeaderValue(validToken))
                 .select().rewindable();
-        RowSetOps.out(System.out, actualResponseRSR);
+        if (debug)
+            RowSetOps.out(System.out, actualResponseRSR);
         boolean equals = isomorphic(expectedRSR, actualResponseRSR);
         assertTrue(equals);
     }
@@ -224,7 +230,8 @@ class TestYamlConfigParserAuthz {
                 .httpHeader(LibTestsSCG.tokenHeader(),
                         LibTestsSCG.tokenHeaderValue(validToken))
                 .select().rewindable();
-        RowSetOps.out(System.out, actualResponseRSR);
+        if (debug)
+            RowSetOps.out(System.out, actualResponseRSR);
         boolean equals = isomorphic(expectedRSRtdl, actualResponseRSR);
         assertTrue(equals);
     }
@@ -241,7 +248,8 @@ class TestYamlConfigParserAuthz {
                 .httpHeader(LibTestsSCG.tokenHeader(),
                         LibTestsSCG.tokenHeaderValue(validToken))
                 .select().rewindable();
-        RowSetOps.out(System.out, actualResponseRSR);
+        if (debug)
+            RowSetOps.out(System.out, actualResponseRSR);
         boolean equals = isomorphic(expectedRSR, actualResponseRSR);
         assertTrue(equals);
     }

--- a/scg-system/src/test/java/io/telicent/backup/TestBackupData.java
+++ b/scg-system/src/test/java/io/telicent/backup/TestBackupData.java
@@ -293,6 +293,41 @@ public class TestBackupData {
     }
 
     @Test
+    public void test_createBackup_async_emptyGraph() {
+        server = buildServer("--port=0", "--empty");
+
+        HttpResponse<InputStream> submitResponse =
+                makeAuthPOSTCallWithPath(server, "$/backups/create?async=true&description=abc&backup-name=new-backup",
+                                         "test");
+        assertEquals(202, submitResponse.statusCode());
+
+        Map submit = convertToMap(submitResponse);
+        assertEquals("CREATE_BACKUP", submit.get("operation"));
+        assertTrue(submit.containsKey("job-id"));
+
+        Map job = waitForJob((String) submit.get("job-id"));
+        assertEquals("SUCCEEDED", job.get("status"));
+        assertEquals(200, job.get("http-status"));
+        Map result = (Map) job.get("result");
+        assertEquals("FULL", result.get("backup-type"));
+        assertEquals("test", result.get("user"));
+        assertEquals("abc", result.get("description"));
+        assertEquals("new-backup", result.get("backup-name"));
+    }
+
+    @Test
+    public void test_getBackupJob_unknownJobId() {
+        server = buildServer("--port=0", "--empty");
+
+        HttpResponse<InputStream> jobResponse =
+                makeAuthGETCallWithPath(server, "$/backups/jobs/unknown-job-id", "test");
+        assertEquals(404, jobResponse.statusCode());
+
+        Map responseMap = convertToMap(jobResponse);
+        assertEquals("Unknown backup job id: unknown-job-id", responseMap.get("error"));
+    }
+
+    @Test
     public void test_listBackups_emptyGraph() {
         // given
         server = buildServer("--port=0", "--empty");
@@ -412,6 +447,46 @@ public class TestBackupData {
     }
 
     @Test
+    public void test_restoreBackup_async_emptyGraph() {
+        server = buildServer("--port=0", "--empty");
+
+        HttpResponse<InputStream> createBackupResponse = makeAuthPOSTCallWithPath(server, "$/backups/create/", "test");
+        assertEquals(200, createBackupResponse.statusCode());
+
+        HttpResponse<InputStream> submitResponse =
+                makeAuthPOSTCallWithPath(server, "$/backups/restore?async=true", "test");
+        assertEquals(202, submitResponse.statusCode());
+
+        Map submit = convertToMap(submitResponse);
+        assertEquals("RESTORE_BACKUP", submit.get("operation"));
+        Map job = waitForJob((String) submit.get("job-id"));
+        assertEquals("SUCCEEDED", job.get("status"));
+        assertEquals(200, job.get("http-status"));
+        Map result = (Map) job.get("result");
+        assertEquals("test", result.get("user"));
+        assertEquals("FULL", result.get("backup-type"));
+        assertTrue(result.containsKey("restorePath"));
+    }
+
+    @Test
+    public void test_listBackupJobs_containsSubmittedJob() {
+        server = buildServer("--port=0", "--empty");
+
+        HttpResponse<InputStream> submitResponse =
+                makeAuthPOSTCallWithPath(server, "$/backups/create?async=true", "test");
+        assertEquals(202, submitResponse.statusCode());
+
+        Map submit = convertToMap(submitResponse);
+        HttpResponse<InputStream> jobsResponse =
+                makeAuthGETCallWithPath(server, "$/backups/jobs", "test");
+        assertEquals(200, jobsResponse.statusCode());
+
+        Map jobsMap = convertToMap(jobsResponse);
+        List<Map<String, Object>> jobs = (List<Map<String, Object>>) jobsMap.get("jobs");
+        assertTrue(jobs.stream().anyMatch(job -> submit.get("job-id").equals(job.get("job-id"))));
+    }
+
+    @Test
     public void test_createBackup_error() {
         // given
         testModule = new FMod_BackupData_Null();
@@ -514,6 +589,28 @@ public class TestBackupData {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @SuppressWarnings("rawtypes")
+    private Map waitForJob(String jobId) {
+        for (int i = 0; i < 20; i++) {
+            HttpResponse<InputStream> jobResponse =
+                    makeAuthGETCallWithPath(server, "$/backups/jobs/" + jobId, "test");
+            assertEquals(200, jobResponse.statusCode());
+            Map responseMap = convertToMap(jobResponse);
+            Map job = (Map) responseMap.get("job");
+            if ("SUCCEEDED".equals(job.get("status")) || "FAILED".equals(job.get("status"))) {
+                return job;
+            }
+            try {
+                Thread.sleep(50L);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                fail("Interrupted while waiting for async backup job");
+            }
+        }
+        fail("Timed out waiting for async backup job completion");
+        return null;
     }
 
 

--- a/scg-system/src/test/java/io/telicent/backup/TestBackupData.java
+++ b/scg-system/src/test/java/io/telicent/backup/TestBackupData.java
@@ -469,6 +469,7 @@ public class TestBackupData {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void test_listBackupJobs_containsSubmittedJob() {
         server = buildServer("--port=0", "--empty");
 

--- a/scg-system/src/test/java/io/telicent/backup/utils/RSAKeyPairGenerator.java
+++ b/scg-system/src/test/java/io/telicent/backup/utils/RSAKeyPairGenerator.java
@@ -46,6 +46,7 @@ public class RSAKeyPairGenerator
             CompressionAlgorithmTags.ZLIB, CompressionAlgorithmTags.BZIP2, CompressionAlgorithmTags.ZLIB, CompressionAlgorithmTags.UNCOMPRESSED
     };
 
+    @SuppressWarnings("deprecation")
     public static void generateAndExportKeyRing(
             OutputStream secretOut,
             OutputStream publicOut,

--- a/scg-system/src/test/java/io/telicent/core/TestInitialCompaction.java
+++ b/scg-system/src/test/java/io/telicent/core/TestInitialCompaction.java
@@ -1,5 +1,6 @@
 package io.telicent.core;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import io.telicent.LibTestsSCG;
 import io.telicent.backup.TestBackupData;
 import io.telicent.jena.abac.ABAC;
@@ -41,6 +42,7 @@ import java.util.Set;
 
 import static io.telicent.TestJwtServletAuth.*;
 import static io.telicent.TestSmartCacheGraphIntegration.launchServer;
+import static io.telicent.backup.utils.JsonFileUtils.OBJECT_MAPPER;
 import static io.telicent.core.FMod_InitialCompaction.compactLabels;
 import static org.apache.jena.graph.Graph.emptyGraph;
 import static org.junit.jupiter.api.Assertions.*;
@@ -160,6 +162,7 @@ public class TestInitialCompaction {
     }
 
     @Test
+    @SuppressWarnings("removal")
     public void test_TDB1_DSG() {
         // given
         DatasetGraph tdb1_DG = TDB1Factory.createDatasetGraph(Location.mem());
@@ -461,6 +464,67 @@ public class TestInitialCompaction {
     }
 
     @Test
+    public void test_compactOne_async_happyPath() throws IOException {
+        mockDatabaseMgr.when(() -> DatabaseMgr.compact(any(), anyBoolean())).thenAnswer(invocationOnMock -> null);
+        DatasetGraphSwitchable dsgPersists = createPersistentSwitchableDataset();
+        server = SmartCacheGraph.smartCacheGraphBuilder().port(0).add("test", dsgPersists).build().start();
+        String token = tokenForUserWithCompactPermissions("test", "test");
+
+        HttpResponse<InputStream> submitResponse =
+                makeAuthCallWithCustomToken(server, "$/compact/test?async=true", token, "POST");
+
+        assertEquals(202, submitResponse.statusCode());
+        Map<String, Object> submit = convertToMap(submitResponse);
+        assertEquals("COMPACT_DATASET", submit.get("operation"));
+        String statusPath = (String) submit.get("status-path");
+        assertTrue(statusPath.contains("/$/compaction/jobs/test/"));
+
+        Map<String, Object> job = waitForJob(statusPath, token);
+        assertEquals("SUCCEEDED", job.get("status"));
+        assertEquals(200, job.get("http-status"));
+        Map<?, ?> result = asMap(job.get("result"));
+        assertEquals("ok", result.get("status"));
+        Map<?, ?> datasets = asMap(result.get("datasets"));
+        assertTrue(Set.of("COMPACTED", "SKIPPED_ALREADY_COMPACTED", "SKIPPED_PREVIOUSLY_COMPACTED")
+                      .contains(datasets.get("/test")));
+    }
+
+    @Test
+    public void test_compactOne_async_unknownJobId() {
+        server = SmartCacheGraph.smartCacheGraphBuilder().port(0).add("test", DatasetGraphFactory.createTxnMem()).build().start();
+
+        HttpResponse<InputStream> jobResponse =
+                makeAuthCallWithCustomToken(server, "$/compaction/jobs/test/unknown-job-id",
+                                            tokenForUserWithCompactPermissions("test", "test"), "GET");
+
+        assertEquals(404, jobResponse.statusCode());
+        Map<String, Object> responseMap = convertToMap(jobResponse);
+        assertEquals("Unknown compaction job id: unknown-job-id", responseMap.get("error"));
+    }
+
+    @Test
+    public void test_compactOne_async_listJobs() throws IOException {
+        mockDatabaseMgr.when(() -> DatabaseMgr.compact(any(), anyBoolean())).thenAnswer(invocationOnMock -> null);
+        DatasetGraphSwitchable dsgPersists = createPersistentSwitchableDataset();
+        server = SmartCacheGraph.smartCacheGraphBuilder().port(0).add("test", dsgPersists).build().start();
+        String token = tokenForUserWithCompactPermissions("test", "test");
+
+        HttpResponse<InputStream> submitResponse =
+                makeAuthCallWithCustomToken(server, "$/compact/test?async=true", token, "POST");
+        Map<String, Object> submit = convertToMap(submitResponse);
+        String statusPath = (String) submit.get("status-path");
+        waitForJob(statusPath, token);
+
+        HttpResponse<InputStream> listResponse =
+                makeAuthCallWithCustomToken(server, "$/compaction/jobs/test", token, "GET");
+
+        assertEquals(200, listResponse.statusCode());
+        Map<String, Object> responseMap = convertToMap(listResponse);
+        List<?> jobs = asList(responseMap.get("jobs"));
+        assertFalse(jobs.isEmpty());
+    }
+
+    @Test
     public void test_compactAll_mixedOutcomesReturnsSummary() throws IOException {
         // Given
         DatasetGraphSwitchable dsgPersists = createPersistentSwitchableDataset();
@@ -533,6 +597,53 @@ public class TestInitialCompaction {
         assertTrue(indicator.isPresent());
         assertEquals(FMod_InitialCompaction.CompactionIndicatorState.FAILED, indicator.get().state());
         assertNotNull(indicator.get().error());
+    }
+
+    @Test
+    public void test_compactAll_async_happyPath() throws IOException {
+        mockDatabaseMgr.when(() -> DatabaseMgr.compact(any(), anyBoolean())).thenAnswer(invocationOnMock -> null);
+        DatasetGraphSwitchable dsgPersists = createPersistentSwitchableDataset();
+        server = SmartCacheGraph.smartCacheGraphBuilder().port(0).add("test", dsgPersists).build().start();
+        String token = tokenForUserWithCompactPermissions("test", "test");
+
+        HttpResponse<InputStream> submitResponse =
+                makeAuthCallWithCustomToken(server, "$/compactall?async=true", token, "POST");
+
+        assertEquals(202, submitResponse.statusCode());
+        Map<String, Object> submit = convertToMap(submitResponse);
+        assertEquals("COMPACT_ALL_DATASETS", submit.get("operation"));
+        String statusPath = (String) submit.get("status-path");
+        assertTrue(statusPath.contains("/$/compaction/jobs/all/"));
+
+        Map<String, Object> job = waitForJob(statusPath, token);
+        assertEquals("SUCCEEDED", job.get("status"));
+        assertEquals(200, job.get("http-status"));
+        Map<?, ?> result = asMap(job.get("result"));
+        Map<?, ?> datasets = asMap(result.get("datasets"));
+        assertTrue(Set.of("COMPACTED", "SKIPPED_ALREADY_COMPACTED", "SKIPPED_PREVIOUSLY_COMPACTED")
+                      .contains(datasets.get("/test")));
+    }
+
+    @Test
+    public void test_compactAll_async_listJobs() throws IOException {
+        mockDatabaseMgr.when(() -> DatabaseMgr.compact(any(), anyBoolean())).thenAnswer(invocationOnMock -> null);
+        DatasetGraphSwitchable dsgPersists = createPersistentSwitchableDataset();
+        server = SmartCacheGraph.smartCacheGraphBuilder().port(0).add("test", dsgPersists).build().start();
+        String token = tokenForUserWithCompactPermissions("test", "test");
+
+        HttpResponse<InputStream> submitResponse =
+                makeAuthCallWithCustomToken(server, "$/compactall?async=true", token, "POST");
+        Map<String, Object> submit = convertToMap(submitResponse);
+        String statusPath = (String) submit.get("status-path");
+        waitForJob(statusPath, token);
+
+        HttpResponse<InputStream> listResponse =
+                makeAuthCallWithCustomToken(server, "$/compaction/jobs/all", token, "GET");
+
+        assertEquals(200, listResponse.statusCode());
+        Map<String, Object> responseMap = convertToMap(listResponse);
+        List<?> jobs = asList(responseMap.get("jobs"));
+        assertFalse(jobs.isEmpty());
     }
 
     @Test
@@ -610,7 +721,7 @@ public class TestInitialCompaction {
     @Test
     public void test_compactLabels_notABAC() {
         // given
-        DatasetGraph dsgNotABAC = TDB1Factory.createDatasetGraph(Location.mem());
+        DatasetGraph dsgNotABAC = DatasetGraphFactory.createTxnMem();
         // when
         // then
         compactLabels(dsgNotABAC);
@@ -637,17 +748,20 @@ public class TestInitialCompaction {
         // then
         FusekiServer.Builder mockBuilder = mock(FusekiServer.Builder.class);
 
+        ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<HttpServlet> servletCaptor = ArgumentCaptor.forClass(HttpServlet.class);
-        when(mockBuilder.addServlet(any(), servletCaptor.capture())).thenReturn(mockBuilder);
+        when(mockBuilder.addServlet(pathCaptor.capture(), servletCaptor.capture())).thenReturn(mockBuilder);
 
         fModInitialCompaction.configured(mockBuilder, null, null);
 
         verify(mockBuilder).addServlet(eq("/$/compactall"), any(HttpServlet.class));
-        HttpServlet capturedServlet = servletCaptor.getValue();
+        int compactAllIndex = pathCaptor.getAllValues().indexOf("/$/compactall");
+        HttpServlet capturedServlet = servletCaptor.getAllValues().get(compactAllIndex);
 
 
         HttpServletRequest request = mock(HttpServletRequest.class);
         when(request.getMethod()).thenReturn("POST");
+        when(request.getProtocol()).thenReturn("HTTP/1.1");
 
         HttpServletResponse response = mock(HttpServletResponse.class);
         assertThrows(ActionErrorException.class, () -> capturedServlet.service(request, response));
@@ -661,6 +775,61 @@ public class TestInitialCompaction {
                           .claims(Map.of("roles", List.of("ADMIN_SYSTEM"),
                                          "permissions", compactPermissions))
                           .compact();
+    }
+
+    private Map<String, Object> convertToMap(HttpResponse<InputStream> response) {
+        try {
+            InputStreamReader reader = new InputStreamReader(response.body(), StandardCharsets.UTF_8);
+            return OBJECT_MAPPER.readValue(reader, new TypeReference<>() {});
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Map<String, Object> waitForJob(String jobPath, String jwt) {
+        String requestPath = jobPath.startsWith("/") ? jobPath.substring(1) : jobPath;
+        for (int i = 0; i < 20; i++) {
+            HttpResponse<InputStream> jobResponse = makeAuthCallWithCustomToken(server, requestPath, jwt, "GET");
+            if (jobResponse.statusCode() != 200) {
+                try {
+                    fail("Unexpected status " + jobResponse.statusCode() + " for " + requestPath + ": "
+                         + IOUtils.toString(jobResponse.body(), StandardCharsets.UTF_8));
+                } catch (IOException e) {
+                    fail("Unexpected status " + jobResponse.statusCode() + " for " + requestPath
+                         + " and failed to read body: " + e.getMessage());
+                }
+            }
+            Map<String, Object> responseMap = convertToMap(jobResponse);
+            Map<String, Object> job = asTypedMap(responseMap.get("job"));
+            if ("SUCCEEDED".equals(job.get("status")) || "FAILED".equals(job.get("status"))) {
+                return job;
+            }
+            try {
+                Thread.sleep(50L);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                fail("Interrupted while waiting for async compaction job");
+            }
+        }
+        fail("Timed out waiting for async compaction job completion");
+        return null;
+    }
+
+    private static Map<?, ?> asMap(Object value) {
+        assertInstanceOf(Map.class, value);
+        return (Map<?, ?>) value;
+    }
+
+    private static Map<String, Object> asTypedMap(Object value) {
+        assertInstanceOf(Map.class, value);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> typed = (Map<String, Object>) value;
+        return typed;
+    }
+
+    private static List<?> asList(Object value) {
+        assertInstanceOf(List.class, value);
+        return (List<?>) value;
     }
 
     private static DatasetGraphSwitchable createPersistentSwitchableDataset() throws IOException {

--- a/scg-system/src/test/java/io/telicent/core/auth/TestSCGAuthPolicyGeneration.java
+++ b/scg-system/src/test/java/io/telicent/core/auth/TestSCGAuthPolicyGeneration.java
@@ -81,6 +81,8 @@ public class TestSCGAuthPolicyGeneration {
         verifyPermissions(policies, "/" + datasetName + "/access/*", readPermission);
         verifyPermissions(policies, "/$/labels/" + datasetName, readPermission);
         verifyPermissions(policies, "/$/compact/" + datasetName, compactPermission);
+        verifyPermissions(policies, "/$/compaction/jobs/" + datasetName, compactPermission);
+        verifyPermissions(policies, "/$/compaction/jobs/" + datasetName + "/*", compactPermission);
     }
 
     private void verifyRoles(Map<PathExclusion, Policy> policies, String path, String... expected) {
@@ -106,6 +108,9 @@ public class TestSCGAuthPolicyGeneration {
         // Verify roles generated for Telicent custom endpoints
         verifyRoles(policies, "/" + datasetName + "/access/*", SCG_AuthPolicy.DEFAULT_ROLES.values());
         verifyRoles(policies, "/$/labels/" + datasetName, SCG_AuthPolicy.DEFAULT_ROLES.values());
+        verifyRoles(policies, "/$/compact/" + datasetName, SCG_AuthPolicy.ADMIN_ROLES.values());
+        verifyRoles(policies, "/$/compaction/jobs/" + datasetName, SCG_AuthPolicy.ADMIN_ROLES.values());
+        verifyRoles(policies, "/$/compaction/jobs/" + datasetName + "/*", SCG_AuthPolicy.ADMIN_ROLES.values());
     }
 
     @Test
@@ -125,6 +130,8 @@ public class TestSCGAuthPolicyGeneration {
         // NB - The /$/compactall permissions are dynamically built based upon all the registered datasets so in this
         //      case will only have one permission required
         verifyPermissions(perms, "/$/compactall", TelicentPermissions.compactPermission("knowledge"));
+        verifyPermissions(perms, "/$/compaction/jobs/all", TelicentPermissions.compactPermission("knowledge"));
+        verifyPermissions(perms, "/$/compaction/jobs/all/*", TelicentPermissions.compactPermission("knowledge"));
     }
 
     @Test
@@ -148,6 +155,10 @@ public class TestSCGAuthPolicyGeneration {
         verifyDatasetPermissions(perms, "catalog");
         // NB - The /$/compactall permissions are dynamically built based upon all the registered datasets
         verifyPermissions(perms, "/$/compactall", TelicentPermissions.compactPermission("knowledge"),
+                          TelicentPermissions.compactPermission("catalog"));
+        verifyPermissions(perms, "/$/compaction/jobs/all", TelicentPermissions.compactPermission("knowledge"),
+                          TelicentPermissions.compactPermission("catalog"));
+        verifyPermissions(perms, "/$/compaction/jobs/all/*", TelicentPermissions.compactPermission("knowledge"),
                           TelicentPermissions.compactPermission("catalog"));
     }
 
@@ -180,9 +191,13 @@ public class TestSCGAuthPolicyGeneration {
         Assertions.assertFalse(roles.isEmpty());
         Assertions.assertFalse(perms.isEmpty());
         verifyRoles(roles, "/$/compactall", SCG_AuthPolicy.ADMIN_ROLES.values());
+        verifyRoles(roles, "/$/compaction/jobs/all", SCG_AuthPolicy.ADMIN_ROLES.values());
+        verifyRoles(roles, "/$/compaction/jobs/all/*", SCG_AuthPolicy.ADMIN_ROLES.values());
         // NB - Permissions for /$/compactall are dynamically built based on the datasets so will be undefined in this
         //      case
         verifyNoPolicy(perms, "/$/compactall");
+        verifyNoPolicy(perms, "/$/compaction/jobs/all");
+        verifyNoPolicy(perms, "/$/compaction/jobs/all/*");
         verifyRoles(roles, "/$/backups/*", SCG_AuthPolicy.ADMIN_ROLES.values());
         verifyPermissions(perms, "/$/backups/create", SCG_AuthPolicy.BACKUP_CREATE.values());
         verifyPermissions(perms, "/$/backups/delete", SCG_AuthPolicy.BACKUP_DELETE.values());


### PR DESCRIPTION
Keeping inline with similar API changes to SC Search([here](https://github.com/Telicent-io/smart-cache-search/pull/762)). 

Adding additional endpoints to list running asycn jobs and provide details. 

Also retaining backwards compatibility with existing operations by default.