### PR TITLE
[CORE-1276] When using named graph routing, provide additional filtering based upon the new distribution lifecycle.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,51 @@ Graph then you can disable this via the aforementioned [`FEATURE_FLAG_AUTHZ`](#f
 If you disable this you may wish to limit access to these endpoints via other mechanisms available in your deployment
 environment, e.g. service mesh policy, proxy server rules etc.
 
+### `ROUTE_TO_NAMED_GRAPHS`
+
+When set to `true` the Smart Cache Graph Kafka sink routes each incoming event into a named graph whose URI is the
+`Distribution-ID` header from the event. All event data is written into the corresponding named graph; the default graph
+is left empty. Events that lack a `Distribution-ID` header are rejected. When unset, or set to `false`, events are
+applied to the dataset as authored, and the `Distribution-ID` header is ignored.
+
+This is the prerequisite for distribution lifecycle filtering described below.
+
+### `DISTRIBUTION_LIFECYCLE_STATE_FILE`
+
+Path to a JSON file that describes the lifecycle state of each known distribution. When set (and
+[`ROUTE_TO_NAMED_GRAPHS`](#route_to_named_graphs) is also `true`) the server filters every ABAC-enabled dataset so that
+only named graphs whose corresponding distribution is currently in the `Active` state are visible to queries.
+Distributions in any other state (`Unregistered`, `Registered`, `Withdrawn`, `Deleted`, or any unrecognised value) are
+hidden from query results regardless of the user's attributes.
+
+The file is expected to be written by an external lifecycle manager (see the
+[CORE-1275 `distribution-lifecycle` module](https://github.com/telicent-oss/smart-caches-core)) and is re-read on demand
+whenever its modification time or size changes. Atomic update via a sibling `<file>.tmp` file is supported, and a
+`<file>.bak` is used as a fallback if the primary file is unreadable. The expected JSON shape is:
+
+```json
+{
+  "application": "my-scg-instance",
+  "distributions": {
+    "http://example/distribution/1": "Active",
+    "http://example/distribution/2": "Withdrawn"
+  }
+}
+```
+
+If the file is missing, malformed, or refers to a different application (see
+[`DISTRIBUTION_LIFECYCLE_APP_ID`](#distribution_lifecycle_app_id)), no graphs are exposed — the filter fails closed.
+
+Has no effect when `ROUTE_TO_NAMED_GRAPHS` is not enabled; a warning will be logged at server startup in that case.
+
+### `DISTRIBUTION_LIFECYCLE_APP_ID`
+
+Optional. The application identifier expected to appear in the `application` field of
+[`DISTRIBUTION_LIFECYCLE_STATE_FILE`](#distribution_lifecycle_state_file). When set, a state file whose `application`
+field does not match this value is rejected (and no graphs are exposed) — this prevents an SC-Graph instance from
+accidentally consuming a lifecycle state file intended for a different application. When unset, the `application` field
+in the state file is not checked.
+
 ### `ENABLE_LABELS_QUERY`
 
 Setting this to `true` will enable the security label query endpoint at `http://{hostname}/$/labels/{datasetName}`. More

--- a/scg-system/pom.xml
+++ b/scg-system/pom.xml
@@ -133,6 +133,11 @@
             <groupId>io.telicent.smart-caches</groupId>
             <artifactId>jwt-auth-common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.telicent.smart-caches</groupId>
+            <artifactId>distribution-lifecycle</artifactId>
+            <version>${dependency.smart-caches-core}</version>
+        </dependency>
         <!-- GraphQL -->
         <dependency>
             <groupId>io.telicent.jena.graphql</groupId>

--- a/scg-system/src/main/java/io/telicent/core/FMod_DistributionLifecycleFilter.java
+++ b/scg-system/src/main/java/io/telicent/core/FMod_DistributionLifecycleFilter.java
@@ -49,7 +49,7 @@ public class FMod_DistributionLifecycleFilter implements FusekiAutoModule {
             if (!(dap.getDataService().getDataset() instanceof DatasetGraphABAC abacDataset)) {
                 continue;
             }
-            DistributionLifecycleFilters.installIfConfigured(abacDataset, routeToNamedGraphs);
+            DistributionLifecycleFilters.installIfConfigured(abacDataset);
         }
     }
 }

--- a/scg-system/src/main/java/io/telicent/core/FMod_DistributionLifecycleFilter.java
+++ b/scg-system/src/main/java/io/telicent/core/FMod_DistributionLifecycleFilter.java
@@ -1,0 +1,55 @@
+package io.telicent.core;
+
+import io.telicent.distribution.DistributionLifecycleFilters;
+import io.telicent.jena.abac.core.DatasetGraphABAC;
+import io.telicent.smart.cache.configuration.Configurator;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jena.atlas.lib.Version;
+import org.apache.jena.atlas.logging.FmtLog;
+import org.apache.jena.fuseki.Fuseki;
+import org.apache.jena.fuseki.main.FusekiServer;
+import org.apache.jena.fuseki.main.sys.FusekiAutoModule;
+import org.apache.jena.fuseki.server.DataAccessPoint;
+import org.apache.jena.fuseki.server.DataAccessPointRegistry;
+import org.apache.jena.rdf.model.Model;
+
+/**
+ * Installs lifecycle-aware named graph filtering for ABAC datasets.
+ */
+public class FMod_DistributionLifecycleFilter implements FusekiAutoModule {
+
+    public static final String DISTRIBUTION_LIFECYCLE_STATE_FILE = "DISTRIBUTION_LIFECYCLE_STATE_FILE";
+    public static final String DISTRIBUTION_LIFECYCLE_APP_ID = "DISTRIBUTION_LIFECYCLE_APP_ID";
+
+    private static final String VERSION =
+            Version.versionForClass(FMod_DistributionLifecycleFilter.class).orElse("<development>");
+
+    @Override
+    public String name() {
+        return "Distribution Lifecycle Module";
+    }
+
+    @Override
+    public void configured(FusekiServer.Builder serverBuilder, DataAccessPointRegistry dapRegistry, Model configModel) {
+        String stateFile = Configurator.get(DISTRIBUTION_LIFECYCLE_STATE_FILE);
+        if (StringUtils.isBlank(stateFile)) {
+            return;
+        }
+
+        boolean routeToNamedGraphs = Configurator.get("ROUTE_TO_NAMED_GRAPHS", Boolean::parseBoolean, false);
+        if (!routeToNamedGraphs) {
+            FmtLog.warn(Fuseki.configLog,
+                        "Telicent Distribution Lifecycle Module (%s) ignored because ROUTE_TO_NAMED_GRAPHS is disabled",
+                        VERSION);
+            return;
+        }
+
+        FmtLog.info(Fuseki.configLog, "Telicent Distribution Lifecycle Module (%s)", VERSION);
+        for (DataAccessPoint dap : dapRegistry.accessPoints()) {
+            if (!(dap.getDataService().getDataset() instanceof DatasetGraphABAC abacDataset)) {
+                continue;
+            }
+            DistributionLifecycleFilters.installIfConfigured(abacDataset, routeToNamedGraphs);
+        }
+    }
+}

--- a/scg-system/src/main/java/io/telicent/core/SmartCacheGraph.java
+++ b/scg-system/src/main/java/io/telicent/core/SmartCacheGraph.java
@@ -122,6 +122,7 @@ public class SmartCacheGraph {
                 , new FMod_TelicentGraphQL()
                 , new FMod_RequestIDFilter()
                 , new FMod_DatasetAvailabilityFilter()
+                , new FMod_DistributionLifecycleFilter()
                 , new FMod_BackupData()
                 , new FMod_LabelsQuery()
                 , new FMod_AccessQuery()

--- a/scg-system/src/main/java/io/telicent/distribution/DistributionLifecycleDatasetFilterProvider.java
+++ b/scg-system/src/main/java/io/telicent/distribution/DistributionLifecycleDatasetFilterProvider.java
@@ -1,0 +1,47 @@
+package io.telicent.distribution;
+
+import io.telicent.jena.abac.DefaultDatasetFilterProvider;
+import io.telicent.jena.abac.DatasetFilterProvider;
+import io.telicent.jena.abac.core.CxtABAC;
+import io.telicent.jena.abac.core.DatasetGraphABAC;
+import io.telicent.jena.abac.labels.Label;
+import io.telicent.jena.abac.labels.LabelsStore;
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.DatasetGraphFilteredView;
+
+import java.util.Set;
+
+/**
+ * A dataset filter provider that limits visible named graphs to distributions that are currently active.
+ */
+public class DistributionLifecycleDatasetFilterProvider implements DatasetFilterProvider {
+
+    private static final DatasetFilterProvider DEFAULT_PROVIDER = new DefaultDatasetFilterProvider();
+
+    private final DistributionLifecycleStateFile lifecycleStateFile;
+    private final DatasetFilterProvider delegate;
+
+    DistributionLifecycleDatasetFilterProvider(DistributionLifecycleStateFile lifecycleStateFile,
+                                              DatasetFilterProvider delegate) {
+        this.lifecycleStateFile = lifecycleStateFile;
+        this.delegate = delegate != null ? delegate : DEFAULT_PROVIDER;
+    }
+
+    @Override
+    public DatasetGraph filterDataset(DatasetGraphABAC dsgAuthz, CxtABAC cxt) {
+        DatasetGraph filtered = this.delegate.filterDataset(dsgAuthz, cxt);
+        return applyLifecycleFilter(filtered);
+    }
+
+    @Override
+    public DatasetGraph filterDataset(DatasetGraph dsgBase, LabelsStore labels, Label defaultLabel, CxtABAC cxt) {
+        DatasetGraph filtered = this.delegate.filterDataset(dsgBase, labels, defaultLabel, cxt);
+        return applyLifecycleFilter(filtered);
+    }
+
+    private DatasetGraph applyLifecycleFilter(DatasetGraph dataset) {
+        Set<Node> activeGraphs = this.lifecycleStateFile.activeGraphNodes();
+        return new DatasetGraphFilteredView(dataset, null, activeGraphs);
+    }
+}

--- a/scg-system/src/main/java/io/telicent/distribution/DistributionLifecycleFilters.java
+++ b/scg-system/src/main/java/io/telicent/distribution/DistributionLifecycleFilters.java
@@ -1,0 +1,45 @@
+package io.telicent.distribution;
+
+import io.telicent.core.FMod_DistributionLifecycleFilter;
+import io.telicent.jena.abac.DatasetFilterProvider;
+import io.telicent.jena.abac.core.DatasetGraphABAC;
+import io.telicent.smart.cache.configuration.Configurator;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
+
+/** Installs the lifecycle-aware dataset filter when the feature is configured. */
+public class DistributionLifecycleFilters {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DistributionLifecycleFilters.class);
+
+    private DistributionLifecycleFilters() {
+    }
+
+    public static boolean installIfConfigured(DatasetGraphABAC dataset, boolean routeToNamedGraphs) {
+        if (!routeToNamedGraphs) {
+            return false;
+        }
+        if (dataset.getFilterProvider() instanceof DistributionLifecycleDatasetFilterProvider) {
+            return false;
+        }
+
+        String stateFile = Configurator.get(FMod_DistributionLifecycleFilter.DISTRIBUTION_LIFECYCLE_STATE_FILE);
+        if (StringUtils.isBlank(stateFile)) {
+            return false;
+        }
+
+        String applicationId = Configurator.get(FMod_DistributionLifecycleFilter.DISTRIBUTION_LIFECYCLE_APP_ID);
+        DatasetFilterProvider delegate = dataset.getFilterProvider();
+        dataset.setFilterProvider(new DistributionLifecycleDatasetFilterProvider(
+                new DistributionLifecycleStateFile(Path.of(stateFile), applicationId), delegate));
+        if (delegate != null) {
+            LOGGER.info("Installed lifecycle-aware dataset filter for SCG named-graph routing by wrapping existing dataset filter provider");
+        } else {
+            LOGGER.info("Installed lifecycle-aware dataset filter for SCG named-graph routing");
+        }
+        return true;
+    }
+}

--- a/scg-system/src/main/java/io/telicent/distribution/DistributionLifecycleFilters.java
+++ b/scg-system/src/main/java/io/telicent/distribution/DistributionLifecycleFilters.java
@@ -18,16 +18,16 @@ public class DistributionLifecycleFilters {
     private DistributionLifecycleFilters() {
     }
 
-    public static boolean installIfConfigured(DatasetGraphABAC dataset, boolean routeToNamedGraphs) {
-        if (!routeToNamedGraphs) {
-            return false;
-        }
+    public static boolean installIfConfigured(DatasetGraphABAC dataset) {
         if (dataset.getFilterProvider() instanceof DistributionLifecycleDatasetFilterProvider) {
+            LOGGER.info("Lifecycle-aware dataset filter already installed for this dataset; skipping");
             return false;
         }
 
         String stateFile = Configurator.get(FMod_DistributionLifecycleFilter.DISTRIBUTION_LIFECYCLE_STATE_FILE);
         if (StringUtils.isBlank(stateFile)) {
+            LOGGER.info("Lifecycle-aware dataset filter not installed: {} is not configured",
+                        FMod_DistributionLifecycleFilter.DISTRIBUTION_LIFECYCLE_STATE_FILE);
             return false;
         }
 

--- a/scg-system/src/main/java/io/telicent/distribution/DistributionLifecycleStateFile.java
+++ b/scg-system/src/main/java/io/telicent/distribution/DistributionLifecycleStateFile.java
@@ -1,0 +1,139 @@
+package io.telicent.distribution;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.telicent.smart.cache.distribution.lifecycle.DistributionLifecycleState;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/** Reads the active distribution set from the lifecycle state file. */
+public class DistributionLifecycleStateFile {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DistributionLifecycleStateFile.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String TMP_EXTENSION = ".tmp";
+    private static final String BAK_EXTENSION = ".bak";
+    private static final Cache EMPTY_CACHE = new Cache(null, null, Set.of());
+
+    private final Path stateFile;
+    private final String applicationId;
+    private volatile Cache cache = EMPTY_CACHE;
+
+    DistributionLifecycleStateFile(Path stateFile, String applicationId) {
+        this.stateFile = Objects.requireNonNull(stateFile, "stateFile cannot be null");
+        this.applicationId = StringUtils.trimToNull(applicationId);
+    }
+
+    Set<Node> activeGraphNodes() {
+        refresh();
+        return this.cache.activeGraphs();
+    }
+
+    private synchronized void refresh() {
+        List<Path> candidates = candidateFiles();
+        if (candidates.isEmpty()) {
+            this.cache = EMPTY_CACHE;
+            return;
+        }
+
+        for (Path candidate : candidates) {
+            try {
+                byte[] content = Files.readAllBytes(candidate);
+                String fingerprint = fingerprint(content);
+                Cache current = this.cache;
+                if (Objects.equals(current.source(), candidate) && Objects.equals(current.fingerprint(), fingerprint)) {
+                    return;
+                }
+
+                Set<Node> activeGraphs = loadActiveGraphs(candidate, content);
+                this.cache = new Cache(candidate, fingerprint, activeGraphs);
+                return;
+            } catch (IOException | IllegalArgumentException e) {
+                LOGGER.warn("Failed to load distribution lifecycle state from {}", candidate, e);
+            }
+        }
+    }
+
+    private List<Path> candidateFiles() {
+        List<Path> candidates = new ArrayList<>(3);
+        addCandidate(candidates, this.stateFile);
+        addCandidate(candidates, Path.of(this.stateFile.toString() + TMP_EXTENSION));
+        addCandidate(candidates, Path.of(this.stateFile.toString() + BAK_EXTENSION));
+        return candidates;
+    }
+
+    private static void addCandidate(List<Path> candidates, Path path) {
+        if (Files.isRegularFile(path)) {
+            candidates.add(path);
+        }
+    }
+
+    private Set<Node> loadActiveGraphs(Path candidate, byte[] content) throws IOException {
+        try (InputStream input = new java.io.ByteArrayInputStream(content)) {
+            JsonNode root = MAPPER.readTree(input);
+            verifyApplication(root, candidate);
+
+            JsonNode distributions = root.path("distributions");
+            if (!distributions.isObject()) {
+                return Set.of();
+            }
+
+            Set<Node> activeGraphs = new LinkedHashSet<>();
+
+            distributions.properties().forEach(entry ->  {
+                if (!DistributionLifecycleState.Active.name().equals(entry.getValue().asText())) {
+                    return;
+                }
+                activeGraphs.add(NodeFactory.createURI(entry.getKey()));
+            });
+            return Collections.unmodifiableSet(activeGraphs);
+        }
+    }
+
+    private void verifyApplication(JsonNode root, Path candidate) {
+        if (this.applicationId == null) {
+            return;
+        }
+
+        String fileApplication = root.path("application").asText(null);
+        if (!Objects.equals(this.applicationId, fileApplication)) {
+            throw new IllegalArgumentException(
+                    "Lifecycle state file " + candidate + " is for application " + fileApplication
+                    + " not expected application " + this.applicationId);
+        }
+    }
+
+    private static String fingerprint(byte[] content) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(content);
+            StringBuilder builder = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                builder.append(Character.forDigit((b >> 4) & 0xF, 16));
+                builder.append(Character.forDigit(b & 0xF, 16));
+            }
+            return builder.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 digest unavailable", e);
+        }
+    }
+
+    private record Cache(Path source, String fingerprint, Set<Node> activeGraphs) {
+    }
+}

--- a/scg-system/src/main/java/io/telicent/distribution/DistributionLifecycleStateFile.java
+++ b/scg-system/src/main/java/io/telicent/distribution/DistributionLifecycleStateFile.java
@@ -68,6 +68,9 @@ public class DistributionLifecycleStateFile {
                 LOGGER.warn("Failed to load distribution lifecycle state from {}", candidate, e);
             }
         }
+        LOGGER.warn("All candidate lifecycle state files for {} failed to parse - dropping cached active set",
+                    this.stateFile);
+        this.cache = EMPTY_CACHE;
     }
 
     private List<Path> candidateFiles() {

--- a/scg-system/src/main/java/io/telicent/distribution/DistributionLifecycleStateFile.java
+++ b/scg-system/src/main/java/io/telicent/distribution/DistributionLifecycleStateFile.java
@@ -73,8 +73,8 @@ public class DistributionLifecycleStateFile {
     private List<Path> candidateFiles() {
         List<Path> candidates = new ArrayList<>(3);
         addCandidate(candidates, this.stateFile);
-        addCandidate(candidates, Path.of(this.stateFile.toString() + TMP_EXTENSION));
-        addCandidate(candidates, Path.of(this.stateFile.toString() + BAK_EXTENSION));
+        addCandidate(candidates, Path.of(this.stateFile + TMP_EXTENSION));
+        addCandidate(candidates, Path.of(this.stateFile + BAK_EXTENSION));
         return candidates;
     }
 

--- a/scg-system/src/test/java/io/telicent/core/AbstractSmartCacheGraphSinkTests.java
+++ b/scg-system/src/test/java/io/telicent/core/AbstractSmartCacheGraphSinkTests.java
@@ -3,6 +3,7 @@ package io.telicent.core;
 import io.telicent.LibTestsSCG;
 import io.telicent.jena.abac.ABAC;
 import io.telicent.jena.abac.AttributeValueSet;
+import io.telicent.jena.abac.DefaultDatasetFilterProvider;
 import io.telicent.jena.abac.SysABAC;
 import io.telicent.jena.abac.attributes.Attribute;
 import io.telicent.jena.abac.attributes.AttributeValue;
@@ -14,6 +15,7 @@ import io.telicent.jena.abac.core.AttributesStoreModifiable;
 import io.telicent.jena.abac.core.DatasetGraphABAC;
 import io.telicent.jena.abac.labels.LabelsStore;
 import io.telicent.smart.cache.configuration.Configurator;
+import io.telicent.smart.cache.configuration.sources.SystemPropertiesSource;
 import io.telicent.smart.cache.payloads.RdfPayload;
 import io.telicent.smart.cache.projectors.Sink;
 import io.telicent.smart.cache.sources.Event;
@@ -42,13 +44,18 @@ import org.apache.jena.sparql.exec.RowSet;
 import org.apache.jena.sparql.exec.RowSetOps;
 import org.apache.jena.system.Txn;
 import org.apache.kafka.common.utils.Bytes;
-import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -524,6 +531,41 @@ public abstract class AbstractSmartCacheGraphSinkTests {
         sink.send(event);
     }
 
+    private static void withDistributionLifecycleConfig(Path stateFile, String applicationId, ThrowingRunnable action)
+            throws IOException {
+        String previousRouteToNamedGraphs = System.getProperty("ROUTE_TO_NAMED_GRAPHS");
+        String previousStateFile = System.getProperty(FMod_DistributionLifecycleFilter.DISTRIBUTION_LIFECYCLE_STATE_FILE);
+        String previousAppId = System.getProperty(FMod_DistributionLifecycleFilter.DISTRIBUTION_LIFECYCLE_APP_ID);
+        try {
+            Configurator.addSource(SystemPropertiesSource.INSTANCE);
+            System.setProperty("ROUTE_TO_NAMED_GRAPHS", "true");
+            System.setProperty(FMod_DistributionLifecycleFilter.DISTRIBUTION_LIFECYCLE_STATE_FILE, stateFile.toString());
+            if (applicationId != null) {
+                System.setProperty(FMod_DistributionLifecycleFilter.DISTRIBUTION_LIFECYCLE_APP_ID, applicationId);
+            } else {
+                System.clearProperty(FMod_DistributionLifecycleFilter.DISTRIBUTION_LIFECYCLE_APP_ID);
+            }
+            action.run();
+        } finally {
+            restoreProperty("ROUTE_TO_NAMED_GRAPHS", previousRouteToNamedGraphs);
+            restoreProperty(FMod_DistributionLifecycleFilter.DISTRIBUTION_LIFECYCLE_STATE_FILE, previousStateFile);
+            restoreProperty(FMod_DistributionLifecycleFilter.DISTRIBUTION_LIFECYCLE_APP_ID, previousAppId);
+            Files.deleteIfExists(stateFile);
+        }
+    }
+
+    private static void writeLifecycleStateFile(Path lifecycleState, String content) throws IOException {
+        Files.writeString(lifecycleState, content, StandardCharsets.UTF_8);
+    }
+
+    private static void restoreProperty(String key, String value) {
+        if (value != null) {
+            System.setProperty(key, value);
+        } else {
+            System.clearProperty(key);
+        }
+    }
+
     private void runTestProcessorSCGWithAuth(TestAction execTestAction) {
         // Set up a DatasetGraphABAC in a Fuseki/SCG
         DatasetGraph dsgBase = createBaseDataset();
@@ -596,6 +638,10 @@ public abstract class AbstractSmartCacheGraphSinkTests {
     protected abstract boolean supportsLabellingQuads();
 
     private void runTestProcessorSCGWithAuthNamedGraph(TestAction execTestAction) {
+        runTestProcessorSCGWithAuthNamedGraph(null, execTestAction);
+    }
+
+    private void runTestProcessorSCGWithAuthNamedGraph(DatasetConfigurer datasetConfigurer, TestAction execTestAction) {
         Assumptions.assumeTrue(supportsLabellingQuads(), "Test requires label store that supports labelling quads");
 
         DatasetGraph dsgBase = createBaseDataset();
@@ -607,6 +653,9 @@ public abstract class AbstractSmartCacheGraphSinkTests {
 
         DatasetGraphABAC dsgz =
                 ABAC.authzDataset(dsgBase, AEX.strALLOW, labelsStore, SysABAC.denyLabel, attributesStore);
+        if (datasetConfigurer != null) {
+            datasetConfigurer.configure(dsgz);
+        }
         DataService dataSrv = DataService.newBuilder(dsgz).addEndpoint(Operation.Query).build();
 
         FusekiServer server = SmartCacheGraph.serverBuilder().port(0).add(dsName, dataSrv).add(dsBase, dsgBase).build();
@@ -778,6 +827,281 @@ public abstract class AbstractSmartCacheGraphSinkTests {
     }
 
     @Test
+    final void processorSCG_namedGraph_onlyActiveDistributionsVisible() throws IOException {
+        String activeGraph = "http://example/active";
+        String inactiveGraph = "http://example/inactive";
+        Path lifecycleState = Files.createTempFile("distribution-lifecycle", ".json");
+        writeLifecycleStateFile(lifecycleState, """
+                {
+                  "application" : "scg-test",
+                  "distributions" : {
+                    "%s" : "Active",
+                    "%s" : "Withdrawn"
+                  }
+                }
+                """.formatted(activeGraph, inactiveGraph));
+
+        TestAction action =
+                (Sink<Event<Bytes, RdfPayload>> proc, FusekiServer server, DatasetGraph dsgBase, DatasetGraph dsg) -> {
+                    dsg.begin(TxnType.WRITE);
+                    sendEventWithDistributionId(dsg, proc, """
+                            PREFIX : <http://example/>
+                            :s :p "value1" .
+                            """, WebContent.contentTypeTurtle, attrPermit, activeGraph);
+                    sendEventWithDistributionId(dsg, proc, """
+                            PREFIX : <http://example/>
+                            :s :p "value2" .
+                            """, WebContent.contentTypeTurtle, attrPermit, inactiveGraph);
+                    dsg.commit();
+
+                    verifyNamedGraphsHaveData(dsgBase, activeGraph, inactiveGraph);
+
+                    String URL = server.datasetURL(dsName);
+                    verifyCounts(URL, queryAll, 1L, 0L);
+                    verifyCounts(URL, queryUnion, 1L, 0L);
+                };
+
+        withDistributionLifecycleConfig(lifecycleState, "scg-test", () -> runTestProcessorSCGWithAuthNamedGraph(action));
+    }
+
+    @Test
+    final void processorSCG_namedGraph_lifecycleFilterComposesWithExistingDatasetFilterProvider() throws IOException {
+        String activeGraph = "http://example/active";
+        String inactiveGraph = "http://example/inactive";
+        Path lifecycleState = Files.createTempFile("distribution-lifecycle", ".json");
+        writeLifecycleStateFile(lifecycleState, """
+                {
+                  "distributions" : {
+                    "%s" : "Active",
+                    "%s" : "Deleted"
+                  }
+                }
+                """.formatted(activeGraph, inactiveGraph));
+
+        TestAction action =
+                (Sink<Event<Bytes, RdfPayload>> proc, FusekiServer server, DatasetGraph dsgBase, DatasetGraph dsg) -> {
+                    dsg.begin(TxnType.WRITE);
+                    sendEventWithDistributionId(dsg, proc, """
+                            PREFIX : <http://example/>
+                            :s :p "value1" .
+                            """, WebContent.contentTypeTurtle, attrPermit, activeGraph);
+                    sendEventWithDistributionId(dsg, proc, """
+                            PREFIX : <http://example/>
+                            :s :p "value2" .
+                            """, WebContent.contentTypeTurtle, attrPermit, inactiveGraph);
+                    dsg.commit();
+
+                    verifyNamedGraphsHaveData(dsgBase, activeGraph, inactiveGraph);
+
+                    String URL = server.datasetURL(dsName);
+                    verifyCounts(URL, queryAll, 1L, 0L);
+                    verifyCounts(URL, queryUnion, 1L, 0L);
+                };
+
+        withDistributionLifecycleConfig(lifecycleState, null,
+                                        () -> runTestProcessorSCGWithAuthNamedGraph(
+                                                dataset -> dataset.setFilterProvider(new DefaultDatasetFilterProvider()),
+                                                action));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"Unregistered", "Registered", "Withdrawn", "Deleted", "Unrecognised"})
+    final void processorSCG_namedGraph_inactiveDistributionsAreHidden(String state) throws IOException {
+        String graph = "http://example/graph1";
+        Path lifecycleState = Files.createTempFile("distribution-lifecycle", ".json");
+        writeLifecycleStateFile(lifecycleState, """
+                {
+                  "distributions" : {
+                    "%s" : "%s"
+                  }
+                }
+                """.formatted(graph, state));
+
+        TestAction action =
+                (Sink<Event<Bytes, RdfPayload>> proc, FusekiServer server, DatasetGraph dsgBase, DatasetGraph dsg) -> {
+                    dsg.begin(TxnType.WRITE);
+                    sendEventWithDistributionId(dsg, proc, """
+                            PREFIX : <http://example/>
+                            :s :p "value" .
+                            """, WebContent.contentTypeTurtle, attrPermit, graph);
+                    dsg.commit();
+
+                    // Data is physically present in the underlying store...
+                    verifyNamedGraphsHaveData(dsgBase, graph);
+
+                    // ...but invisible through SCG because the distribution isn't Active, even for the permitted user.
+                    String URL = server.datasetURL(dsName);
+                    verifyCounts(URL, queryAll, 0L, 0L);
+                    verifyCounts(URL, queryUnion, 0L, 0L);
+                };
+
+        withDistributionLifecycleConfig(lifecycleState, null, () -> runTestProcessorSCGWithAuthNamedGraph(action));
+    }
+
+    @Test
+    final void processorSCG_namedGraph_applicationIdMismatchHidesAllGraphs() throws IOException {
+        String graph = "http://example/graph1";
+        Path lifecycleState = Files.createTempFile("distribution-lifecycle", ".json");
+        writeLifecycleStateFile(lifecycleState, """
+                {
+                  "application" : "some-other-app",
+                  "distributions" : {
+                    "%s" : "Active"
+                  }
+                }
+                """.formatted(graph));
+
+        TestAction action =
+                (Sink<Event<Bytes, RdfPayload>> proc, FusekiServer server, DatasetGraph dsgBase, DatasetGraph dsg) -> {
+                    dsg.begin(TxnType.WRITE);
+                    sendEventWithDistributionId(dsg, proc, """
+                            PREFIX : <http://example/>
+                            :s :p "value" .
+                            """, WebContent.contentTypeTurtle, attrPermit, graph);
+                    dsg.commit();
+
+                    verifyNamedGraphsHaveData(dsgBase, graph);
+
+                    // App id mismatch -> reader treats the file as unreadable -> empty active set -> nothing visible.
+                    String URL = server.datasetURL(dsName);
+                    verifyCounts(URL, queryAll, 0L, 0L);
+                    verifyCounts(URL, queryUnion, 0L, 0L);
+                };
+
+        withDistributionLifecycleConfig(lifecycleState, "scg-test",
+                                        () -> runTestProcessorSCGWithAuthNamedGraph(action));
+    }
+
+    @Test
+    final void processorSCG_namedGraph_lifecycleFilterDoesNotBypassDenyingLabel() throws IOException {
+        String activeGraph = "http://example/active";
+        Path lifecycleState = Files.createTempFile("distribution-lifecycle", ".json");
+        writeLifecycleStateFile(lifecycleState, """
+                {
+                  "distributions" : {
+                    "%s" : "Active"
+                  }
+                }
+                """.formatted(activeGraph));
+
+        TestAction action =
+                (Sink<Event<Bytes, RdfPayload>> proc, FusekiServer server, DatasetGraph dsgBase, DatasetGraph dsg) -> {
+                    dsg.begin(TxnType.WRITE);
+                    sendEventWithDistributionId(dsg, proc, """
+                            PREFIX : <http://example/>
+                            :s :p "denied" .
+                            """, WebContent.contentTypeTurtle, attrNotPermitted, activeGraph);
+                    dsg.commit();
+
+                    // Distribution is Active so the graph passes the lifecycle filter, but the security label
+                    // denies access regardless of attribute presence.
+                    verifyNamedGraphsHaveData(dsgBase, activeGraph);
+
+                    String URL = server.datasetURL(dsName);
+                    verifyCounts(URL, queryAll, 0L, 0L);
+                    verifyCounts(URL, queryUnion, 0L, 0L);
+                };
+
+        withDistributionLifecycleConfig(lifecycleState, null, () -> runTestProcessorSCGWithAuthNamedGraph(action));
+    }
+
+    @Test
+    final void processorSCG_namedGraph_distributionVisibilityReloadsWhenStateFileChanges() throws IOException {
+        String graph = "http://example/graph1";
+        Path lifecycleState = Files.createTempFile("distribution-lifecycle", ".json");
+        writeLifecycleStateFile(lifecycleState, """
+                {
+                  "distributions" : {
+                    "%s" : "Active"
+                  }
+                }
+                """.formatted(graph));
+
+        TestAction action =
+                (Sink<Event<Bytes, RdfPayload>> proc, FusekiServer server, DatasetGraph dsgBase, DatasetGraph dsg) -> {
+                    dsg.begin(TxnType.WRITE);
+                    sendEventWithDistributionId(dsg, proc, """
+                            PREFIX : <http://example/>
+                            :s :p "value1" .
+                            """, WebContent.contentTypeTurtle, attrPermit, graph);
+                    dsg.commit();
+
+                    String URL = server.datasetURL(dsName);
+                    verifyCounts(URL, queryAll, 1L, 0L);
+
+                    try {
+                        writeLifecycleStateFile(lifecycleState, """
+                                {
+                                  "distributions" : {
+                                    "%s" : "Deleted"
+                                  }
+                                }
+                                """.formatted(graph));
+                    } catch (IOException e) {
+                        fail("Failed to update lifecycle state file", e);
+                    }
+
+                    verifyCounts(URL, queryAll, 0L, 0L);
+                    verifyCounts(URL, queryUnion, 0L, 0L);
+                };
+
+        withDistributionLifecycleConfig(lifecycleState, null, () -> runTestProcessorSCGWithAuthNamedGraph(action));
+    }
+
+    @Test
+    final void processorSCG_namedGraph_distributionVisibilityReloadsSameSizeSameTimestampStateChange()
+            throws IOException {
+        String graph = "http://example/graph1";
+        Path lifecycleState = Files.createTempFile("distribution-lifecycle", ".json");
+        String activeState = """
+                {
+                  "distributions" : {
+                    "%s" : "Active"
+                  }
+                }
+                """.formatted(graph);
+        String hiddenState = """
+                {
+                  "distributions" : {
+                    "%s" : "Hidden"
+                  }
+                }
+                """.formatted(graph);
+        assertEquals(activeState.length(), hiddenState.length(), "Test fixture must keep the JSON size unchanged");
+
+        writeLifecycleStateFile(lifecycleState, activeState);
+        FileTime originalTimestamp = Files.getLastModifiedTime(lifecycleState);
+        long originalSize = Files.size(lifecycleState);
+
+        TestAction action =
+                (Sink<Event<Bytes, RdfPayload>> proc, FusekiServer server, DatasetGraph dsgBase, DatasetGraph dsg) -> {
+                    dsg.begin(TxnType.WRITE);
+                    sendEventWithDistributionId(dsg, proc, """
+                            PREFIX : <http://example/>
+                            :s :p "value1" .
+                            """, WebContent.contentTypeTurtle, attrPermit, graph);
+                    dsg.commit();
+
+                    String URL = server.datasetURL(dsName);
+                    verifyCounts(URL, queryAll, 1L, 0L);
+
+                    try {
+                        writeLifecycleStateFile(lifecycleState, hiddenState);
+                        assertEquals(originalSize, Files.size(lifecycleState),
+                                     "Test fixture must preserve the JSON byte size");
+                        Files.setLastModifiedTime(lifecycleState, originalTimestamp);
+                    } catch (IOException e) {
+                        fail("Failed to update lifecycle state file", e);
+                    }
+
+                    verifyCounts(URL, queryAll, 0L, 0L);
+                    verifyCounts(URL, queryUnion, 0L, 0L);
+                };
+
+        withDistributionLifecycleConfig(lifecycleState, null, () -> runTestProcessorSCGWithAuthNamedGraph(action));
+    }
+
+    @Test
     final void processorSCG_normalMode_distributionIdIgnored() {
         TestAction action =
                 (Sink<Event<Bytes, RdfPayload>> proc, FusekiServer server, DatasetGraph dsgBase, DatasetGraph dsg) -> {
@@ -913,5 +1237,15 @@ public abstract class AbstractSmartCacheGraphSinkTests {
     // The test - directly send requests to the sink and check by making HTTP requests to the Fuseki server.
     interface TestAction {
         void execTest(Sink<Event<Bytes, RdfPayload>> sink, FusekiServer server, DatasetGraph dsgBase, DatasetGraph dsg);
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable {
+        void run() throws IOException;
+    }
+
+    @FunctionalInterface
+    private interface DatasetConfigurer {
+        void configure(DatasetGraphABAC dataset);
     }
 }

--- a/scg-system/src/test/java/io/telicent/distribution/TestDistributionLifecycleFilters.java
+++ b/scg-system/src/test/java/io/telicent/distribution/TestDistributionLifecycleFilters.java
@@ -1,0 +1,120 @@
+package io.telicent.distribution;
+
+import io.telicent.core.FMod_DistributionLifecycleFilter;
+import io.telicent.jena.abac.ABAC;
+import io.telicent.jena.abac.DatasetFilterProvider;
+import io.telicent.jena.abac.DefaultDatasetFilterProvider;
+import io.telicent.jena.abac.SysABAC;
+import io.telicent.jena.abac.attributes.syntax.AEX;
+import io.telicent.jena.abac.core.AttributesStoreLocal;
+import io.telicent.jena.abac.core.DatasetGraphABAC;
+import io.telicent.jena.abac.labels.Labels;
+import io.telicent.smart.cache.configuration.Configurator;
+import io.telicent.smart.cache.configuration.sources.PropertiesSource;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TestDistributionLifecycleFilters {
+
+    private static final String STATE_FILE_PATH = "/tmp/scg-test-lifecycle-state.json";
+
+    private DatasetGraphABAC dataset;
+
+    @BeforeEach
+    void setUp() {
+        Configurator.reset();
+        this.dataset = ABAC.authzDataset(DatasetGraphFactory.createTxnMem(),
+                                         AEX.strALLOW,
+                                         Labels.createLabelsStoreMem(),
+                                         SysABAC.denyLabel,
+                                         new AttributesStoreLocal());
+    }
+
+    @AfterEach
+    void tearDown() {
+        Configurator.reset();
+    }
+
+    @Test
+    void installIfConfigured_returnsFalse_whenLifecycleFilterAlreadyInstalled() {
+        configureStateFile(STATE_FILE_PATH);
+        DistributionLifecycleDatasetFilterProvider existing = new DistributionLifecycleDatasetFilterProvider(
+                new DistributionLifecycleStateFile(Path.of(STATE_FILE_PATH), null), null);
+        dataset.setFilterProvider(existing);
+
+        boolean installed = DistributionLifecycleFilters.installIfConfigured(dataset);
+
+        assertFalse(installed, "Should not reinstall when a lifecycle filter is already present");
+        assertSame(existing, dataset.getFilterProvider(),
+                   "Existing lifecycle filter provider should be left untouched");
+    }
+
+    @Test
+    void installIfConfigured_returnsFalse_whenStateFileNotConfigured() {
+        // Note: deliberately no configureStateFile() call here.
+
+        boolean installed = DistributionLifecycleFilters.installIfConfigured(dataset);
+
+        assertFalse(installed, "Should not install when no state file path is configured");
+        assertNull(dataset.getFilterProvider(),
+                   "No filter provider should have been installed when state file is unconfigured");
+    }
+
+    @Test
+    void installIfConfigured_returnsTrue_andInstallsFreshFilter_whenStateFileConfigured() {
+        configureStateFile(STATE_FILE_PATH);
+        assertNull(dataset.getFilterProvider(), "Pre-condition: dataset has no filter provider");
+
+        boolean installed = DistributionLifecycleFilters.installIfConfigured(dataset);
+
+        assertTrue(installed, "Should install when state file is configured");
+        assertInstanceOf(DistributionLifecycleDatasetFilterProvider.class, dataset.getFilterProvider(),
+                         "Installed filter provider should be the lifecycle one");
+    }
+
+    @Test
+    void installIfConfigured_returnsTrue_andWrapsExistingDelegate_whenStateFileConfigured() {
+        configureStateFile(STATE_FILE_PATH);
+        DatasetFilterProvider existingDelegate = new DefaultDatasetFilterProvider();
+        dataset.setFilterProvider(existingDelegate);
+
+        boolean installed = DistributionLifecycleFilters.installIfConfigured(dataset);
+
+        assertTrue(installed, "Should install (wrapping the existing delegate) when state file configured");
+        assertInstanceOf(DistributionLifecycleDatasetFilterProvider.class, dataset.getFilterProvider(),
+                         "Installed filter provider should be the lifecycle one");
+        // The integration test processorSCG_namedGraph_lifecycleFilterComposesWithExistingDatasetFilterProvider
+        // in AbstractSmartCacheGraphSinkTests verifies that the delegate is actually invoked during query;
+        // here we only need to verify that the wrapping install path returned true and replaced the field.
+    }
+
+    @Test
+    void installIfConfigured_returnsTrue_andInstallsFreshFilter_whenApplicationIdAlsoConfigured() {
+        Properties props = new Properties();
+        props.setProperty(FMod_DistributionLifecycleFilter.DISTRIBUTION_LIFECYCLE_STATE_FILE, STATE_FILE_PATH);
+        props.setProperty(FMod_DistributionLifecycleFilter.DISTRIBUTION_LIFECYCLE_APP_ID, "some-application-id");
+        Configurator.addSource(new PropertiesSource(props));
+
+        boolean installed = DistributionLifecycleFilters.installIfConfigured(dataset);
+
+        assertTrue(installed, "Application id is optional - install should still succeed");
+        assertInstanceOf(DistributionLifecycleDatasetFilterProvider.class, dataset.getFilterProvider());
+    }
+
+    private static void configureStateFile(String path) {
+        Properties props = new Properties();
+        props.setProperty(FMod_DistributionLifecycleFilter.DISTRIBUTION_LIFECYCLE_STATE_FILE, path);
+        Configurator.addSource(new PropertiesSource(props));
+    }
+}

--- a/scg-system/src/test/java/io/telicent/distribution/TestDistributionLifecycleStateFile.java
+++ b/scg-system/src/test/java/io/telicent/distribution/TestDistributionLifecycleStateFile.java
@@ -1,0 +1,109 @@
+package io.telicent.distribution;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TestDistributionLifecycleStateFile {
+
+    private Path stateFile;
+    private Path tmpFile;
+    private Path bakFile;
+    private DistributionLifecycleStateFile reader;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        this.stateFile = Files.createTempFile("scg-test-lifecycle-", ".json");
+        this.tmpFile = Path.of(this.stateFile + ".tmp");
+        this.bakFile = Path.of(this.stateFile + ".bak");
+        this.reader = new DistributionLifecycleStateFile(this.stateFile, null);
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        Files.deleteIfExists(this.stateFile);
+        Files.deleteIfExists(this.tmpFile);
+        Files.deleteIfExists(this.bakFile);
+    }
+
+    @Test
+    void activeGraphNodes_returnsActiveDistributions_whenStateFileIsValid() throws IOException {
+        Files.writeString(this.stateFile, """
+                {
+                  "distributions" : {
+                    "http://example/a" : "Active",
+                    "http://example/b" : "Withdrawn"
+                  }
+                }
+                """, StandardCharsets.UTF_8);
+
+        Set<Node> active = this.reader.activeGraphNodes();
+
+        assertEquals(Set.of(NodeFactory.createURI("http://example/a")), active);
+    }
+
+    @Test
+    void activeGraphNodes_isEmpty_whenStateFileMissing() {
+        // The temp file was created in setUp; remove it so the primary, .tmp and .bak are all absent.
+        Path missingFile = this.stateFile.resolveSibling("does-not-exist.json");
+        DistributionLifecycleStateFile missingReader = new DistributionLifecycleStateFile(missingFile, null);
+
+        Set<Node> active = missingReader.activeGraphNodes();
+
+        assertTrue(active.isEmpty(), "No state file present -> no active distributions");
+    }
+
+    @Test
+    void activeGraphNodes_dropsCachedActiveSet_whenAllCandidatesBecomeUnparseable() throws IOException {
+        // Prime cache with a valid state file.
+        Files.writeString(this.stateFile, """
+                {
+                  "distributions" : {
+                    "http://example/a" : "Active"
+                  }
+                }
+                """, StandardCharsets.UTF_8);
+
+        Set<Node> activeBefore = this.reader.activeGraphNodes();
+        assertEquals(Set.of(NodeFactory.createURI("http://example/a")), activeBefore,
+                     "Pre-condition: primed cache contains the Active distribution");
+
+        // Corrupt candidates.
+        Files.writeString(this.stateFile, "this is not valid json - corruption padding to change size",
+                          StandardCharsets.UTF_8);
+        Files.writeString(this.tmpFile, "also not valid json", StandardCharsets.UTF_8);
+        Files.writeString(this.bakFile, "still not valid json", StandardCharsets.UTF_8);
+
+        Set<Node> activeAfter = this.reader.activeGraphNodes();
+        assertTrue(activeAfter.isEmpty(),
+                   "All candidates unparseable -> active set must be dropped (fail closed); was " + activeAfter);
+    }
+
+    @Test
+    void activeGraphNodes_fallsBackToBackup_whenPrimaryIsUnparseable() throws IOException {
+        Files.writeString(this.stateFile, "garbage", StandardCharsets.UTF_8);
+        Files.writeString(this.bakFile, """
+                {
+                  "distributions" : {
+                    "http://example/from-bak" : "Active"
+                  }
+                }
+                """, StandardCharsets.UTF_8);
+
+        Set<Node> active = this.reader.activeGraphNodes();
+
+        assertEquals(Set.of(NodeFactory.createURI("http://example/from-bak")), active,
+                     ".bak should be used when primary fails to parse");
+    }
+}


### PR DESCRIPTION
Updating SC Graph to be aware of the distribution lifecycle and (in conjunction with named graphs) apply that to filtering so that only distributions marked as ACTIVE are returned. 