### PR TITLE
[CORE-1280] Proactively delete named graphs for deleted distributions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <dependency.jena>6.1.0</dependency.jena>
     <dependency.graphql>0.12.2</dependency.graphql>
     <dependency.jwt-servlet-auth>4.1.0</dependency.jwt-servlet-auth>
-    <dependency.smart-caches-core>0.39.0</dependency.smart-caches-core>
+    <dependency.smart-caches-core>0.40.0</dependency.smart-caches-core>
 
     <!-- External dependencies -->
     <dependency.awaitility>4.3.0</dependency.awaitility>
@@ -294,6 +294,11 @@
       <dependency>
         <groupId>io.telicent.smart-caches</groupId>
         <artifactId>jwt-auth-common</artifactId>
+        <version>${dependency.smart-caches-core}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.telicent.smart-caches</groupId>
+        <artifactId>distribution-lifecycle</artifactId>
         <version>${dependency.smart-caches-core}</version>
       </dependency>
 

--- a/scg-system/src/main/java/io/telicent/core/DistributionGraphDeletionListener.java
+++ b/scg-system/src/main/java/io/telicent/core/DistributionGraphDeletionListener.java
@@ -88,7 +88,7 @@ public class DistributionGraphDeletionListener implements DistributionLifecycleL
             try {
                 deleteDistributionGraph(dataset, graphName);
             } catch (RuntimeException e) {
-                LOGGER.error("Failed to delete named graph {} for deleted distribution {}", distributionId,
+                LOGGER.error("Failed to delete named graph {} for deleted distribution {}", graphName,
                              distributionId, e);
                 failures.add(e);
             }

--- a/scg-system/src/main/java/io/telicent/core/DistributionGraphDeletionListener.java
+++ b/scg-system/src/main/java/io/telicent/core/DistributionGraphDeletionListener.java
@@ -69,13 +69,13 @@ public class DistributionGraphDeletionListener implements DistributionLifecycleL
 
         String distributionId = action.getDistributionId();
         if (StringUtils.isBlank(distributionId)) {
-            LOGGER.debug("Ignoring distribution deletion event {} with no distribution id", action.getEventId());
+            LOGGER.info("Ignoring distribution deletion event {} with no distribution id", action.getEventId());
             return;
         }
 
         Collection<DatasetGraphABAC> datasets = this.datasetSupplier.get();
         if (datasets == null || datasets.isEmpty()) {
-            LOGGER.debug("No ABAC datasets to delete named graph {} from", distributionId);
+            LOGGER.info("No ABAC datasets to delete named graph {} from", distributionId);
             return;
         }
 

--- a/scg-system/src/main/java/io/telicent/core/DistributionGraphDeletionListener.java
+++ b/scg-system/src/main/java/io/telicent/core/DistributionGraphDeletionListener.java
@@ -107,22 +107,25 @@ public class DistributionGraphDeletionListener implements DistributionLifecycleL
      * Deletes the named graph corresponding to a distribution, and any associated ABAC security labels, for the given dataset.
      * @param dataset   ABAC dataset to delete from
      * @param graphName Named graph to delete
+     *
+     * Note: Commented out code to remove corresponding security labels until
+     * it is address as part of wider work
      */
     static void deleteDistributionGraph(DatasetGraphABAC dataset, Node graphName) {
         Txn.executeWrite(dataset, () -> {
             DatasetGraph base = dataset.getBase();
-            LabelsStore labels = dataset.labelsStore();
-            if (labels != null) {
-                List<Quad> quads = Iter.toList(base.find(graphName, Node.ANY, Node.ANY, Node.ANY));
-                for (Quad quad : quads) {
-                    try {
-                        labels.remove(quad);
-                    } catch (RuntimeException e) {
-                        LOGGER.warn("Failed to remove security labels for quad {} while deleting named graph {}", quad,
-                                    graphName, e);
-                    }
-                }
-            }
+//            LabelsStore labels = dataset.labelsStore();
+//            if (labels != null) {
+//                List<Quad> quads = Iter.toList(base.find(graphName, Node.ANY, Node.ANY, Node.ANY));
+//                for (Quad quad : quads) {
+//                    try {
+//                        labels.remove(quad);
+//                    } catch (RuntimeException e) {
+//                        LOGGER.warn("Failed to remove security labels for quad {} while deleting named graph {}", quad,
+//                                    graphName, e);
+//                    }
+//                }
+//            }
             base.removeGraph(graphName);
             LOGGER.info("Deleted named graph {} for deleted distribution", graphName.getURI());
         });

--- a/scg-system/src/main/java/io/telicent/core/DistributionGraphDeletionListener.java
+++ b/scg-system/src/main/java/io/telicent/core/DistributionGraphDeletionListener.java
@@ -1,0 +1,130 @@
+/*
+ *  Copyright (c) Telicent Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.telicent.core;
+
+import io.telicent.jena.abac.core.DatasetGraphABAC;
+import io.telicent.jena.abac.labels.LabelsStore;
+import io.telicent.smart.cache.distribution.lifecycle.DistributionLifecycleState;
+import io.telicent.smart.cache.distribution.lifecycle.events.LifecycleAction;
+import io.telicent.smart.cache.distribution.lifecycle.events.listeners.DistributionLifecycleListener;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jena.atlas.iterator.Iter;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.system.Txn;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * A Distribution Lifecycle Listener that reacts to the Deleted state by
+ * proactively removing the named graph that corresponds to the distribution
+ * from the underlying dataset(s).
+ */
+public class DistributionGraphDeletionListener implements DistributionLifecycleListener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DistributionGraphDeletionListener.class);
+
+    private final Supplier<Collection<DatasetGraphABAC>> datasetSupplier;
+
+    /**
+     * Creates a new listener.
+     *
+     * @param datasetSupplier Supplies the ABAC datasets to review
+     */
+    public DistributionGraphDeletionListener(Supplier<Collection<DatasetGraphABAC>> datasetSupplier) {
+        this.datasetSupplier = Objects.requireNonNull(datasetSupplier, "datasetsSupplier cannot be null");
+    }
+
+    @Override
+    public void accept(LifecycleAction action) {
+        if (action == null) {
+            return;
+        }
+
+        if (action.getState().getTo() != DistributionLifecycleState.Deleted) {
+            return;
+        }
+
+        String distributionId = action.getDistributionId();
+        if (StringUtils.isBlank(distributionId)) {
+            LOGGER.debug("Ignoring distribution deletion event {} with no distribution id", action.getEventId());
+            return;
+        }
+
+        Collection<DatasetGraphABAC> datasets = this.datasetSupplier.get();
+        if (datasets == null || datasets.isEmpty()) {
+            LOGGER.debug("No ABAC datasets to delete named graph {} from", distributionId);
+            return;
+        }
+
+        Node graphName = NodeFactory.createURI(distributionId);
+        List<RuntimeException> failures = new ArrayList<>();
+        for (DatasetGraphABAC dataset : datasets) {
+            if (dataset == null) {
+                continue;
+            }
+            try {
+                deleteDistributionGraph(dataset, graphName);
+            } catch (RuntimeException e) {
+                LOGGER.error("Failed to delete named graph {} for deleted distribution {}", distributionId,
+                             distributionId, e);
+                failures.add(e);
+            }
+        }
+
+        if (!failures.isEmpty()) {
+            RuntimeException toThrow =
+                    new RuntimeException("Failed to delete named graph for deleted distribution " + distributionId +
+                                         " from " + failures.size() + " dataset(s)");
+            failures.forEach(toThrow::addSuppressed);
+            throw toThrow;
+        }
+    }
+
+    /**
+     * Deletes the named graph corresponding to a distribution, and any associated ABAC security labels, for the given dataset.
+     * @param dataset   ABAC dataset to delete from
+     * @param graphName Named graph to delete
+     */
+    static void deleteDistributionGraph(DatasetGraphABAC dataset, Node graphName) {
+        Txn.executeWrite(dataset, () -> {
+            DatasetGraph base = dataset.getBase();
+            LabelsStore labels = dataset.labelsStore();
+            if (labels != null) {
+                List<Quad> quads = Iter.toList(base.find(graphName, Node.ANY, Node.ANY, Node.ANY));
+                for (Quad quad : quads) {
+                    try {
+                        labels.remove(quad);
+                    } catch (RuntimeException e) {
+                        LOGGER.warn("Failed to remove security labels for quad {} while deleting named graph {}", quad,
+                                    graphName, e);
+                    }
+                }
+            }
+            base.removeGraph(graphName);
+            LOGGER.info("Deleted named graph {} for deleted distribution", graphName.getURI());
+        });
+    }
+}

--- a/scg-system/src/test/java/io/telicent/core/TestDistributionGraphDeletionListener.java
+++ b/scg-system/src/test/java/io/telicent/core/TestDistributionGraphDeletionListener.java
@@ -32,6 +32,7 @@ import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.apache.jena.sparql.core.Quad;
 import org.apache.jena.sparql.core.mem.DatasetGraphInMemory;
 import org.apache.jena.system.Txn;
+import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -117,20 +118,21 @@ public class TestDistributionGraphDeletionListener {
 
     }
 
-    @Test
-    void removesSecurityLabelsForDeletedDistribution() {
-        //given
-        DatasetGraphABAC dsg = newDataset();
-        addQuad(dsg, DISTRIBUTION_ID, "value1", Label.fromText("PERMIT"));
-        // when
-        try (DistributionGraphDeletionListener  listener = listenerFor(dsg)) {
-            assertNotNull(listener);
-            listener.accept(action(DISTRIBUTION_ID, DistributionLifecycleState.Active, DistributionLifecycleState.Deleted));
-        }
-        // then
-        assertTrue(graphEmpty(dsg, DISTRIBUTION_ID), "Named graph should be removed");
-        assertTrue(labelsEmpty(dsg), "Security labels for the deleted distribution should be removed");
-    }
+    // Disabling due to commented out code.
+//    @Test
+//    void removesSecurityLabelsForDeletedDistribution() {
+//        //given
+//        DatasetGraphABAC dsg = newDataset();
+//        addQuad(dsg, DISTRIBUTION_ID, "value1", Label.fromText("PERMIT"));
+//        // when
+//        try (DistributionGraphDeletionListener  listener = listenerFor(dsg)) {
+//            assertNotNull(listener);
+//            listener.accept(action(DISTRIBUTION_ID, DistributionLifecycleState.Active, DistributionLifecycleState.Deleted));
+//        }
+//        // then
+//        assertTrue(graphEmpty(dsg, DISTRIBUTION_ID), "Named graph should be removed");
+//        assertTrue(labelsEmpty(dsg), "Security labels for the deleted distribution should be removed");
+//    }
 
     @Test
     void ignoresNonDeletedTransition() {

--- a/scg-system/src/test/java/io/telicent/core/TestDistributionGraphDeletionListener.java
+++ b/scg-system/src/test/java/io/telicent/core/TestDistributionGraphDeletionListener.java
@@ -1,0 +1,288 @@
+/*
+ *  Copyright (c) Telicent Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.telicent.core;
+
+import io.telicent.jena.abac.ABAC;
+import io.telicent.jena.abac.SysABAC;
+import io.telicent.jena.abac.attributes.syntax.AEX;
+import io.telicent.jena.abac.core.DatasetGraphABAC;
+import io.telicent.jena.abac.labels.Label;
+import io.telicent.jena.abac.labels.Labels;
+import io.telicent.jena.abac.labels.LabelsStore;
+import io.telicent.smart.cache.distribution.lifecycle.DistributionLifecycleState;
+import io.telicent.smart.cache.distribution.lifecycle.events.LifecycleAction;
+import io.telicent.smart.cache.distribution.lifecycle.events.utils.LifecycleStateTransition;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
+import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.sparql.core.mem.DatasetGraphInMemory;
+import org.apache.jena.system.Txn;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestDistributionGraphDeletionListener {
+
+    private static final String DISTRIBUTION_ID = "https://example.org/distributions/id-1";
+    private static final String DISTRIBUTION_ID_2 = "https://example.org/distributions/id-2";
+    private static final String DATASET_ID = "dataset-1";
+    private static final String USER_ID = "test@example.org";
+    private static final Node SUBJECT_NODE = NodeFactory.createURI("https://example.org/subject");
+    private static final Node PREDICATE_NODE = NodeFactory.createURI("https://example.org/predicate");
+
+    private static DatasetGraphABAC newDataset() {
+        LabelsStore labels = Labels.createLabelsStoreMem();
+        return ABAC.authzDataset(DatasetGraphFactory.createTxnMem(), AEX.strALLOW, labels, SysABAC.allowLabel, null);
+    }
+
+    private static void addQuad(DatasetGraphABAC dsg, String graphUri, String objectValue, Label label) {
+        Quad quad = Quad.create(NodeFactory.createURI(graphUri), SUBJECT_NODE, PREDICATE_NODE, NodeFactory.createLiteralString(objectValue));
+        Txn.executeWrite(dsg, () -> {
+            dsg.add(quad);
+            if (label != null) {
+                dsg.labelsStore().add(quad, label);
+            }
+        });
+    }
+
+    private static boolean graphEmpty(DatasetGraphABAC dsg, String graphUri) {
+        return Txn.calculateRead(dsg, () -> dsg.getBase().getGraph(NodeFactory.createURI(graphUri)).isEmpty());
+    }
+
+    private static boolean labelsEmpty(DatasetGraphABAC dsg) {
+        return Txn.calculateRead(dsg, () -> dsg.labelsStore().isEmpty());
+    }
+
+    private static LifecycleAction action(String distributionId, DistributionLifecycleState from,
+                                          DistributionLifecycleState to) {
+        return LifecycleAction.builder()
+                              .eventId(UUID.randomUUID())
+                              .distributionId(distributionId)
+                              .datasetId(DATASET_ID)
+                              .user(USER_ID)
+                              .state(LifecycleStateTransition.builder().from(from).to(to).build())
+                              .build();
+    }
+
+    private static DistributionGraphDeletionListener listenerFor(DatasetGraphABAC... datasets) {
+        List<DatasetGraphABAC> list = List.of(datasets);
+        return new DistributionGraphDeletionListener(() -> list);
+    }
+
+    private static DatasetGraphABAC throwingDataset() {
+        // The override must live on the innermost (non-wrapper) graph: DatasetGraphABAC.getBase() recursively unwraps
+        // any DatasetGraphWrapper layers, so a wrapper's override would be bypassed by the listener.
+        DatasetGraphInMemory base = new DatasetGraphInMemory() {
+            @Override
+            public void removeGraph(Node graphName) {
+                throw new RuntimeException("Failure removing graph");
+            }
+        };
+        return ABAC.authzDataset(base, AEX.strALLOW, Labels.createLabelsStoreMem(), SysABAC.allowLabel, null);
+    }
+
+    @Test
+    void deletesNamedGraphForDeletedDistribution() {
+        // given
+        DatasetGraphABAC dsg = newDataset();
+        addQuad(dsg, DISTRIBUTION_ID, "value1", Label.fromText("PERMIT"));
+        addQuad(dsg, DISTRIBUTION_ID_2, "value2", Label.fromText("PERMIT"));
+        // when
+        try (DistributionGraphDeletionListener  listener = listenerFor(dsg)) {
+            assertNotNull(listener);
+            listener.accept(action(DISTRIBUTION_ID, DistributionLifecycleState.Active, DistributionLifecycleState.Deleted));
+        }
+        // then
+        assertTrue(graphEmpty(dsg, DISTRIBUTION_ID), "Deleted distribution's named graph should be removed");
+        assertFalse(graphEmpty(dsg, DISTRIBUTION_ID_2), "Other distribution's named graph should be untouched");
+
+    }
+
+    @Test
+    void removesSecurityLabelsForDeletedDistribution() {
+        //given
+        DatasetGraphABAC dsg = newDataset();
+        addQuad(dsg, DISTRIBUTION_ID, "value1", Label.fromText("PERMIT"));
+        // when
+        try (DistributionGraphDeletionListener  listener = listenerFor(dsg)) {
+            assertNotNull(listener);
+            listener.accept(action(DISTRIBUTION_ID, DistributionLifecycleState.Active, DistributionLifecycleState.Deleted));
+        }
+        // then
+        assertTrue(graphEmpty(dsg, DISTRIBUTION_ID), "Named graph should be removed");
+        assertTrue(labelsEmpty(dsg), "Security labels for the deleted distribution should be removed");
+    }
+
+    @Test
+    void ignoresNonDeletedTransition() {
+        // given
+        DatasetGraphABAC dsg = newDataset();
+        addQuad(dsg, DISTRIBUTION_ID, "value1", Label.fromText("PERMIT"));
+        // when
+        try (DistributionGraphDeletionListener  listener = listenerFor(dsg)) {
+            assertNotNull(listener);
+            listener.accept(action(DISTRIBUTION_ID, DistributionLifecycleState.Active, DistributionLifecycleState.Withdrawn));
+        }
+        // then
+        assertFalse(graphEmpty(dsg, DISTRIBUTION_ID), "A non-Deleted transition must not delete the named graph");
+        assertFalse(labelsEmpty(dsg), "A non-Deleted transition must not remove labels");
+    }
+
+    @Test
+    void isIdempotentWhenAppliedRepeatedly() {
+        // given
+        DatasetGraphABAC dsg = newDataset();
+        addQuad(dsg, DISTRIBUTION_ID, "value1", Label.fromText("PERMIT"));
+        // when
+        try (DistributionGraphDeletionListener listener = listenerFor(dsg)) {
+            LifecycleAction deleted =
+                    action(DISTRIBUTION_ID, DistributionLifecycleState.Active, DistributionLifecycleState.Deleted);
+            // then
+            assertDoesNotThrow(() -> {
+                listener.accept(deleted);
+                listener.accept(deleted);
+            });
+        }
+        assertTrue(graphEmpty(dsg, DISTRIBUTION_ID));
+    }
+
+    @Test
+    void isSafeWhenNamedGraphDoesNotExist() {
+        // given
+        DatasetGraphABAC dsg = newDataset();
+        // when
+        try (DistributionGraphDeletionListener listener = listenerFor(dsg)) {
+            // then
+            assertDoesNotThrow(() -> listener.accept(
+                    action(DISTRIBUTION_ID, DistributionLifecycleState.Active, DistributionLifecycleState.Deleted)));
+            assertTrue(graphEmpty(dsg, DISTRIBUTION_ID));
+        }
+    }
+
+    @Test
+    void deletesNamedGraphFromAllManagedDatasets() {
+        // given
+        DatasetGraphABAC dsg1 = newDataset();
+        DatasetGraphABAC dsg2 = newDataset();
+        addQuad(dsg1, DISTRIBUTION_ID, "value1", Label.fromText("PERMIT"));
+        addQuad(dsg2, DISTRIBUTION_ID, "value1", Label.fromText("PERMIT"));
+        // when
+        try (DistributionGraphDeletionListener listener = listenerFor(dsg1, dsg2)) {
+            listener.accept(action(DISTRIBUTION_ID, DistributionLifecycleState.Active, DistributionLifecycleState.Deleted));
+        }
+        // then
+        assertTrue(graphEmpty(dsg1, DISTRIBUTION_ID), "Named graph should be removed from the first dataset");
+        assertTrue(graphEmpty(dsg2, DISTRIBUTION_ID), "Named graph should be removed from the second dataset");
+    }
+
+    @Test
+    void handlesNoManagedDatasets() {
+        // given
+        try (DistributionGraphDeletionListener listener = new DistributionGraphDeletionListener(List::of)) {
+            // when
+            // then
+            assertDoesNotThrow(() -> listener.accept(
+                    action(DISTRIBUTION_ID, DistributionLifecycleState.Active, DistributionLifecycleState.Deleted)));
+        }
+    }
+
+    @Test
+    void ignoresNullAction() {
+        // given
+        DatasetGraphABAC dsg = newDataset();
+        addQuad(dsg, DISTRIBUTION_ID, "value1", Label.fromText("PERMIT"));
+
+        try (DistributionGraphDeletionListener listener = listenerFor(dsg)) {
+            // when
+            assertDoesNotThrow(() -> listener.accept(null));
+        }
+
+        // then
+        assertFalse(graphEmpty(dsg, DISTRIBUTION_ID), "A null action must not delete any data");
+    }
+
+    @Test
+    void ignoresBlankDistributionId() {
+        // given
+        DatasetGraphABAC dsg = newDataset();
+        addQuad(dsg, DISTRIBUTION_ID, "value1", Label.fromText("PERMIT"));
+
+        try (DistributionGraphDeletionListener listener = listenerFor(dsg)) {
+            // when
+            listener.accept(action("", DistributionLifecycleState.Active, DistributionLifecycleState.Deleted));
+        }
+
+        // then
+        assertFalse(graphEmpty(dsg, DISTRIBUTION_ID),
+                    "A deletion event with a blank distribution id must not delete any data");
+    }
+
+    @Test
+    void handlesNullDatasetCollection() {
+        // given
+        LifecycleAction deleted =
+                action(DISTRIBUTION_ID, DistributionLifecycleState.Active, DistributionLifecycleState.Deleted);
+
+        try (DistributionGraphDeletionListener listener = new DistributionGraphDeletionListener(() -> null)) {
+            // when
+            // then
+            assertDoesNotThrow(() -> listener.accept(deleted));
+        }
+    }
+
+    @Test
+    void skipsNullDatasetEntries() {
+        // given
+        DatasetGraphABAC dsg = newDataset();
+        addQuad(dsg, DISTRIBUTION_ID, "value1", Label.fromText("PERMIT"));
+
+        try (DistributionGraphDeletionListener listener =
+                     new DistributionGraphDeletionListener(() -> Arrays.asList(null, dsg))) {
+            // when
+            assertDoesNotThrow(() -> listener.accept(
+                    action(DISTRIBUTION_ID, DistributionLifecycleState.Active, DistributionLifecycleState.Deleted)));
+        }
+
+        // then
+        assertTrue(graphEmpty(dsg, DISTRIBUTION_ID),
+                   "Null dataset entries should be skipped and remaining datasets still processed");
+    }
+
+    @Test
+    void continuesProcessingOtherDatasetsAndRethrowsWhenADatasetFails() {
+        // given
+        DatasetGraphABAC failing = throwingDataset();
+        DatasetGraphABAC working = newDataset();
+        addQuad(working, DISTRIBUTION_ID, "value1", Label.fromText("PERMIT"));
+
+        try (DistributionGraphDeletionListener listener = listenerFor(failing, working)) {
+            LifecycleAction deleted =
+                    action(DISTRIBUTION_ID, DistributionLifecycleState.Active, DistributionLifecycleState.Deleted);
+
+            // when
+            // then
+            assertThrows(RuntimeException.class, () -> listener.accept(deleted));
+            assertTrue(graphEmpty(working, DISTRIBUTION_ID),
+                       "A failure on one dataset must not prevent deletion on the others");
+        }
+    }
+}


### PR DESCRIPTION
Adding new module that listens for Distribution lifecycle delete and remove the associated named graph.

*Note:* We've not plugged DistributionGraphDeletionListener in just yet. We need to decide how to process the lifecycle message on the relevant kafka topic. I don't think we should necessarily use jena-fuseki (so the SC Core code) but that would mean two differing kafka processes within a single app. 