### PR TITLE
[CORE-1347] Address sbom missing warning in build

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -64,6 +64,7 @@ jobs:
           registry: aws
           fail-on-unfixed: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          download-sbom: "false"
           enable-buildkit-cache: "true"
           build-args: |
             PROJECT_VERSION=${{ needs.maven-build.outputs.version }}


### PR DESCRIPTION
As a follow-up to this https://github.com/telicent-oss/shared-workflows/pull/239