### PR TITLE
[Minor] Remove Docker module from publishing.

### DIFF
--- a/scg-docker/pom.xml
+++ b/scg-docker/pom.xml
@@ -31,6 +31,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <gpg.skip>true</gpg.skip>
     </properties>
 
     <dependencies>
@@ -85,6 +86,13 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <skipPublishing>true</skipPublishing>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
 Given we're not publishing  no need to use gpg either (so hopefully faster without).