### PR TITLE
Add disk usage metric for TDB2 databses (CORE-1147)

### DIFF
--- a/scg-system/src/main/java/io/telicent/core/FMod_MemoryInfo.java
+++ b/scg-system/src/main/java/io/telicent/core/FMod_MemoryInfo.java
@@ -1,0 +1,52 @@
+package io.telicent.core;
+
+import io.telicent.smart.cache.configuration.Configurator;
+import io.telicent.smart.cache.observability.RuntimeInfo;
+import io.telicent.smart.cache.projectors.utils.PeriodicAction;
+import org.apache.jena.atlas.lib.Version;
+import org.apache.jena.atlas.logging.FmtLog;
+import org.apache.jena.fuseki.Fuseki;
+import org.apache.jena.fuseki.main.FusekiServer;
+import org.apache.jena.fuseki.main.sys.FusekiAutoModule;
+import org.apache.jena.rdf.model.Model;
+
+import java.time.Duration;
+import java.util.Set;
+
+/**
+ * A Fuseki module that periodically reports memory usage information to the logs
+ */
+public class FMod_MemoryInfo implements FusekiAutoModule {
+
+    private static final String VERSION = Version.versionForClass(FMod_MemoryInfo.class).orElse("<development>");
+
+    @Override
+    public String name() {
+        return "Memory Info Reporting Module";
+    }
+
+    @Override
+    public void prepare(FusekiServer.Builder serverBuilder, Set<String> datasetNames, Model configModel) {
+        FmtLog.info(Fuseki.configLog, "Memory Info Reporting Module (%s)", VERSION);
+
+        long interval = Configurator.get("MEMORY_INFO_INTERVAL", Long::parseLong, 5L);
+        if (interval > 0) {
+            FmtLog.info(Fuseki.configLog, "Configured to report memory information every %d minutes", interval);
+            PeriodicAction memoryReporter =
+                    new PeriodicAction(() -> RuntimeInfo.printMemoryInfo(Fuseki.configLog), Duration.ofMinutes(5));
+            serverBuilder.setServletAttribute(this.getClass().getCanonicalName(), memoryReporter);
+            memoryReporter.autoTrigger();
+        } else {
+            Fuseki.configLog.info("Memory information reporting disabled, MEMORY_INFO_INTERVAL set to negative value");
+        }
+    }
+
+    @Override
+    public void serverStopped(FusekiServer server) {
+        PeriodicAction memoryReporter =
+                (PeriodicAction) server.getServletContext().getAttribute(this.getClass().getCanonicalName());
+        if (memoryReporter != null) {
+            memoryReporter.cancelAutoTrigger();
+        }
+    }
+}

--- a/scg-system/src/main/java/io/telicent/core/SmartCacheGraph.java
+++ b/scg-system/src/main/java/io/telicent/core/SmartCacheGraph.java
@@ -119,6 +119,7 @@ public class SmartCacheGraph {
         mods.addAll(List.of(
                 new FMod_JwtServletAuth()
                 , new FMod_OpenTelemetry()
+                , new FMod_MemoryInfo()
                 , new FMod_TelicentGraphQL()
                 , new FMod_RequestIDFilter()
                 , new FMod_DatasetAvailabilityFilter()

--- a/scg-system/src/main/java/io/telicent/otel/FMod_OpenTelemetry.java
+++ b/scg-system/src/main/java/io/telicent/otel/FMod_OpenTelemetry.java
@@ -23,6 +23,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.ObservableLongGauge;
+import io.opentelemetry.semconv.DbAttributes;
+import io.telicent.core.FMod_InitialCompaction;
+import org.apache.commons.io.FileUtils;
 import org.apache.jena.Jena;
 import org.apache.jena.atlas.lib.Lib;
 import org.apache.jena.atlas.lib.Version;
@@ -32,6 +36,10 @@ import org.apache.jena.fuseki.main.FusekiServer;
 import org.apache.jena.fuseki.main.sys.FusekiModule;
 import org.apache.jena.fuseki.server.*;
 import org.apache.jena.rdf.model.Model;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.util.DatasetUtils;
+import org.apache.jena.tdb2.store.DatasetGraphSwitchable;
+import org.apache.jena.tdb2.store.DatasetGraphTDB;
 
 @SuppressWarnings("deprecation")
 public class FMod_OpenTelemetry implements FusekiModule {
@@ -41,6 +49,11 @@ public class FMod_OpenTelemetry implements FusekiModule {
     public static final AttributeKey<String> DB_OPERATION = AttributeKey.stringKey("db.operation");
     public static final AttributeKey<String> FUSEKI_ENDPOINT = AttributeKey.stringKey("fuseki.endpoint");
     public static final AttributeKey<String> FUSEKI_OPERATION = AttributeKey.stringKey("fuseki.operation");
+    protected static final String METRIC_PREFIX = "smartcache.graph.";
+    /**
+     * Metric that records TDB2 disk space usage
+     */
+    public static final String TDB_DISK_USAGE = METRIC_PREFIX + "tdb2.disk.usage";
 
     public static String ENV_OPENTELEMETRY = "FUSEKI_FMOD_OTEL";
     public static String SYS_OPENTELEMETRY = "fuseki:fmod:OpenTelemetry";
@@ -53,17 +66,18 @@ public class FMod_OpenTelemetry implements FusekiModule {
     private static final String VERSION = Version.versionForClass(FMod_OpenTelemetry.class).orElse("<development>");
 
     /**
-     * Enable / disable FMod_OpenTelemetry : this is necessary because there are
-     * background operations (threads) associated with OpenTelemetry. If running with
-     * OTel on the class/module path, and setting {@code ENABLED = false} means
-     * FMod_OpenTelemetry will not start OpenTelemetry. This must be called before
-     * Fuseki module loading, which is usually happening during JenaSystem.init();
+     * Enable / disable FMod_OpenTelemetry : this is necessary because there are background operations (threads)
+     * associated with OpenTelemetry. If running with OTel on the class/module path, and setting {@code ENABLED = false}
+     * means FMod_OpenTelemetry will not start OpenTelemetry. This must be called before Fuseki module loading, which is
+     * usually happening during JenaSystem.init();
      */
     public static boolean ENABLED = Lib.isPropertyOrEnvVarSetToTrue(SYS_OPENTELEMETRY, ENV_OPENTELEMETRY);
 
     private static AtomicBoolean INITIALIZED = new AtomicBoolean(false);
 
-    /** One time initialization */
+    /**
+     * One time initialization
+     */
     private static void init() {
         // Run once.
         INITIALIZED.getAndSet(true);
@@ -75,16 +89,18 @@ public class FMod_OpenTelemetry implements FusekiModule {
 
     @Override
     public void prepare(FusekiServer.Builder serverBuilder, Set<String> datasetNames, Model configModel) {
-        if ( ! ENABLED )
+        if (!ENABLED) {
             return;
+        }
         init();
         FmtLog.info(Fuseki.configLog, "OpenTelemetry Fuseki Module (%s)", VERSION);
     }
 
     @Override
     public void configured(FusekiServer.Builder serverBuilder, DataAccessPointRegistry dapRegistry, Model configModel) {
-        if ( ! ENABLED )
+        if (!ENABLED) {
             return;
+        }
         dapRegistry.accessPoints().forEach(FMod_OpenTelemetry::buildMetrics);
     }
 
@@ -92,25 +108,49 @@ public class FMod_OpenTelemetry implements FusekiModule {
         Meter meter = JenaMetrics.getMeter("Jena", Jena.VERSION);
         DataService dataService = dap.getDataService();
 
-        for ( Operation operation : dataService.getOperations() ) {
+        // Add gauge for disk space usage if using TDB2
+        DatasetGraphSwitchable tdb = FMod_InitialCompaction.getTDB2(dataService.getDataset());
+        if (tdb != null) {
+            Attributes diskUsageAttributes = Attributes.builder()
+                                                       .put(DB_SYSTEM, "Apache Jena TDB2")
+                                                       .put(DbAttributes.DB_SYSTEM_NAME, "Apache Jena TDB2")
+                                                       .put(DB_NAME, dap.getName())
+                                                       .put(DbAttributes.DB_NAMESPACE,
+                                                            "file://" + tdb.getContainerPath()
+                                                                           .toFile()
+                                                                           .getAbsolutePath())
+                                                       .build();
+            meter.gaugeBuilder(TDB_DISK_USAGE)
+                 .setUnit("bytes")
+                 .ofLongs()
+                 .buildWithCallback(m -> m.record(FileUtils.sizeOfDirectory(tdb.getContainerPath().toFile()),
+                                                  diskUsageAttributes));
+        }
+
+        // Add gauges for each Fuseki counter
+        for (Operation operation : dataService.getOperations()) {
             List<Endpoint> endpoints = dataService.getEndpoints(operation);
-            for ( Endpoint endpoint : endpoints ) {
+            for (Endpoint endpoint : endpoints) {
                 CounterSet counters = endpoint.getCounters();
-                for ( CounterName counterName : counters.counters() ) {
+                for (CounterName counterName : counters.counters()) {
                     Counter counter = counters.get(counterName);
 
                     // Single shared gauge for each Fuseki counter, unique attribute sets for each endpoint that has
                     // that counter
                     // smartcache.graph.[counter name]
-                    Attributes metricAttributes = Attributes.of(DB_SYSTEM, "Apache Jena Fuseki",
-                                                                DB_NAME, dap.getName(),
-                                                                DB_OPERATION,
-                                                                endpoint.getOperation().getName(),
-                                                                FUSEKI_ENDPOINT, endpoint.getName(),
-                                                                FUSEKI_OPERATION, operation.getDescription());
+                    Attributes metricAttributes = Attributes.builder()
+                                                            .put(DB_SYSTEM, "Apache Jena Fuseki")
+                                                            .put(DbAttributes.DB_SYSTEM_NAME, "Apache Jena Fuseki")
+                                                            .put(DB_NAME, dap.getName())
+                                                            .put(DB_OPERATION, endpoint.getOperation().getName())
+                                                            .put(DbAttributes.DB_OPERATION_NAME,
+                                                                 endpoint.getOperation().getName())
+                                                            .put(FUSEKI_ENDPOINT, endpoint.getName())
+                                                            .put(FUSEKI_OPERATION, operation.getDescription())
+                                                            .build();
 
                     String counterTxt = fixupName(counterName.getFullName());
-                    String gaugeName = "smartcache.graph." + counterTxt;
+                    String gaugeName = METRIC_PREFIX + counterTxt;
                     meter.gaugeBuilder(gaugeName)
                          .ofLongs()
                          .buildWithCallback(measure -> measure.record(counter.value(), metricAttributes));
@@ -121,6 +161,7 @@ public class FMod_OpenTelemetry implements FusekiModule {
 
     /**
      * Take a filename string and replace any troublesome characters
+     *
      * @param name to be cleaned
      * @return a cleaned filename
      */

--- a/scg-system/src/test/java/io/telicent/otel/TestJenaMetrics.java
+++ b/scg-system/src/test/java/io/telicent/otel/TestJenaMetrics.java
@@ -59,6 +59,7 @@ import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.apache.jena.sys.JenaSystem;
 import org.apache.jena.tdb2.TDB2Factory;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -73,11 +74,15 @@ class TestJenaMetrics {
         LibTestsSCG.disableInitialCompaction();
     }
 
+    @AfterAll
+    static void teardown() throws Exception {
+        LibTestsSCG.teardownAuthentication();
+    }
+
     @Test
     void no_configuration() throws Exception {
         OpenTelemetry otel = JenaMetrics.get();
         assertNotNull(otel);
-        LibTestsSCG.teardownAuthentication();
     }
 
     @Test

--- a/scg-system/src/test/java/io/telicent/otel/TestJenaMetrics.java
+++ b/scg-system/src/test/java/io/telicent/otel/TestJenaMetrics.java
@@ -21,11 +21,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.file.Files;
 import java.time.Duration;
 import java.util.Map;
 import java.util.UUID;
@@ -53,8 +55,10 @@ import org.apache.jena.Jena;
 import org.apache.jena.fuseki.main.FusekiServer;
 import org.apache.jena.fuseki.system.FusekiLogging;
 import org.apache.jena.http.HttpEnv;
+import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.apache.jena.sys.JenaSystem;
+import org.apache.jena.tdb2.TDB2Factory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -264,13 +268,13 @@ class TestJenaMetrics {
         boolean openTelemetryEnabledSetting = FMod_OpenTelemetry.ENABLED;
         FMod_OpenTelemetry.ENABLED = true;
         try {
-            server_metrics_reader2();
+            server_metrics_reader2(DatasetGraphFactory.empty());
         } finally {
             FMod_OpenTelemetry.ENABLED = openTelemetryEnabledSetting;
         }
     }
 
-    private void server_metrics_reader2() throws IOException, InterruptedException {
+    private InMemoryMetricReader server_metrics_reader2(DatasetGraph dsg) throws IOException, InterruptedException {
         InMemoryMetricReader reader = InMemoryMetricReader.create();
         SdkMeterProvider meterProvider = SdkMeterProvider.builder().registerMetricReader(reader).build();
         OpenTelemetrySdk sdk = OpenTelemetrySdk.builder().setMeterProvider(meterProvider).build();
@@ -279,7 +283,7 @@ class TestJenaMetrics {
 
         FusekiServer server = SmartCacheGraph.smartCacheGraphBuilder()
                 .port(0)
-                .add("/ds", DatasetGraphFactory.empty())
+                .add("/ds", dsg)
                 .build()
                 .start();
         int port = server.getPort();
@@ -306,6 +310,8 @@ class TestJenaMetrics {
         } finally {
             server.stop();
         }
+
+        return reader;
     }
 
     @Test
@@ -342,5 +348,31 @@ class TestJenaMetrics {
         String actual = fModOpenTelemetry.name();
         // then
         assertEquals(expected, actual);
+    }
+
+    @Test
+    void tdb_disk_usage_metric() throws IOException, InterruptedException {
+        boolean openTelemetryEnabledSetting = FMod_OpenTelemetry.ENABLED;
+        FMod_OpenTelemetry.ENABLED = true;
+        DatasetGraph dsg = null;
+        try {
+            File tempDir = Files.createTempDirectory("tdb2").toFile();
+            dsg = TDB2Factory.connectDataset(tempDir.getAbsolutePath()).asDatasetGraph();
+            try (InMemoryMetricReader reader = server_metrics_reader2(dsg)) {
+                assertTrue(
+                        reader.collectAllMetrics()
+                              .stream()
+                              .filter(m -> m.getName().equals(FMod_OpenTelemetry.TDB_DISK_USAGE))
+                              .flatMap(m -> m.getLongGaugeData().getPoints().stream())
+                              .filter(d -> d.getAttributes().get(FMod_OpenTelemetry.DB_NAME).equals("/ds"))
+                              .anyMatch(d -> d.getValue() > 0L));
+            }
+        } finally {
+            FMod_OpenTelemetry.ENABLED = openTelemetryEnabledSetting;
+
+            if (dsg != null) {
+                dsg.close();
+            }
+        }
     }
 }


### PR DESCRIPTION
FMod_OpenTelemetry now reports a disk space usage metric for TDB2 backed datasets.

Also adds a new FMod_MemoryInfo module that periodically reports memory usage information to the logs