### PR TITLE
CORE-1366: add backup encryption env vars to Helm charts

### DIFF
--- a/charts/graph/README.md
+++ b/charts/graph/README.md
@@ -32,16 +32,9 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Automating README and schema generation
 
-To obtain the latest version of the generator script run:
+Run the `metadata-updater.sh` script from the root directory:
 ```bash
 .dev/metadata-updater.sh
-```
-Then run the following from the project root directory:
-```bash
-.dev/readme-generator-for-helm --config=charts/graph/readme.config \
- --values=charts/graph/values.yaml \
- --readme=charts/graph/README.md \
- --schema=charts/graph/values.schema.json
 ```
 
 ## Configuration and installation details
@@ -123,14 +116,14 @@ Contains Java configuration parameters to be used by the *Graph* application
 
 Contains configuration parameters that configure aspects of the *Graph* application behaviour.
 
-| Name                                    | Description                                                                                                                                                                                                                                                                                      | Value   |
-| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- |
-| `graph.routeToNamedGraphs`              | Enable or disable routing to named graphs. When set to true, data will be routed into named graphs based on the Distribution-ID header set on the incoming Kafka events.                                                                                                                         | `false` |
-| `graph.legacyLabels`                    | Enable or disable legacy label store format.  When set to false then the new label store format will be used, which allows for more efficient storage and querying of labels.  If a pre-existing store exists in the legacy format it will be automatically migrated forwards to the new format. | `false` |
-| `graph.enableBackupEncryption`          | Enable GPG encryption of backups. When true, sets BACKUPS_PRIVATE_KEY_URL, BACKUPS_PUBLIC_KEY_URL and BACKUPS_PASSKEY environment variables. Keys are generated on first run if they do not exist.                                                                                               | `false` |
-| `graph.backupEncryption.privateKeyUrl`  | URL of the private key file (e.g. file:///tmp/private.asc). If empty, defaults to a path determined by the key source.                                                                                                                                                                           | `""`    |
-| `graph.backupEncryption.publicKeyUrl`   | URL of the public key file (e.g. file:///tmp/public.asc). If empty, defaults to a path determined by the key source.                                                                                                                                                                             | `""`    |
-| `graph.backupEncryption.existingSecret` | Name of an existing secret containing the backup encryption passphrase. The secret must contain 1 key: 'passphrase'. Public and private keys are generated from this passphrase on first run.                                                                                                    | `""`    |
+| Name                                    | Description                                                                                                                                                                                                                                                                                      | Value                                     |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------- |
+| `graph.routeToNamedGraphs`              | Enable or disable routing to named graphs. When set to true, data will be routed into named graphs based on the Distribution-ID header set on the incoming Kafka events.                                                                                                                         | `false`                                   |
+| `graph.legacyLabels`                    | Enable or disable legacy label store format.  When set to false then the new label store format will be used, which allows for more efficient storage and querying of labels.  If a pre-existing store exists in the legacy format it will be automatically migrated forwards to the new format. | `false`                                   |
+| `graph.enableBackupEncryption`          | Enable GPG encryption of backups. When true, sets BACKUPS_PRIVATE_KEY_URL, BACKUPS_PUBLIC_KEY_URL and BACKUPS_PASSKEY environment variables. Keys are generated on first run if they do not exist.                                                                                               | `false`                                   |
+| `graph.backupEncryption.privateKeyUrl`  | URL of the private key file                                                                                                                                                                                                                                                                      | `file:///fuseki/backups/keys/private.asc` |
+| `graph.backupEncryption.publicKeyUrl`   | URL of the public key file                                                                                                                                                                                                                                                                       | `file:///fuseki/backups/keys/public.asc`  |
+| `graph.backupEncryption.existingSecret` | Name of an existing secret containing the backup encryption passphrase. The secret must contain 1 key: 'passphrase'. Public and private keys are generated from this passphrase on first run.                                                                                                    | `""`                                      |
 
 ### ConfigMap Parameters
 

--- a/charts/graph/README.md
+++ b/charts/graph/README.md
@@ -32,11 +32,16 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Automating README and schema generation
 
+To obtain the latest version of the generator script run:
 ```bash
-.dev/readme-generator-for-helm --config=charts/telicent-core/readme.config \
- --values=charts/telicent-core/charts/graph/values.yaml \
- --readme=charts/telicent-core/charts/graph/README.md \
- --schema=charts/telicent-core/charts/graph/values.schema.json
+.dev/metadata-updater.sh
+```
+Then run the following from the project root directory:
+```bash
+.dev/readme-generator-for-helm --config=charts/graph/readme.config \
+ --values=charts/graph/values.yaml \
+ --readme=charts/graph/README.md \
+ --schema=charts/graph/values.schema.json
 ```
 
 ## Configuration and installation details
@@ -118,10 +123,14 @@ Contains Java configuration parameters to be used by the *Graph* application
 
 Contains configuration parameters that configure aspects of the *Graph* application behaviour.
 
-| Name                       | Description                                                                                                                                                                                                                                                                                      | Value   |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- |
-| `graph.routeToNamedGraphs` | Enable or disable routing to named graphs. When set to true, data will be routed into named graphs based on the Distribution-ID header set on the incoming Kafka events.                                                                                                                         | `false` |
-| `graph.legacyLabels`       | Enable or disable legacy label store format.  When set to false then the new label store format will be used, which allows for more efficient storage and querying of labels.  If a pre-existing store exists in the legacy format it will be automatically migrated forwards to the new format. | `false` |
+| Name                                    | Description                                                                                                                                                                                                                                                                                      | Value   |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| `graph.routeToNamedGraphs`              | Enable or disable routing to named graphs. When set to true, data will be routed into named graphs based on the Distribution-ID header set on the incoming Kafka events.                                                                                                                         | `false` |
+| `graph.legacyLabels`                    | Enable or disable legacy label store format.  When set to false then the new label store format will be used, which allows for more efficient storage and querying of labels.  If a pre-existing store exists in the legacy format it will be automatically migrated forwards to the new format. | `false` |
+| `graph.enableBackupEncryption`          | Enable GPG encryption of backups. When true, sets BACKUPS_PRIVATE_KEY_URL, BACKUPS_PUBLIC_KEY_URL and BACKUPS_PASSKEY environment variables. Keys are generated on first run if they do not exist.                                                                                               | `false` |
+| `graph.backupEncryption.privateKeyUrl`  | URL of the private key file (e.g. file:///tmp/private.asc). If empty, defaults to a path determined by the key source.                                                                                                                                                                           | `""`    |
+| `graph.backupEncryption.publicKeyUrl`   | URL of the public key file (e.g. file:///tmp/public.asc). If empty, defaults to a path determined by the key source.                                                                                                                                                                             | `""`    |
+| `graph.backupEncryption.existingSecret` | Name of an existing secret containing the backup encryption passphrase. The secret must contain 1 key: 'passphrase'. Public and private keys are generated from this passphrase on first run.                                                                                                    | `""`    |
 
 ### ConfigMap Parameters
 

--- a/charts/graph/templates/_secrets.tpl
+++ b/charts/graph/templates/_secrets.tpl
@@ -1,4 +1,10 @@
 {{/*
 Copyright (C) 2026 Telicent Limited
-todo: kafka auth secret
 */}}
+
+{{/*
+Create the name of the backup encryption secret
+*/}}
+{{- define "graph.backupEncryptionSecretName" -}}
+{{- required "graph.backupEncryption.existingSecret is required when graph.enableBackupEncryption is true" .Values.graph.backupEncryption.existingSecret }}
+{{- end -}}

--- a/charts/graph/templates/_secrets.tpl
+++ b/charts/graph/templates/_secrets.tpl
@@ -6,5 +6,7 @@ Copyright (C) 2026 Telicent Limited
 Create the name of the backup encryption secret
 */}}
 {{- define "graph.backupEncryptionSecretName" -}}
+{{- if .Values.graph.enableBackupEncryption -}}
 {{- required "graph.backupEncryption.existingSecret is required when graph.enableBackupEncryption is true" .Values.graph.backupEncryption.existingSecret }}
+{{- end -}}
 {{- end -}}

--- a/charts/graph/templates/configmap-env.yaml
+++ b/charts/graph/templates/configmap-env.yaml
@@ -35,7 +35,7 @@ data:
   {{- end }}
 
   {{- if .Values.graph.enableBackupEncryption }}
-  BACKUPS_PRIVATE_KEY_URL: {{ .Values.graph.backupEncryption.privateKeyUrl | default "file:///fuseki/backups/keys/private.asc" | quote }}
-  BACKUPS_PUBLIC_KEY_URL: {{ .Values.graph.backupEncryption.publicKeyUrl | default "file:///fuseki/backups/keys/public.asc" | quote }}
+  BACKUPS_PRIVATE_KEY_URL: {{ .Values.graph.backupEncryption.privateKeyUrl | quote }}
+  BACKUPS_PUBLIC_KEY_URL: {{ .Values.graph.backupEncryption.publicKeyUrl | quote }}
   {{- end }}
 {{- end }}

--- a/charts/graph/templates/configmap-env.yaml
+++ b/charts/graph/templates/configmap-env.yaml
@@ -33,4 +33,9 @@ data:
   OTEL_TRACES_EXPORTER: "none"
   OTEL_LOGS_EXPORTER: "none"
   {{- end }}
+
+  {{- if .Values.graph.enableBackupEncryption }}
+  BACKUPS_PRIVATE_KEY_URL: {{ .Values.graph.backupEncryption.privateKeyUrl | default "file:///fuseki/backups/keys/private.asc" | quote }}
+  BACKUPS_PUBLIC_KEY_URL: {{ .Values.graph.backupEncryption.publicKeyUrl | default "file:///fuseki/backups/keys/public.asc" | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/graph/templates/statefulset.yaml
+++ b/charts/graph/templates/statefulset.yaml
@@ -64,14 +64,26 @@ spec:
             - -c
             - |
               KEYS_DIR=/fuseki/backups/keys
-              if [ -f "${KEYS_DIR}/private.asc" ] && [ -f "${KEYS_DIR}/public.asc" ]; then
-                echo "Backup encryption keys already exist, skipping generation"
-                exit 0
-              fi
-              mkdir -p "${KEYS_DIR}"
               GNUPGHOME=$(mktemp -d)
               export GNUPGHOME
               printf '%s' "${BACKUPS_PASSKEY}" > "${GNUPGHOME}/passphrase"
+              if [ -f "${KEYS_DIR}/private.asc" ] && [ -f "${KEYS_DIR}/public.asc" ]; then
+                echo "Backup encryption keys already exist, verifying passphrase..."
+                gpg --batch --import "${KEYS_DIR}/private.asc" 2>/dev/null
+                if ! gpg --batch --pinentry-mode loopback --passphrase-file "${GNUPGHOME}/passphrase" \
+                    --armor --export-secret-keys > /dev/null 2>&1; then
+                  echo "ERROR: The provided passphrase cannot unlock the existing backup encryption keys."
+                  echo "Either restore the original passphrase in the secret, or manually delete"
+                  echo "${KEYS_DIR}/private.asc and ${KEYS_DIR}/public.asc to regenerate the keys."
+                  echo "WARNING: Deleting the key files will make any existing encrypted backups inaccessible."
+                  rm -rf "${GNUPGHOME}"
+                  exit 1
+                fi
+                echo "Passphrase verified successfully"
+                rm -rf "${GNUPGHOME}"
+                exit 0
+              fi
+              mkdir -p "${KEYS_DIR}"
               gpg --batch --pinentry-mode loopback --passphrase-file "${GNUPGHOME}/passphrase" \
                 --quick-gen-key "Smart Cache Graph Backup <scg-backup@localhost>" rsa4096 encr 0
               gpg --armor --export > "${KEYS_DIR}/public.asc"

--- a/charts/graph/templates/statefulset.yaml
+++ b/charts/graph/templates/statefulset.yaml
@@ -49,10 +49,46 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 6 }}
       {{- end }}
-      {{- if .Values.initContainers }}
+      {{- if or .Values.initContainers .Values.graph.enableBackupEncryption }}
       initContainers:
       {{- with .Values.initContainers }}
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.graph.enableBackupEncryption }}
+        - name: generate-backup-keys
+          image: {{ include "graph.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext: {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              KEYS_DIR=/fuseki/backups/keys
+              if [ -f "${KEYS_DIR}/private.asc" ] && [ -f "${KEYS_DIR}/public.asc" ]; then
+                echo "Backup encryption keys already exist, skipping generation"
+                exit 0
+              fi
+              mkdir -p "${KEYS_DIR}"
+              GNUPGHOME=$(mktemp -d)
+              export GNUPGHOME
+              printf '%s' "${BACKUPS_PASSKEY}" > "${GNUPGHOME}/passphrase"
+              gpg --batch --pinentry-mode loopback --passphrase-file "${GNUPGHOME}/passphrase" \
+                --quick-gen-key "Smart Cache Graph Backup <scg-backup@localhost>" rsa4096 encr 0
+              gpg --armor --export > "${KEYS_DIR}/public.asc"
+              gpg --batch --pinentry-mode loopback --passphrase-file "${GNUPGHOME}/passphrase" \
+                --armor --export-secret-keys > "${KEYS_DIR}/private.asc"
+              chmod 600 "${KEYS_DIR}/private.asc"
+              rm -rf "${GNUPGHOME}"
+              echo "Backup encryption keys generated successfully"
+          env:
+          - name: BACKUPS_PASSKEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "graph.backupEncryptionSecretName" . }}
+                key: passphrase
+          volumeMounts:
+          - name: backups-volume
+            mountPath: /fuseki/backups
       {{- end }}
       {{- end }}
       containers:
@@ -66,11 +102,19 @@ spec:
           - --config
           - /fuseki/config/config.ttl
 
-        {{- if .Values.extraEnvVars }}
+        {{- if or .Values.extraEnvVars .Values.graph.enableBackupEncryption }}
         env:
         {{- range .Values.extraEnvVars }}
         - name: {{ .name }}
           value: {{ .value | quote }}
+        {{- end }}
+        {{- if .Values.graph.enableBackupEncryption }}
+        - name: BACKUPS_PASSKEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "graph.backupEncryptionSecretName" . }}
+              key: passphrase
+              optional: false
         {{- end }}
         {{- end }}
         envFrom:

--- a/charts/graph/values.schema.json
+++ b/charts/graph/values.schema.json
@@ -131,13 +131,13 @@
                     "properties": {
                         "privateKeyUrl": {
                             "type": "string",
-                            "description": "URL of the private key file (e.g. file:///tmp/private.asc). If empty, defaults to a path determined by the key source.",
-                            "default": ""
+                            "description": "URL of the private key file",
+                            "default": "file:///fuseki/backups/keys/private.asc"
                         },
                         "publicKeyUrl": {
                             "type": "string",
-                            "description": "URL of the public key file (e.g. file:///tmp/public.asc). If empty, defaults to a path determined by the key source.",
-                            "default": ""
+                            "description": "URL of the public key file",
+                            "default": "file:///fuseki/backups/keys/public.asc"
                         },
                         "existingSecret": {
                             "type": "string",

--- a/charts/graph/values.schema.json
+++ b/charts/graph/values.schema.json
@@ -120,6 +120,31 @@
                     "type": "boolean",
                     "description": "Enable or disable legacy label store format.  When set to false then the new label store format will be used, which allows for more efficient storage and querying of labels.  If a pre-existing store exists in the legacy format it will be automatically migrated forwards to the new format.",
                     "default": false
+                },
+                "enableBackupEncryption": {
+                    "type": "boolean",
+                    "description": "Enable GPG encryption of backups. When true, sets BACKUPS_PRIVATE_KEY_URL, BACKUPS_PUBLIC_KEY_URL and BACKUPS_PASSKEY environment variables. Keys are generated on first run if they do not exist.",
+                    "default": false
+                },
+                "backupEncryption": {
+                    "type": "object",
+                    "properties": {
+                        "privateKeyUrl": {
+                            "type": "string",
+                            "description": "URL of the private key file (e.g. file:///tmp/private.asc). If empty, defaults to a path determined by the key source.",
+                            "default": ""
+                        },
+                        "publicKeyUrl": {
+                            "type": "string",
+                            "description": "URL of the public key file (e.g. file:///tmp/public.asc). If empty, defaults to a path determined by the key source.",
+                            "default": ""
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "description": "Name of an existing secret containing the backup encryption passphrase. The secret must contain 1 key: 'passphrase'. Public and private keys are generated from this passphrase on first run.",
+                            "default": ""
+                        }
+                    }
                 }
             }
         },

--- a/charts/graph/values.yaml
+++ b/charts/graph/values.yaml
@@ -90,10 +90,10 @@ graph:
   # @key graph.enableBackupEncryption Enable GPG encryption of backups. When true, sets BACKUPS_PRIVATE_KEY_URL, BACKUPS_PUBLIC_KEY_URL and BACKUPS_PASSKEY environment variables. Keys are generated on first run if they do not exist.
   enableBackupEncryption: false
   backupEncryption:
-    # @key graph.backupEncryption.privateKeyUrl URL of the private key file (e.g. file:///tmp/private.asc). If empty, defaults to a path determined by the key source.
-    privateKeyUrl: ""
-    # @key graph.backupEncryption.publicKeyUrl URL of the public key file (e.g. file:///tmp/public.asc). If empty, defaults to a path determined by the key source.
-    publicKeyUrl: ""
+    # @key graph.backupEncryption.privateKeyUrl URL of the private key file
+    privateKeyUrl: "file:///fuseki/backups/keys/private.asc"
+    # @key graph.backupEncryption.publicKeyUrl URL of the public key file
+    publicKeyUrl: "file:///fuseki/backups/keys/public.asc"
     # @key graph.backupEncryption.existingSecret Name of an existing secret containing the backup encryption passphrase. The secret must contain 1 key: 'passphrase'. Public and private keys are generated from this passphrase on first run.
     existingSecret: ""
 

--- a/charts/graph/values.yaml
+++ b/charts/graph/values.yaml
@@ -87,6 +87,15 @@ graph:
   routeToNamedGraphs: false
   # @key graph.legacyLabels Enable or disable legacy label store format.  When set to false then the new label store format will be used, which allows for more efficient storage and querying of labels.  If a pre-existing store exists in the legacy format it will be automatically migrated forwards to the new format.
   legacyLabels: false
+  # @key graph.enableBackupEncryption Enable GPG encryption of backups. When true, sets BACKUPS_PRIVATE_KEY_URL, BACKUPS_PUBLIC_KEY_URL and BACKUPS_PASSKEY environment variables. Keys are generated on first run if they do not exist.
+  enableBackupEncryption: false
+  backupEncryption:
+    # @key graph.backupEncryption.privateKeyUrl URL of the private key file (e.g. file:///tmp/private.asc). If empty, defaults to a path determined by the key source.
+    privateKeyUrl: ""
+    # @key graph.backupEncryption.publicKeyUrl URL of the public key file (e.g. file:///tmp/public.asc). If empty, defaults to a path determined by the key source.
+    publicKeyUrl: ""
+    # @key graph.backupEncryption.existingSecret Name of an existing secret containing the backup encryption passphrase. The secret must contain 1 key: 'passphrase'. Public and private keys are generated from this passphrase on first run.
+    existingSecret: ""
 
 #
 # @section ConfigMap Parameters

--- a/docs/running-fuseki-tdb.md
+++ b/docs/running-fuseki-tdb.md
@@ -128,6 +128,9 @@ Select the default or other appropriate options and choose a passphrase - this w
 ```shell
 gpg --list-keys --keyid-format=long
 ```
+> [!CAUTION]
+> Care must be taken not to loose the passphrase as this will render existing backups unreadable and replacement keys will need to be created for future backups.
+
 Copy the key ID for the public key you just created, e.g. `F2C0B93297F09448`, then export the key to a file:
 ```shell
 gpg --armor --export F2C0B93297F09448 > public.asc


### PR DESCRIPTION
Adds support for GPG encryption of Fuseki backups in the graph Helm chart, migrating functionality previously configured via Kubernetes manifest files in k8s-manifests. Backup encryption requirements are [described here](https://github.com/telicent-oss/smart-cache-graph/blob/main/docs/running-fuseki-tdb.md#encryption).

Three environment variables are conditionally set when `graph.enableBackupEncryption` is true:                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                   
  - `BACKUPS_PRIVATE_KEY_URL` — file URL of the GPG private key (defaults to `file:///fuseki/backups/keys/private.asc`)                                                                                                                                                                                                
  - `BACKUPS_PUBLIC_KEY_URL` — file URL of the GPG public key (defaults to `file:///fuseki/backups/keys/public.asc`)                                                                                                                                                                                                   
  - `BACKUPS_PASSKEY` — the GPG passphrase, sourced from a Kubernetes secret via `secretKeyRef`                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                   
**How it works**                                                                                                                                                                                                                                                                                                     
Enabling backup encryption requires a pre-existing Kubernetes secret specified via `graph.backupEncryption.existingSecret`. The secret must contain a single key: `passphrase`. Helm will produce an error at render time if `enableBackupEncryption` is true and no `existingSecret` is provided.                  
                                                                                                                                                                                                                                                                                                                   
On pod startup a `generate-backup-keys` init container runs using the application image (which includes gnupg). It reads the passphrase from the secret and generates a 4096-bit RSA key pair, writing armored `private.asc` and `public.asc` to `/fuseki/backups/keys/` on the persistent backups volume. If both files already exist the init container exits immediately, making it idempotent across pod restarts and Helm upgrades. The main container then reads the keys from the backups volume via the URL environment variables.                                                                                                
                                                                                                                                                                                                                                                                                                                   
The generated armored PGP key format is directly compatible with the `EncryptionUtils` class in scg-system, which reads keys via BouncyCastle's `PGPUtil.getDecoderStream()`.     