### PR TITLE
[CORE-1355] Reject and ignore events for deleted distributions when routing to named graphs

### DIFF
--- a/scg-system/src/main/java/io/telicent/core/FMod_FusekiKafkaSCG.java
+++ b/scg-system/src/main/java/io/telicent/core/FMod_FusekiKafkaSCG.java
@@ -17,17 +17,20 @@
 package io.telicent.core;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Function;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.telicent.backup.services.DatasetBackupService;
+import io.telicent.distribution.DistributionLifecycleStateFile;
 import io.telicent.jena.abac.core.DatasetGraphABAC;
 import io.telicent.smart.cache.configuration.Configurator;
 import io.telicent.smart.cache.payloads.RdfPayload;
 import io.telicent.smart.cache.projectors.Sink;
 import io.telicent.smart.cache.sources.Event;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.atlas.io.IOX;
 import org.apache.jena.fuseki.kafka.FKS;
 import org.apache.jena.fuseki.kafka.FMod_FusekiKafka;
@@ -68,10 +71,15 @@ public class FMod_FusekiKafkaSCG extends FMod_FusekiKafka {
     @Override
     protected Function<DatasetGraph, Sink<Event<Bytes, RdfPayload>>> getSinkBuilder() {
         boolean routeToNamedGraphs = Configurator.get("ROUTE_TO_NAMED_GRAPHS", Boolean::parseBoolean, false);
+        String lifecycleStateFile = Configurator.get(FMod_DistributionLifecycle.DISTRIBUTION_LIFECYCLE_STATE_FILE);
+        String applicationId = Configurator.get(FMod_DistributionLifecycle.DISTRIBUTION_LIFECYCLE_APP_ID);
+        DistributionLifecycleStateFile lifecycleState =
+                routeToNamedGraphs && StringUtils.isNotBlank(lifecycleStateFile) ?
+                new DistributionLifecycleStateFile(Path.of(lifecycleStateFile), applicationId) : null;
         return dsg -> {
             if (dsg instanceof DatasetGraphABAC dsgABAC) {
                 // For ABAC enabled datasets use our custom sink that applies labels
-                return new SmartCacheGraphSink(dsgABAC, routeToNamedGraphs);
+                return new SmartCacheGraphSink(dsgABAC, routeToNamedGraphs, lifecycleState);
             } else {
                 // For non-ABAC datasets use the default Fuseki Kafka sink
                 return FusekiSink.builder().dataset(dsg).build();

--- a/scg-system/src/main/java/io/telicent/core/SmartCacheGraphSink.java
+++ b/scg-system/src/main/java/io/telicent/core/SmartCacheGraphSink.java
@@ -1,9 +1,11 @@
 package io.telicent.core;
 
+import io.telicent.distribution.DistributionLifecycleStateFile;
 import io.telicent.jena.abac.core.DatasetGraphABAC;
 import io.telicent.jena.abac.core.VocabAuthz;
 import io.telicent.jena.abac.labels.Label;
 import io.telicent.jena.abac.labels.LabelsStore;
+import io.telicent.smart.cache.distribution.lifecycle.DistributionLifecycleState;
 import io.telicent.smart.cache.payloads.RdfPayload;
 import io.telicent.smart.cache.sources.Event;
 import io.telicent.smart.cache.sources.TelicentHeaders;
@@ -15,6 +17,11 @@ import org.apache.jena.kafka.common.FusekiSink;
 import org.apache.jena.rdfpatch.RDFChanges;
 import org.apache.jena.sparql.core.Quad;
 import org.apache.kafka.common.utils.Bytes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * An event sink that handles incoming events from Fuseki Kafka connector applying them, and their security labels, to a
@@ -22,11 +29,25 @@ import org.apache.kafka.common.utils.Bytes;
  */
 public class SmartCacheGraphSink extends FusekiSink<DatasetGraphABAC> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(SmartCacheGraphSink.class);
+
     private final boolean routeToNamedGraphs;
+    private final DistributionLifecycleStateFile lifecycleState;
+    // Tracks distributions whose first event we have already rejected (DLQ'd). The first event for a deleted
+    // distribution throws so it is dead-lettered with a clear reason; subsequent events for the same distribution are
+    // silently dropped. NB - this is in-memory only, so after a restart the first new event for a still-deleted
+    // distribution will be DLQ'd again rather than dropped.
+    private final Set<String> deletedDistributionsAlreadyRejected = ConcurrentHashMap.newKeySet();
 
     public SmartCacheGraphSink(DatasetGraphABAC dataset, boolean routeToNamedGraphs) {
+        this(dataset, routeToNamedGraphs, null);
+    }
+
+    public SmartCacheGraphSink(DatasetGraphABAC dataset, boolean routeToNamedGraphs,
+                               DistributionLifecycleStateFile lifecycleState) {
         super(dataset);
         this.routeToNamedGraphs = routeToNamedGraphs;
+        this.lifecycleState = lifecycleState;
     }
 
     @Override
@@ -35,33 +56,26 @@ public class SmartCacheGraphSink extends FusekiSink<DatasetGraphABAC> {
         //      that handles those sensibly.  Transaction boundaries can still lead to failures if the
         //      transaction boundaries in the patch are not valid.
         //      The implementation used here also ensures that labels are applied to the labels store as appropriate
-        String distributionId = null;
-        if (routeToNamedGraphs) {
-            distributionId = event.lastHeader(TelicentHeaders.DISTRIBUTION_ID);
-            if (StringUtils.isEmpty(distributionId)) {
-                throw new IllegalArgumentException("No distribution id specified when in routing mode");
-            }
+        String distributionId = getDistributionId(event);
+        if (ignoreEvent(distributionId)) {
+            return;
         }
-        RDFChanges apply = new RDFChangesApplyWithLabels(this.dataset, getEventSecurityLabel(event), distributionId);
+        RDFChanges apply =
+                new RDFChangesApplyWithLabels(this.dataset, getEventSecurityLabel(event), distributionId);
         event.value().getPatch().apply(apply);
     }
 
     @Override
     @SuppressWarnings("resources")
     protected void applyDatasetEvent(Event<Bytes, RdfPayload> event) {
+        String distributionId = getDistributionId(event);
+        if (ignoreEvent(distributionId)) {
+            return;
+        }
         // Find the Security-Label for this event, if any
         Label eventSecurityLabel = getEventSecurityLabel(event);
         LabelsStore labelsStore = this.dataset.labelsStore();
-        Node targetGraph;
-        if (routeToNamedGraphs) {
-            String distributionId = event.lastHeader(TelicentHeaders.DISTRIBUTION_ID);
-            if (StringUtils.isEmpty(distributionId)) {
-                throw new IllegalArgumentException("No distribution id specified when in routing mode");
-            }
-            targetGraph = NodeFactory.createURI(distributionId);
-        } else {
-            targetGraph = null;
-        }
+        Node targetGraph = this.routeToNamedGraphs ? NodeFactory.createURI(distributionId) : null;
 
         // Copy across quads, updating the labels store as needed
         event.value().getDataset().stream().forEach(q -> {
@@ -97,6 +111,52 @@ public class SmartCacheGraphSink extends FusekiSink<DatasetGraphABAC> {
     private static Label getEventSecurityLabel(Event<Bytes, RdfPayload> event) {
         return StringUtils.isNotBlank(event.lastHeader(TelicentHeaders.SECURITY_LABEL)) ?
                Label.fromText(event.lastHeader(TelicentHeaders.SECURITY_LABEL)) : null;
+    }
+
+    /*
+     * To avoid accidentally routing set null
+     */
+    private String getDistributionId(Event<Bytes, RdfPayload> event) {
+        return this.routeToNamedGraphs ? event.lastHeader(TelicentHeaders.DISTRIBUTION_ID) : null;
+    }
+
+    /*
+     * Decides whether an event should be skipped before any writes. Returns false when the event should be ingested,
+     * true when it should be silently dropped, and throws to reject (DLQ) the event - for a missing distribution id,
+     * unavailable lifecycle state, or the first event of a deleted distribution.
+     */
+    private boolean ignoreEvent(String distributionId) {
+        if (!this.routeToNamedGraphs) {
+            return false;
+        }
+
+        if (StringUtils.isEmpty(distributionId)) {
+            throw new IllegalArgumentException("No distribution id specified when in routing mode");
+        }
+        if (this.lifecycleState == null) {
+            return false;
+        }
+
+        DistributionLifecycleStateFile.DistributionStateResult stateResult =
+                this.lifecycleState.distributionStateResult(distributionId);
+        if (!stateResult.available()) {
+            throw new IllegalStateException(
+                    "Rejecting ingest because distribution lifecycle state is unavailable for distribution "
+                    + distributionId);
+        }
+
+        String state = stateResult.state();
+        if (!DistributionLifecycleState.Deleted.name().equals(state)) {
+            this.deletedDistributionsAlreadyRejected.remove(distributionId);
+            return false;
+        }
+        if (this.deletedDistributionsAlreadyRejected.add(distributionId)) {
+            throw new IllegalStateException(
+                    "Rejecting ingest for deleted distribution " + distributionId);
+        }
+
+        LOGGER.info("Dropping ingest for previously rejected deleted distribution {}", distributionId);
+        return true;
     }
 
     @Override

--- a/scg-system/src/main/java/io/telicent/distribution/DistributionLifecycleStateFile.java
+++ b/scg-system/src/main/java/io/telicent/distribution/DistributionLifecycleStateFile.java
@@ -17,8 +17,10 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -29,20 +31,32 @@ public class DistributionLifecycleStateFile {
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final String TMP_EXTENSION = ".tmp";
     private static final String BAK_EXTENSION = ".bak";
-    private static final Cache EMPTY_CACHE = new Cache(null, null, Set.of());
+    private static final Cache EMPTY_CACHE = new Cache(null, null, Set.of(), Map.of(), false);
 
     private final Path stateFile;
     private final String applicationId;
     private volatile Cache cache = EMPTY_CACHE;
 
-    DistributionLifecycleStateFile(Path stateFile, String applicationId) {
+    public DistributionLifecycleStateFile(Path stateFile, String applicationId) {
         this.stateFile = Objects.requireNonNull(stateFile, "stateFile cannot be null");
         this.applicationId = StringUtils.trimToNull(applicationId);
     }
 
-    Set<Node> activeGraphNodes() {
+    public Set<Node> activeGraphNodes() {
         refresh();
         return this.cache.activeGraphs();
+    }
+
+    public String distributionState(String distributionId) {
+        return distributionStateResult(distributionId).state();
+    }
+
+    public DistributionStateResult distributionStateResult(String distributionId) {
+        refresh();
+        if (StringUtils.isBlank(distributionId)) {
+            return new DistributionStateResult(null, this.cache.available());
+        }
+        return new DistributionStateResult(this.cache.distributionStates().get(distributionId), this.cache.available());
     }
 
     private synchronized void refresh() {
@@ -61,8 +75,7 @@ public class DistributionLifecycleStateFile {
                     return;
                 }
 
-                Set<Node> activeGraphs = loadActiveGraphs(candidate, content);
-                this.cache = new Cache(candidate, fingerprint, activeGraphs);
+                this.cache = loadState(candidate, fingerprint, content);
                 return;
             } catch (IOException | IllegalArgumentException e) {
                 LOGGER.warn("Failed to load distribution lifecycle state from {}", candidate, e);
@@ -87,25 +100,29 @@ public class DistributionLifecycleStateFile {
         }
     }
 
-    private Set<Node> loadActiveGraphs(Path candidate, byte[] content) throws IOException {
+    private Cache loadState(Path candidate, String fingerprint, byte[] content) throws IOException {
         try (InputStream input = new java.io.ByteArrayInputStream(content)) {
             JsonNode root = MAPPER.readTree(input);
             verifyApplication(root, candidate);
 
             JsonNode distributions = root.path("distributions");
             if (!distributions.isObject()) {
-                return Set.of();
+                return new Cache(candidate, fingerprint, Set.of(), Map.of(), true);
             }
 
             Set<Node> activeGraphs = new LinkedHashSet<>();
+            Map<String, String> distributionStates = new LinkedHashMap<>();
 
             distributions.properties().forEach(entry ->  {
+                String state = entry.getValue().asText();
+                distributionStates.put(entry.getKey(), state);
                 if (!DistributionLifecycleState.Active.name().equals(entry.getValue().asText())) {
                     return;
                 }
                 activeGraphs.add(NodeFactory.createURI(entry.getKey()));
             });
-            return Collections.unmodifiableSet(activeGraphs);
+            return new Cache(candidate, fingerprint, Collections.unmodifiableSet(activeGraphs),
+                             Collections.unmodifiableMap(distributionStates), true);
         }
     }
 
@@ -137,6 +154,10 @@ public class DistributionLifecycleStateFile {
         }
     }
 
-    private record Cache(Path source, String fingerprint, Set<Node> activeGraphs) {
+    public record DistributionStateResult(String state, boolean available) {
+    }
+
+    private record Cache(Path source, String fingerprint, Set<Node> activeGraphs,
+                         Map<String, String> distributionStates, boolean available) {
     }
 }

--- a/scg-system/src/test/java/io/telicent/core/AbstractSmartCacheGraphSinkTests.java
+++ b/scg-system/src/test/java/io/telicent/core/AbstractSmartCacheGraphSinkTests.java
@@ -1,6 +1,7 @@
 package io.telicent.core;
 
 import io.telicent.LibTestsSCG;
+import io.telicent.distribution.DistributionLifecycleStateFile;
 import io.telicent.jena.abac.ABAC;
 import io.telicent.jena.abac.AttributeValueSet;
 import io.telicent.jena.abac.DefaultDatasetFilterProvider;
@@ -23,6 +24,7 @@ import io.telicent.smart.cache.sources.EventHeader;
 import io.telicent.smart.cache.sources.Header;
 import io.telicent.smart.cache.sources.TelicentHeaders;
 import io.telicent.smart.cache.sources.memory.SimpleEvent;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.fuseki.main.FusekiServer;
 import org.apache.jena.fuseki.server.DataService;
 import org.apache.jena.fuseki.server.Operation;
@@ -661,12 +663,21 @@ public abstract class AbstractSmartCacheGraphSinkTests {
         FusekiServer server = SmartCacheGraph.serverBuilder().port(0).add(dsName, dataSrv).add(dsBase, dsgBase).build();
         server.start();
         try {
-            try (SmartCacheGraphSink sink = new SmartCacheGraphSink(dsgz, true)) {
+            try (SmartCacheGraphSink sink = createNamedGraphSink(dsgz)) {
                 execTestAction.execTest(sink, server, dsgBase, dsgz);
             }
         } finally {
             server.stop();
         }
+    }
+
+    private SmartCacheGraphSink createNamedGraphSink(DatasetGraphABAC dataset) {
+        String lifecycleStateFile = Configurator.get(FMod_DistributionLifecycle.DISTRIBUTION_LIFECYCLE_STATE_FILE);
+        String applicationId = Configurator.get(FMod_DistributionLifecycle.DISTRIBUTION_LIFECYCLE_APP_ID);
+        DistributionLifecycleStateFile lifecycleState =
+                StringUtils.isNotBlank(lifecycleStateFile) ?
+                new DistributionLifecycleStateFile(Path.of(lifecycleStateFile), applicationId) : null;
+        return new SmartCacheGraphSink(dataset, true, lifecycleState);
     }
 
     /**
@@ -752,6 +763,105 @@ public abstract class AbstractSmartCacheGraphSinkTests {
                     checkDatasetSize(dsgBase, 0);
                 };
         runTestProcessorSCGWithAuthNamedGraph(action);
+    }
+
+    @Test
+    final void processorSCG_namedGraph_deletedDistributionRejectedBeforeWrite_thenSubsequentEventsDropped()
+            throws IOException {
+        String deletedGraph = "http://example/deleted";
+        Path lifecycleState = Files.createTempFile("distribution-lifecycle", ".json");
+        writeLifecycleStateFile(lifecycleState, """
+                {
+                  "distributions" : {
+                    "%s" : "Deleted"
+                  }
+                }
+                """.formatted(deletedGraph));
+
+        TestAction action =
+                (Sink<Event<Bytes, RdfPayload>> proc, FusekiServer server, DatasetGraph dsgBase, DatasetGraph dsg) -> {
+                    JenaKafkaException ex =
+                            assertThrows(JenaKafkaException.class, () -> sendEventWithDistributionId(dsg, proc, """
+                                    PREFIX : <http://example/>
+                                    :s :p "value1" .
+                                    """, WebContent.contentTypeTurtle, attrPermit, deletedGraph));
+                    assertInstanceOf(IllegalStateException.class, ex.getCause());
+                    assertEquals("Rejecting ingest for deleted distribution " + deletedGraph,
+                                 ex.getCause().getMessage());
+
+                    sendEventWithDistributionId(dsg, proc, """
+                            PREFIX : <http://example/>
+                            :s :p "value2" .
+                            """, WebContent.contentTypeTurtle, attrPermit, deletedGraph);
+
+                    verifyNamedGraphsEmpty(dsgBase, deletedGraph);
+                    checkDatasetSize(dsgBase, 0);
+
+                    String URL = server.datasetURL(dsName);
+                    verifyCounts(URL, queryAll, 0L, 0L);
+                    verifyCounts(URL, queryUnion, 0L, 0L);
+                    verifyDefaultGraphEmpty(URL);
+                };
+
+        withDistributionLifecycleConfig(lifecycleState, null, () -> runTestProcessorSCGWithAuthNamedGraph(action));
+    }
+
+    @Test
+    final void processorSCG_namedGraph_unregisteredDistributionIsIngested() throws IOException {
+        // A distribution that is not present in the lifecycle state file at all is treated as unregistered. Per the
+        // ticket, rejecting unregistered distributions is deferred to a later ticket, so ingest must still proceed.
+        String deletedGraph = "http://example/deleted";
+        String unregisteredGraph = "http://example/unregistered";
+        Path lifecycleState = Files.createTempFile("distribution-lifecycle", ".json");
+        writeLifecycleStateFile(lifecycleState, """
+                {
+                  "distributions" : {
+                    "%s" : "Deleted"
+                  }
+                }
+                """.formatted(deletedGraph));
+
+        TestAction action =
+                (Sink<Event<Bytes, RdfPayload>> proc, FusekiServer server, DatasetGraph dsgBase, DatasetGraph dsg) -> {
+                    dsg.begin(TxnType.WRITE);
+                    // No exception expected - the unregistered distribution is accepted for ingest.
+                    sendEventWithDistributionId(dsg, proc, """
+                            PREFIX : <http://example/>
+                            :s :p "value" .
+                            """, WebContent.contentTypeTurtle, attrPermit, unregisteredGraph);
+                    dsg.commit();
+
+                    // Data is physically written to the underlying store for the unregistered distribution.
+                    verifyNamedGraphsHaveData(dsgBase, unregisteredGraph);
+                };
+
+        withDistributionLifecycleConfig(lifecycleState, null, () -> runTestProcessorSCGWithAuthNamedGraph(action));
+    }
+
+    @Test
+    final void processorSCG_namedGraph_missingLifecycleStateRejectsIngest() throws IOException {
+        String graph = "http://example/graph1";
+        Path lifecycleState = Files.createTempFile("distribution-lifecycle", ".json");
+        Files.deleteIfExists(lifecycleState);
+
+        TestAction action =
+                (Sink<Event<Bytes, RdfPayload>> proc, FusekiServer server, DatasetGraph dsgBase, DatasetGraph dsg) -> {
+                    JenaKafkaException ex =
+                            assertThrows(JenaKafkaException.class, () -> sendEventWithDistributionId(dsg, proc, """
+                                    PREFIX : <http://example/>
+                                    :s :p "value" .
+                                    """, WebContent.contentTypeTurtle, attrPermit, graph));
+                    assertInstanceOf(IllegalStateException.class, ex.getCause());
+                    assertEquals(
+                            "Rejecting ingest because distribution lifecycle state is unavailable for distribution "
+                            + graph,
+                            ex.getCause().getMessage());
+
+                    verifyNamedGraphsEmpty(dsgBase, graph);
+                    verifyDefaultGraphEmpty(dsgBase);
+                };
+
+        withDistributionLifecycleConfig(lifecycleState, null, () -> runTestProcessorSCGWithAuthNamedGraph(action));
     }
 
     @Test
@@ -873,7 +983,7 @@ public abstract class AbstractSmartCacheGraphSinkTests {
                 {
                   "distributions" : {
                     "%s" : "Active",
-                    "%s" : "Deleted"
+                    "%s" : "Withdrawn"
                   }
                 }
                 """.formatted(activeGraph, inactiveGraph));
@@ -905,7 +1015,7 @@ public abstract class AbstractSmartCacheGraphSinkTests {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"Unregistered", "Registered", "Withdrawn", "Deleted", "Unrecognised"})
+    @ValueSource(strings = {"Unregistered", "Registered", "Withdrawn", "Unrecognised"})
     final void processorSCG_namedGraph_inactiveDistributionsAreHidden(String state) throws IOException {
         String graph = "http://example/graph1";
         Path lifecycleState = Files.createTempFile("distribution-lifecycle", ".json");
@@ -939,7 +1049,7 @@ public abstract class AbstractSmartCacheGraphSinkTests {
     }
 
     @Test
-    final void processorSCG_namedGraph_applicationIdMismatchHidesAllGraphs() throws IOException {
+    final void processorSCG_namedGraph_applicationIdMismatchRejectsIngest() throws IOException {
         String graph = "http://example/graph1";
         Path lifecycleState = Files.createTempFile("distribution-lifecycle", ".json");
         writeLifecycleStateFile(lifecycleState, """
@@ -953,16 +1063,18 @@ public abstract class AbstractSmartCacheGraphSinkTests {
 
         TestAction action =
                 (Sink<Event<Bytes, RdfPayload>> proc, FusekiServer server, DatasetGraph dsgBase, DatasetGraph dsg) -> {
-                    dsg.begin(TxnType.WRITE);
-                    sendEventWithDistributionId(dsg, proc, """
-                            PREFIX : <http://example/>
-                            :s :p "value" .
-                            """, WebContent.contentTypeTurtle, attrPermit, graph);
-                    dsg.commit();
+                    JenaKafkaException ex =
+                            assertThrows(JenaKafkaException.class, () -> sendEventWithDistributionId(dsg, proc, """
+                                    PREFIX : <http://example/>
+                                    :s :p "value" .
+                                    """, WebContent.contentTypeTurtle, attrPermit, graph));
+                    assertInstanceOf(IllegalStateException.class, ex.getCause());
+                    assertEquals(
+                            "Rejecting ingest because distribution lifecycle state is unavailable for distribution "
+                            + graph,
+                            ex.getCause().getMessage());
 
-                    verifyNamedGraphsHaveData(dsgBase, graph);
-
-                    // App id mismatch -> reader treats the file as unreadable -> empty active set -> nothing visible.
+                    verifyNamedGraphsEmpty(dsgBase, graph);
                     String URL = server.datasetURL(dsName);
                     verifyCounts(URL, queryAll, 0L, 0L);
                     verifyCounts(URL, queryUnion, 0L, 0L);
@@ -1203,6 +1315,37 @@ public abstract class AbstractSmartCacheGraphSinkTests {
                             """, WebContent.contentTypePatch, attrPermit, null));
                 };
         runTestProcessorSCGWithAuthNamedGraph(action);
+    }
+
+    @Test
+    final void processorSCG_namedGraph_rdfPatch_deletedDistributionRejectedBeforeWrite() throws IOException {
+        String deletedGraph = "http://example/deleted";
+        Path lifecycleState = Files.createTempFile("distribution-lifecycle", ".json");
+        writeLifecycleStateFile(lifecycleState, """
+                {
+                  "distributions" : {
+                    "%s" : "Deleted"
+                  }
+                }
+                """.formatted(deletedGraph));
+
+        TestAction action =
+                (Sink<Event<Bytes, RdfPayload>> proc, FusekiServer server, DatasetGraph dsgBase, DatasetGraph dsg) -> {
+                    JenaKafkaException ex =
+                            assertThrows(JenaKafkaException.class, () -> sendEventWithDistributionId(dsg, proc, """
+                                    TX .
+                                    A <http://example/s> <http://example/p> "value1" .
+                                    TC .
+                                    """, WebContent.contentTypePatch, attrPermit, deletedGraph));
+                    assertInstanceOf(IllegalStateException.class, ex.getCause());
+                    assertEquals("Rejecting ingest for deleted distribution " + deletedGraph,
+                                 ex.getCause().getMessage());
+
+                    verifyNamedGraphsEmpty(dsgBase, deletedGraph);
+                    verifyDefaultGraphEmpty(dsgBase);
+                };
+
+        withDistributionLifecycleConfig(lifecycleState, null, () -> runTestProcessorSCGWithAuthNamedGraph(action));
     }
 
     @Test

--- a/scg-system/src/test/java/io/telicent/distribution/TestDistributionLifecycleStateFile.java
+++ b/scg-system/src/test/java/io/telicent/distribution/TestDistributionLifecycleStateFile.java
@@ -10,9 +10,12 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TestDistributionLifecycleStateFile {
@@ -54,14 +57,118 @@ class TestDistributionLifecycleStateFile {
     }
 
     @Test
+    void distributionState_returnsConfiguredState_whenDistributionIsKnown() throws IOException {
+        Files.writeString(this.stateFile, """
+                {
+                  "distributions" : {
+                    "http://example/a" : "Deleted"
+                  }
+                }
+                """, StandardCharsets.UTF_8);
+
+        assertEquals("Deleted", this.reader.distributionState("http://example/a"));
+    }
+
+    @Test
+    void distributionStateResult_marksStateAvailable_whenStateFileIsReadable() throws IOException {
+        Files.writeString(this.stateFile, """
+                {
+                  "distributions" : {
+                    "http://example/a" : "Active"
+                  }
+                }
+                """, StandardCharsets.UTF_8);
+
+        DistributionLifecycleStateFile.DistributionStateResult result =
+                this.reader.distributionStateResult("http://example/a");
+
+        assertTrue(result.available(), "Readable state file should be reported as available");
+        assertEquals("Active", result.state());
+    }
+
+    @Test
+    void distributionState_returnsNull_whenDistributionIsUnknown() throws IOException {
+        Files.writeString(this.stateFile, """
+                {
+                  "distributions" : {
+                    "http://example/a" : "Deleted"
+                  }
+                }
+                """, StandardCharsets.UTF_8);
+
+        assertNull(this.reader.distributionState("http://example/unknown"),
+                   "Unregistered/unknown distributions have no recorded state");
+    }
+
+    @Test
+    void distributionState_reflectsFileUpdate_whenStateChanges() throws IOException {
+        Files.writeString(this.stateFile, """
+                {
+                  "distributions" : {
+                    "http://example/a" : "Deleted"
+                  }
+                }
+                """, StandardCharsets.UTF_8);
+        assertEquals("Deleted", this.reader.distributionState("http://example/a"),
+                     "Pre-condition: primed cache reports the distribution as Deleted");
+
+        // Rewrite the file with a different state; the change in size/last-modified must invalidate the cached value.
+        Files.writeString(this.stateFile, """
+                {
+                  "distributions" : {
+                    "http://example/a" : "Active"
+                  }
+                }
+                """, StandardCharsets.UTF_8);
+
+        assertEquals("Active", this.reader.distributionState("http://example/a"),
+                     "Updated state file must be picked up on the next read");
+    }
+
+    @Test
+    void distributionState_reflectsSameSizeSameTimestampUpdate_whenContentChanges() throws IOException {
+        String deletedState = """
+                {
+                  "distributions" : {
+                    "http://example/a" : "Deleted"
+                  }
+                }
+                """;
+        String activeState = """
+                {
+                  "distributions" : {
+                    "http://example/a" : "Active "
+                  }
+                }
+                """;
+        assertEquals(deletedState.length(), activeState.length(),
+                     "Test fixture must preserve the JSON byte size");
+
+        Files.writeString(this.stateFile, deletedState, StandardCharsets.UTF_8);
+        assertEquals("Deleted", this.reader.distributionState("http://example/a"));
+
+        FileTime originalTimestamp = Files.getLastModifiedTime(this.stateFile);
+        Files.writeString(this.stateFile, activeState, StandardCharsets.UTF_8);
+        assertEquals(Files.size(this.stateFile), deletedState.getBytes(StandardCharsets.UTF_8).length);
+        Files.setLastModifiedTime(this.stateFile, originalTimestamp);
+
+        assertEquals("Active", this.reader.distributionState("http://example/a").trim(),
+                     "Same-size/same-timestamp content changes must still be reloaded");
+    }
+
+    @Test
     void activeGraphNodes_isEmpty_whenStateFileMissing() {
         // The temp file was created in setUp; remove it so the primary, .tmp and .bak are all absent.
         Path missingFile = this.stateFile.resolveSibling("does-not-exist.json");
         DistributionLifecycleStateFile missingReader = new DistributionLifecycleStateFile(missingFile, null);
 
         Set<Node> active = missingReader.activeGraphNodes();
+        DistributionLifecycleStateFile.DistributionStateResult result =
+                missingReader.distributionStateResult("http://example/a");
 
         assertTrue(active.isEmpty(), "No state file present -> no active distributions");
+        assertFalse(result.available(), "Missing state file should be reported as unavailable");
+        assertNull(result.state(), "Missing state file should yield no distribution state");
     }
 
     @Test
@@ -88,6 +195,8 @@ class TestDistributionLifecycleStateFile {
         Set<Node> activeAfter = this.reader.activeGraphNodes();
         assertTrue(activeAfter.isEmpty(),
                    "All candidates unparseable -> active set must be dropped (fail closed); was " + activeAfter);
+        assertFalse(this.reader.distributionStateResult("http://example/a").available(),
+                    "Unparseable candidates should be reported as unavailable");
     }
 
     @Test


### PR DESCRIPTION
When named routing is enabled, we validate incoming events before writing to relevant graph. 

On the first message for a deleted distribution - send to DLQ; on remaining - ignore. 

Note: I've not added other states to this - like "unregistered" ; nor have I added an "active distributions" mapping that we check against instead. That might come in later tickets. 