### PR TITLE
Updating to SC-Core 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
   - Reduced release size payloads
   - Improved documentation re: Memory
   - Deleted distribution handling
-  - Dependency updates
+  - Dependency updates including Smart Caches Core upgraded to 1.0.1
 
 ## 1.0.9
 

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <dependency.jena>6.1.0</dependency.jena>
     <dependency.graphql>0.12.2</dependency.graphql>
     <dependency.jwt-servlet-auth>4.1.3</dependency.jwt-servlet-auth>
-    <dependency.smart-caches-core>0.40.3</dependency.smart-caches-core>
+    <dependency.smart-caches-core>1.0.1</dependency.smart-caches-core>
 
     <!-- External dependencies -->
     <dependency.awaitility>4.3.0</dependency.awaitility>
@@ -514,6 +514,11 @@
       <dependency>
         <groupId>org.eclipse.jetty.ee11</groupId>
         <artifactId>jetty-ee11-servlets</artifactId>
+        <version>${dependency.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-http</artifactId>
         <version>${dependency.jetty}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Updating SC-Core to version 1.0.1.

Added `jetty-htttp` to CVE-2026-1605 patch block to ensure all Jetty artifact versions align.