### PR TITLE
[CORE-1383] Reject and ignore events for unregistered distributions when routing to named graphs

### DIFF
--- a/scg-system/src/main/java/io/telicent/core/SmartCacheGraphSink.java
+++ b/scg-system/src/main/java/io/telicent/core/SmartCacheGraphSink.java
@@ -33,11 +33,11 @@ public class SmartCacheGraphSink extends FusekiSink<DatasetGraphABAC> {
 
     private final boolean routeToNamedGraphs;
     private final DistributionLifecycleStateFile lifecycleState;
-    // Tracks distributions whose first event we have already rejected (DLQ'd). The first event for a deleted
+    // Tracks distributions whose first event we have already rejected (DLQ'd). The first event for a deleted/unregistered
     // distribution throws so it is dead-lettered with a clear reason; subsequent events for the same distribution are
     // silently dropped. NB - this is in-memory only, so after a restart the first new event for a still-deleted
     // distribution will be DLQ'd again rather than dropped.
-    private final Set<String> deletedDistributionsAlreadyRejected = ConcurrentHashMap.newKeySet();
+    private final Set<String> distributionsAlreadyRejected = ConcurrentHashMap.newKeySet();
 
     public SmartCacheGraphSink(DatasetGraphABAC dataset, boolean routeToNamedGraphs) {
         this(dataset, routeToNamedGraphs, null);
@@ -146,17 +146,22 @@ public class SmartCacheGraphSink extends FusekiSink<DatasetGraphABAC> {
         }
 
         String state = stateResult.state();
-        if (!DistributionLifecycleState.Deleted.name().equals(state)) {
-            this.deletedDistributionsAlreadyRejected.remove(distributionId);
+        if (viableState(state)) {
+            this.distributionsAlreadyRejected.remove(distributionId);
             return false;
         }
-        if (this.deletedDistributionsAlreadyRejected.add(distributionId)) {
+        if (this.distributionsAlreadyRejected.add(distributionId)) {
             throw new IllegalStateException(
-                    "Rejecting ingest for deleted distribution " + distributionId);
+                    "Rejecting ingest for " + state + " distribution " + distributionId);
         }
 
-        LOGGER.info("Dropping ingest for previously rejected deleted distribution {}", distributionId);
+        LOGGER.info("Dropping ingest for previously rejected distribution {}", distributionId);
         return true;
+    }
+
+    private static boolean viableState(String state) {
+        return !DistributionLifecycleState.Deleted.name().equals(state)
+                && !DistributionLifecycleState.Unregistered.name().equals(state);
     }
 
     @Override

--- a/scg-system/src/test/java/io/telicent/core/AbstractSmartCacheGraphSinkTests.java
+++ b/scg-system/src/test/java/io/telicent/core/AbstractSmartCacheGraphSinkTests.java
@@ -765,18 +765,19 @@ public abstract class AbstractSmartCacheGraphSinkTests {
         runTestProcessorSCGWithAuthNamedGraph(action);
     }
 
-    @Test
-    final void processorSCG_namedGraph_deletedDistributionRejectedBeforeWrite_thenSubsequentEventsDropped()
+    @ParameterizedTest
+    @ValueSource(strings = {"Unregistered", "Deleted"})
+    final void processorSCG_namedGraph_invalidDistributionRejectedBeforeWrite_thenSubsequentEventsDropped(String state)
             throws IOException {
-        String deletedGraph = "http://example/deleted";
+        String invalidGraph = "http://example/invalid";
         Path lifecycleState = Files.createTempFile("distribution-lifecycle", ".json");
         writeLifecycleStateFile(lifecycleState, """
                 {
                   "distributions" : {
-                    "%s" : "Deleted"
+                    "%s" : "%s"
                   }
                 }
-                """.formatted(deletedGraph));
+                """.formatted(invalidGraph, state));
 
         TestAction action =
                 (Sink<Event<Bytes, RdfPayload>> proc, FusekiServer server, DatasetGraph dsgBase, DatasetGraph dsg) -> {
@@ -784,17 +785,17 @@ public abstract class AbstractSmartCacheGraphSinkTests {
                             assertThrows(JenaKafkaException.class, () -> sendEventWithDistributionId(dsg, proc, """
                                     PREFIX : <http://example/>
                                     :s :p "value1" .
-                                    """, WebContent.contentTypeTurtle, attrPermit, deletedGraph));
+                                    """, WebContent.contentTypeTurtle, attrPermit, invalidGraph));
                     assertInstanceOf(IllegalStateException.class, ex.getCause());
-                    assertEquals("Rejecting ingest for deleted distribution " + deletedGraph,
+                    assertEquals("Rejecting ingest for " + state + " distribution " + invalidGraph,
                                  ex.getCause().getMessage());
 
                     sendEventWithDistributionId(dsg, proc, """
                             PREFIX : <http://example/>
                             :s :p "value2" .
-                            """, WebContent.contentTypeTurtle, attrPermit, deletedGraph);
+                            """, WebContent.contentTypeTurtle, attrPermit, invalidGraph);
 
-                    verifyNamedGraphsEmpty(dsgBase, deletedGraph);
+                    verifyNamedGraphsEmpty(dsgBase, invalidGraph);
                     checkDatasetSize(dsgBase, 0);
 
                     String URL = server.datasetURL(dsName);
@@ -1015,7 +1016,7 @@ public abstract class AbstractSmartCacheGraphSinkTests {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"Unregistered", "Registered", "Withdrawn", "Unrecognised"})
+    @ValueSource(strings = {"Registered", "Withdrawn", "Unrecognised"})
     final void processorSCG_namedGraph_inactiveDistributionsAreHidden(String state) throws IOException {
         String graph = "http://example/graph1";
         Path lifecycleState = Files.createTempFile("distribution-lifecycle", ".json");
@@ -1317,17 +1318,18 @@ public abstract class AbstractSmartCacheGraphSinkTests {
         runTestProcessorSCGWithAuthNamedGraph(action);
     }
 
-    @Test
-    final void processorSCG_namedGraph_rdfPatch_deletedDistributionRejectedBeforeWrite() throws IOException {
-        String deletedGraph = "http://example/deleted";
+    @ParameterizedTest
+    @ValueSource(strings = {"Unregistered", "Deleted"})
+    final void processorSCG_namedGraph_rdfPatch_violableDistributionRejectedBeforeWrite(String state) throws IOException {
+        String violableGraph = "http://example/violable";
         Path lifecycleState = Files.createTempFile("distribution-lifecycle", ".json");
         writeLifecycleStateFile(lifecycleState, """
                 {
                   "distributions" : {
-                    "%s" : "Deleted"
+                    "%s" : "%s"
                   }
                 }
-                """.formatted(deletedGraph));
+                """.formatted(violableGraph, state));
 
         TestAction action =
                 (Sink<Event<Bytes, RdfPayload>> proc, FusekiServer server, DatasetGraph dsgBase, DatasetGraph dsg) -> {
@@ -1336,12 +1338,12 @@ public abstract class AbstractSmartCacheGraphSinkTests {
                                     TX .
                                     A <http://example/s> <http://example/p> "value1" .
                                     TC .
-                                    """, WebContent.contentTypePatch, attrPermit, deletedGraph));
+                                    """, WebContent.contentTypePatch, attrPermit, violableGraph));
                     assertInstanceOf(IllegalStateException.class, ex.getCause());
-                    assertEquals("Rejecting ingest for deleted distribution " + deletedGraph,
+                    assertEquals("Rejecting ingest for " + state + " distribution " + violableGraph,
                                  ex.getCause().getMessage());
 
-                    verifyNamedGraphsEmpty(dsgBase, deletedGraph);
+                    verifyNamedGraphsEmpty(dsgBase, violableGraph);
                     verifyDefaultGraphEmpty(dsgBase);
                 };
 


### PR DESCRIPTION
Basically - same as Deleted. 