### PR TITLE
[CORE-1381] Plug lifecycle status into readiness check.

### DIFF
--- a/charts/graph/templates/statefulset.yaml
+++ b/charts/graph/templates/statefulset.yaml
@@ -147,7 +147,7 @@ spec:
         
         readinessProbe:
           httpGet:
-            path: /$/ping
+            path: /$/ready
             port: 3030
             scheme: HTTP
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}

--- a/scg-system/src/main/java/io/telicent/core/DistributionLifecycleReadiness.java
+++ b/scg-system/src/main/java/io/telicent/core/DistributionLifecycleReadiness.java
@@ -1,0 +1,107 @@
+package io.telicent.core;
+
+import io.telicent.distribution.DistributionLifecycleStateFile;
+
+import java.util.Objects;
+import java.util.function.BooleanSupplier;
+
+final class DistributionLifecycleReadiness {
+
+    enum State {
+        DISABLED,
+        EXTERNAL_ONLY,
+        STARTING,
+        READY,
+        FAILED
+    }
+
+    record Snapshot(boolean ready, boolean filteringEnabled, boolean trackerEnabled, State state, String reason) {
+    }
+
+    private static final DistributionLifecycleReadiness INSTANCE = new DistributionLifecycleReadiness();
+
+    private volatile boolean filteringEnabled;
+    private volatile boolean trackerEnabled;
+    private volatile State state = State.DISABLED;
+    private volatile String reason = "Distribution lifecycle filtering is disabled.";
+    private volatile DistributionLifecycleStateFile stateFile;
+    private volatile BooleanSupplier trackerRunningProbe = () -> false;
+
+    static DistributionLifecycleReadiness getInstance() {
+        return INSTANCE;
+    }
+
+    void reset() {
+        this.filteringEnabled = false;
+        this.trackerEnabled = false;
+        this.state = State.DISABLED;
+        this.reason = "Distribution lifecycle filtering is disabled.";
+        this.stateFile = null;
+        this.trackerRunningProbe = () -> false;
+    }
+
+    void configure(boolean filteringEnabled, boolean trackerEnabled, DistributionLifecycleStateFile stateFile,
+                   BooleanSupplier trackerRunningProbe) {
+        this.filteringEnabled = filteringEnabled;
+        this.trackerEnabled = trackerEnabled;
+        this.stateFile = stateFile;
+        this.trackerRunningProbe = trackerRunningProbe != null ? trackerRunningProbe : () -> false;
+        if (!filteringEnabled) {
+            this.state = State.DISABLED;
+            this.reason = "Distribution lifecycle filtering is disabled.";
+        } else if (!trackerEnabled) {
+            this.state = State.EXTERNAL_ONLY;
+            this.reason = "Distribution lifecycle filtering is enabled and waiting for lifecycle state to become usable.";
+        } else {
+            this.state = State.STARTING;
+            this.reason = "Distribution lifecycle tracker is starting or catching up.";
+        }
+    }
+
+    void markStarting(String reason) {
+        this.state = State.STARTING;
+        this.reason = Objects.requireNonNullElse(reason,
+                                                 "Distribution lifecycle tracker is starting or catching up.");
+    }
+
+    void markReady() {
+        this.state = State.READY;
+        this.reason = "Distribution lifecycle state is usable.";
+    }
+
+    void markFailed(String reason) {
+        this.state = State.FAILED;
+        this.reason = Objects.requireNonNullElse(reason, "Distribution lifecycle tracker is unavailable.");
+    }
+
+    Snapshot snapshot() {
+        if (!this.filteringEnabled) {
+            return new Snapshot(true, false, false, State.DISABLED, this.reason);
+        }
+
+        boolean stateAvailable = this.stateFile != null && this.stateFile.available();
+        if (!this.trackerEnabled) {
+            if (stateAvailable) {
+                return new Snapshot(true, true, false, State.READY, "Distribution lifecycle state is usable.");
+            }
+            return new Snapshot(false, true, false, State.EXTERNAL_ONLY,
+                                "Distribution lifecycle filtering is enabled but lifecycle state is still unavailable.");
+        }
+
+        if (this.state == State.READY && !this.trackerRunningProbe.getAsBoolean()) {
+            return new Snapshot(false, true, true, State.FAILED,
+                                "Distribution lifecycle tracker is no longer running.");
+        }
+
+        if (this.state == State.READY && !stateAvailable) {
+            return new Snapshot(false, true, true, State.STARTING,
+                                "Distribution lifecycle tracker is running but lifecycle state is not yet usable.");
+        }
+
+        if (this.state == State.READY) {
+            return new Snapshot(true, true, true, State.READY, this.reason);
+        }
+
+        return new Snapshot(false, true, true, this.state, this.reason);
+    }
+}

--- a/scg-system/src/main/java/io/telicent/core/FMod_DistributionLifecycle.java
+++ b/scg-system/src/main/java/io/telicent/core/FMod_DistributionLifecycle.java
@@ -17,6 +17,7 @@
 package io.telicent.core;
 
 import io.telicent.distribution.DistributionLifecycleFilters;
+import io.telicent.distribution.DistributionLifecycleStateFile;
 import io.telicent.jena.abac.core.DatasetGraphABAC;
 import io.telicent.smart.cache.configuration.Configurator;
 import io.telicent.smart.cache.distribution.lifecycle.events.listeners.AcknowledgingListener;
@@ -47,6 +48,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -54,6 +56,10 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * A Fuseki module that makes Smart Cache Graph "distribution lifecycle aware".
@@ -81,9 +87,13 @@ public class FMod_DistributionLifecycle implements FusekiModule {
     static final String DEFAULT_CONSUMER_GROUP = "smart-cache-graph-distribution-lifecycle";
     static final String DEFAULT_STATE_FILE = "distribution-lifecycle.state";
     static final String DEFAULT_APP_ID = "smart-cache-graph";
+    private static final long TRACKER_STARTUP_RETRY_DELAY_MS = 1_000L;
+    private static final AtomicInteger TRACKER_STARTER_THREAD_ID = new AtomicInteger();
 
+    private final DistributionLifecycleReadiness readiness = DistributionLifecycleReadiness.getInstance();
     private DistributionLifecycleTracker tracker;
     private DistributionLifecycleStateStore stateStore;
+    private ExecutorService trackerStarter;
 
     @Override
     public String name() {
@@ -117,6 +127,8 @@ public class FMod_DistributionLifecycle implements FusekiModule {
 
     @Override
     public void serverBeforeStarting(FusekiServer server) {
+        configureReadiness();
+
         if (!isEnabled()) {
             LOGGER.debug("Distribution lifecycle tracker disabled (ENABLE_DISTRIBUTION_LIFECYCLE=false)");
             return;
@@ -125,7 +137,7 @@ public class FMod_DistributionLifecycle implements FusekiModule {
             LOGGER.warn("Distribution lifecycle tracker ignored because ROUTE_TO_NAMED_GRAPHS is disabled");
             return;
         }
-        if (this.tracker != null) {
+        if (this.tracker != null || this.trackerStarter != null) {
             LOGGER.warn("Distribution lifecycle tracker already started");
             return;
         }
@@ -134,6 +146,8 @@ public class FMod_DistributionLifecycle implements FusekiModule {
                 selectBootstrapServers(connectors(), Configurator.get(DISTRIBUTION_LIFECYCLE_BOOTSTRAP_SERVERS));
         if (StringUtils.isBlank(bootstrapServers)) {
             LOGGER.warn(
+                    "Distribution lifecycle tracker is enabled but no Kafka bootstrap servers could be determined.");
+            this.readiness.markFailed(
                     "Distribution lifecycle tracker is enabled but no Kafka bootstrap servers could be determined.");
             return;
         }
@@ -145,58 +159,23 @@ public class FMod_DistributionLifecycle implements FusekiModule {
         String consumerGroup = consumerGroup();
         String stateFile = stateFilePath();
 
-        try {
-            this.stateStore = AppDistributionLifecycleStoreFile.builder()
-                                                               .app(application)
-                                                               .stateFile(new File(stateFile))
-                                                               .build();
-
-            DistributionLifecycleListener graphDeletion =
-                    new DistributionGraphDeletionListener(() -> abacDatasets(server));
-            DistributionLifecycleListener listener =
-                    AcknowledgingListener.builder()
-                                         .application(application)
-                                         .version(SmartCacheGraph.VERSION)
-                                         .listener(graphDeletion)
-                                         .sink(lifecycleSink(bootstrapServers, topic, kafkaProperties))
-                                         .stateStore(this.stateStore)
-                                         .build();
-
-            EventSource<UUID, LazyEnvelope> source = KafkaEventSource.<UUID, LazyEnvelope>create()
-                                                                     .bootstrapServers(bootstrapServers)
-                                                                     .consumerConfig(kafkaProperties)
-                                                                     .topic(topic)
-                                                                     .consumerGroup(consumerGroup)
-                                                                     .readPolicy(KafkaReadPolicies.fromEarliest())
-                                                                     .commitOnProcessed()
-                                                                     .keyDeserializer(UUIDDeserializer.class)
-                                                                     .valueDeserializer(LazyEnvelopeDeserializer.class)
-                                                                     .build();
-
-            Sink<Event<UUID, LazyEnvelope>> dlq =
-                    StringUtils.isBlank(dlqTopic) ? null : lifecycleSink(bootstrapServers, dlqTopic, kafkaProperties);
-
-            this.tracker = DistributionLifecycleTracker.builder()
-                                                       .application(application)
-                                                       .eventSource(source)
-                                                       .dlq(dlq)
-                                                       .listenerThreads(1)
-                                                       .listeners(List.of(listener))
-                                                       .stateStore(this.stateStore)
-                                                       .build();
-
-            LOGGER.info(
-                    "Distribution lifecycle tracker enabled: consuming topic '{}' from {} (consumer group '{}', application '{}')",
-                    topic, bootstrapServers, consumerGroup, application);
-        } catch (RuntimeException e) {
-            LOGGER.error("Failed to start distribution lifecycle tracker; lifecycle events will NOT be processed", e);
-            closeTracker();
-        }
+        this.readiness.markStarting("Distribution lifecycle tracker is starting or catching up.");
+        ExecutorService starter = Executors.newSingleThreadExecutor(r -> {
+            Thread thread = new Thread(r, "distribution-lifecycle-startup-"
+                    + TRACKER_STARTER_THREAD_ID.incrementAndGet());
+            thread.setDaemon(true);
+            return thread;
+        });
+        this.trackerStarter = starter;
+        starter.submit(() -> startupTracker(starter, server, bootstrapServers, kafkaProperties, application, topic,
+                                            dlqTopic, consumerGroup, stateFile));
     }
 
     @Override
     public void serverStopped(FusekiServer server) {
+        closeTrackerStarter();
         closeTracker();
+        this.readiness.reset();
     }
 
     /**
@@ -222,12 +201,138 @@ public class FMod_DistributionLifecycle implements FusekiModule {
         }
     }
 
+    private void closeTrackerStarter() {
+        if (this.trackerStarter != null) {
+            this.trackerStarter.shutdownNow();
+            try {
+                this.trackerStarter.awaitTermination(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                this.trackerStarter = null;
+            }
+        }
+    }
+
     /**
      * Indicates whether the lifecycle tracker is currently running.
      * @return True if the tracker has been started, false otherwise
      */
     boolean isRunning() {
-        return this.tracker != null;
+        return this.tracker != null && this.tracker.isRunning();
+    }
+
+    private void startupTracker(ExecutorService starter, FusekiServer server, String bootstrapServers,
+                                Properties kafkaProperties,
+                                String application, String topic, String dlqTopic, String consumerGroup,
+                                String stateFile) {
+        try {
+            while (!Thread.currentThread().isInterrupted()) {
+                try {
+                    createTracker(server, bootstrapServers, kafkaProperties, application, topic, dlqTopic,
+                                  consumerGroup, stateFile);
+                    this.stateStore.flush();
+                    this.readiness.markReady();
+                    LOGGER.info(
+                            "Distribution lifecycle tracker enabled: consuming topic '{}' from {} (consumer group '{}', application '{}')",
+                            topic, bootstrapServers, consumerGroup, application);
+                    return;
+                } catch (RuntimeException e) {
+                    closeTracker();
+                    if (isCatchUpFailure(e)) {
+                        this.readiness.markStarting(
+                                "Distribution lifecycle tracker is still catching up; lifecycle state is not yet usable.");
+                        LOGGER.warn("Distribution lifecycle tracker is still catching up; retrying startup", e);
+                        Thread.sleep(TRACKER_STARTUP_RETRY_DELAY_MS);
+                    } else {
+                        this.readiness.markFailed("Distribution lifecycle tracker is unavailable: " + rootMessage(e));
+                        LOGGER.error("Failed to start distribution lifecycle tracker; lifecycle events will NOT be processed", e);
+                        return;
+                    }
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } finally {
+            starter.shutdown();
+            if (this.trackerStarter == starter) {
+                this.trackerStarter = null;
+            }
+        }
+    }
+
+    private void createTracker(FusekiServer server, String bootstrapServers, Properties kafkaProperties,
+                               String application, String topic, String dlqTopic, String consumerGroup,
+                               String stateFile) {
+        this.stateStore = AppDistributionLifecycleStoreFile.builder()
+                                                           .app(application)
+                                                           .stateFile(new File(stateFile))
+                                                           .build();
+
+        DistributionLifecycleListener graphDeletion =
+                new DistributionGraphDeletionListener(() -> abacDatasets(server));
+        DistributionLifecycleListener listener =
+                AcknowledgingListener.builder()
+                                     .application(application)
+                                     .version(SmartCacheGraph.VERSION)
+                                     .listener(graphDeletion)
+                                     .sink(lifecycleSink(bootstrapServers, topic, kafkaProperties))
+                                     .stateStore(this.stateStore)
+                                     .build();
+
+        EventSource<UUID, LazyEnvelope> source = KafkaEventSource.<UUID, LazyEnvelope>create()
+                                                                 .bootstrapServers(bootstrapServers)
+                                                                 .consumerConfig(kafkaProperties)
+                                                                 .topic(topic)
+                                                                 .consumerGroup(consumerGroup)
+                                                                 .readPolicy(KafkaReadPolicies.fromEarliest())
+                                                                 .commitOnProcessed()
+                                                                 .keyDeserializer(UUIDDeserializer.class)
+                                                                 .valueDeserializer(LazyEnvelopeDeserializer.class)
+                                                                 .build();
+
+        Sink<Event<UUID, LazyEnvelope>> dlq =
+                StringUtils.isBlank(dlqTopic) ? null : lifecycleSink(bootstrapServers, dlqTopic, kafkaProperties);
+
+        this.tracker = DistributionLifecycleTracker.builder()
+                                                   .application(application)
+                                                   .eventSource(source)
+                                                   .dlq(dlq)
+                                                   .listenerThreads(1)
+                                                   .listeners(List.of(listener))
+                                                   .stateStore(this.stateStore)
+                                                   .build();
+    }
+
+    private void configureReadiness() {
+        String configuredStateFile = Configurator.get(DISTRIBUTION_LIFECYCLE_STATE_FILE);
+        boolean filteringEnabled = StringUtils.isNotBlank(configuredStateFile) && routeToNamedGraphsEnabled();
+        boolean trackerEnabled = filteringEnabled && isEnabled();
+        DistributionLifecycleStateFile stateFile = filteringEnabled
+                                                   ? new DistributionLifecycleStateFile(Path.of(stateFilePath()),
+                                                                                        Configurator.get(
+                                                                                                DISTRIBUTION_LIFECYCLE_APP_ID))
+                                                   : null;
+        this.readiness.configure(filteringEnabled, trackerEnabled, stateFile,
+                                 () -> this.tracker != null && this.tracker.isRunning());
+    }
+
+    private static boolean isCatchUpFailure(Throwable error) {
+        for (Throwable current = error; current != null; current = current.getCause()) {
+            String message = current.getMessage();
+            if (message != null && message.contains("cannot make up to date decisions about distribution lifecycle")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String rootMessage(Throwable error) {
+        Throwable current = error;
+        while (current.getCause() != null) {
+            current = current.getCause();
+        }
+        return StringUtils.defaultIfBlank(current.getMessage(), error.getClass().getSimpleName());
     }
 
     /**

--- a/scg-system/src/main/java/io/telicent/core/FMod_DistributionLifecycleReadiness.java
+++ b/scg-system/src/main/java/io/telicent/core/FMod_DistributionLifecycleReadiness.java
@@ -1,5 +1,6 @@
 package io.telicent.core;
 
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.telicent.utils.ServletUtils;
 import jakarta.servlet.http.HttpServlet;
@@ -41,13 +42,14 @@ public class FMod_DistributionLifecycleReadiness implements FusekiModule {
                     DistributionLifecycleReadiness.getInstance().snapshot();
 
             ObjectNode json = OBJECT_MAPPER.createObjectNode();
-            json.put("ready", readiness.ready());
+            json.put("healthy", readiness.ready());
+            ArrayNode reasons = json.putArray("reasons");
+            reasons.add(readiness.reason());
 
-            ObjectNode lifecycle = json.putObject("lifecycle");
-            lifecycle.put("filteringEnabled", readiness.filteringEnabled());
-            lifecycle.put("trackerEnabled", readiness.trackerEnabled());
-            lifecycle.put("state", readiness.state().name());
-            lifecycle.put("reason", readiness.reason());
+            ObjectNode config = json.putObject("config");
+            config.put("filteringEnabled", readiness.filteringEnabled());
+            config.put("trackerEnabled", readiness.trackerEnabled());
+            config.put("state", readiness.state().name());
 
             response.setStatus(readiness.ready() ? HttpServletResponse.SC_OK : HttpServletResponse.SC_SERVICE_UNAVAILABLE);
             ServletUtils.processResponse(response, json);

--- a/scg-system/src/main/java/io/telicent/core/FMod_DistributionLifecycleReadiness.java
+++ b/scg-system/src/main/java/io/telicent/core/FMod_DistributionLifecycleReadiness.java
@@ -1,0 +1,56 @@
+package io.telicent.core;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.telicent.utils.ServletUtils;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.jena.atlas.lib.Version;
+import org.apache.jena.atlas.logging.FmtLog;
+import org.apache.jena.fuseki.Fuseki;
+import org.apache.jena.fuseki.main.FusekiServer;
+import org.apache.jena.fuseki.main.sys.FusekiModule;
+import org.apache.jena.rdf.model.Model;
+
+import java.io.IOException;
+import java.util.Set;
+
+import static io.telicent.backup.utils.JsonFileUtils.OBJECT_MAPPER;
+
+public class FMod_DistributionLifecycleReadiness implements FusekiModule {
+
+    private static final String VERSION =
+            Version.versionForClass(FMod_DistributionLifecycleReadiness.class).orElse("<development>");
+
+    @Override
+    public String name() {
+        return "Distribution Lifecycle Readiness";
+    }
+
+    @Override
+    public void prepare(FusekiServer.Builder serverBuilder, Set<String> datasetNames, Model configModel) {
+        FmtLog.info(Fuseki.configLog, "Telicent Distribution Lifecycle Readiness Module (%s)", VERSION);
+        serverBuilder.addServlet("/$/ready", new LifecycleReadinessServlet());
+    }
+
+    static final class LifecycleReadinessServlet extends HttpServlet {
+
+        @Override
+        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+            DistributionLifecycleReadiness.Snapshot readiness =
+                    DistributionLifecycleReadiness.getInstance().snapshot();
+
+            ObjectNode json = OBJECT_MAPPER.createObjectNode();
+            json.put("ready", readiness.ready());
+
+            ObjectNode lifecycle = json.putObject("lifecycle");
+            lifecycle.put("filteringEnabled", readiness.filteringEnabled());
+            lifecycle.put("trackerEnabled", readiness.trackerEnabled());
+            lifecycle.put("state", readiness.state().name());
+            lifecycle.put("reason", readiness.reason());
+
+            response.setStatus(readiness.ready() ? HttpServletResponse.SC_OK : HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+            ServletUtils.processResponse(response, json);
+        }
+    }
+}

--- a/scg-system/src/main/java/io/telicent/core/SmartCacheGraph.java
+++ b/scg-system/src/main/java/io/telicent/core/SmartCacheGraph.java
@@ -123,6 +123,7 @@ public class SmartCacheGraph {
                 , new FMod_TelicentGraphQL()
                 , new FMod_RequestIDFilter()
                 , new FMod_DatasetAvailabilityFilter()
+                , new FMod_DistributionLifecycleReadiness()
                 , new FMod_DistributionLifecycle()
                 , new FMod_BackupData()
                 , new FMod_LabelsQuery()

--- a/scg-system/src/main/java/io/telicent/core/auth/FMod_JwtServletAuth.java
+++ b/scg-system/src/main/java/io/telicent/core/auth/FMod_JwtServletAuth.java
@@ -64,7 +64,7 @@ public class FMod_JwtServletAuth implements FusekiModule {
         // should we enable these features in future
         serverBuilder.setServletAttribute(JwtServletConstants.ATTRIBUTE_PATH_EXCLUSIONS,
                                           PathExclusion.parsePathPatterns(
-                                                  "/$/ping,/$/metrics,/$/stats/*"));
+                                                  "/$/ping,/$/ready,/$/metrics,/$/stats/*"));
 
         // Register the filter
         serverBuilder.addFilter("/*", new FusekiJwtAuthFilter());

--- a/scg-system/src/main/java/io/telicent/distribution/DistributionLifecycleStateFile.java
+++ b/scg-system/src/main/java/io/telicent/distribution/DistributionLifecycleStateFile.java
@@ -47,6 +47,11 @@ public class DistributionLifecycleStateFile {
         return this.cache.activeGraphs();
     }
 
+    public boolean available() {
+        refresh();
+        return this.cache.available();
+    }
+
     public String distributionState(String distributionId) {
         return distributionStateResult(distributionId).state();
     }

--- a/scg-system/src/test/java/io/telicent/TestJwtServletAuth.java
+++ b/scg-system/src/test/java/io/telicent/TestJwtServletAuth.java
@@ -98,6 +98,7 @@ public class TestJwtServletAuth {
         // given
         List<PathExclusion> expectedList = List.of(
                 new PathExclusion("/$/ping"),
+                new PathExclusion("/$/ready"),
                 new PathExclusion("/$/metrics"),
                 new PathExclusion("/$/stats/*")
         );

--- a/scg-system/src/test/java/io/telicent/core/TestDistributionLifecycleReadiness.java
+++ b/scg-system/src/test/java/io/telicent/core/TestDistributionLifecycleReadiness.java
@@ -1,0 +1,109 @@
+package io.telicent.core;
+
+import io.telicent.distribution.DistributionLifecycleStateFile;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TestDistributionLifecycleReadiness {
+
+    private final DistributionLifecycleReadiness readiness = DistributionLifecycleReadiness.getInstance();
+
+    @AfterEach
+    void cleanup() {
+        this.readiness.reset();
+    }
+
+    @Test
+    void snapshot_whenFilteringDisabled_isReady() {
+        this.readiness.configure(false, false, null, () -> false);
+
+        DistributionLifecycleReadiness.Snapshot snapshot = this.readiness.snapshot();
+
+        assertTrue(snapshot.ready());
+        assertFalse(snapshot.filteringEnabled());
+        assertEquals(DistributionLifecycleReadiness.State.DISABLED, snapshot.state());
+    }
+
+    @Test
+    void snapshot_whenExternalStateUnavailable_isUnready() {
+        Path missing = Path.of("target", "missing-lifecycle-state.json");
+        this.readiness.configure(true, false, new DistributionLifecycleStateFile(missing, null), () -> false);
+
+        DistributionLifecycleReadiness.Snapshot snapshot = this.readiness.snapshot();
+
+        assertFalse(snapshot.ready());
+        assertEquals(DistributionLifecycleReadiness.State.EXTERNAL_ONLY, snapshot.state());
+        assertTrue(snapshot.reason().contains("still unavailable"));
+    }
+
+    @Test
+    void snapshot_whenExternalStateAvailable_isReady() throws IOException {
+        Path stateFile = Files.createTempFile("scg-readiness-", ".json");
+        writeLifecycleStateFile(stateFile);
+        this.readiness.configure(true, false, new DistributionLifecycleStateFile(stateFile, null), () -> false);
+
+        DistributionLifecycleReadiness.Snapshot snapshot = this.readiness.snapshot();
+
+        assertTrue(snapshot.ready());
+        assertEquals(DistributionLifecycleReadiness.State.READY, snapshot.state());
+    }
+
+    @Test
+    void snapshot_whenTrackerStarting_isUnready() throws IOException {
+        Path stateFile = Files.createTempFile("scg-readiness-", ".json");
+        this.readiness.configure(true, true, new DistributionLifecycleStateFile(stateFile, null), () -> true);
+        this.readiness.markStarting("Distribution lifecycle tracker is starting or catching up.");
+
+        DistributionLifecycleReadiness.Snapshot snapshot = this.readiness.snapshot();
+
+        assertFalse(snapshot.ready());
+        assertEquals(DistributionLifecycleReadiness.State.STARTING, snapshot.state());
+        assertTrue(snapshot.reason().contains("starting"));
+    }
+
+    @Test
+    void snapshot_whenTrackerFailed_isUnready() throws IOException {
+        Path stateFile = Files.createTempFile("scg-readiness-", ".json");
+        this.readiness.configure(true, true, new DistributionLifecycleStateFile(stateFile, null), () -> false);
+        this.readiness.markFailed("Distribution lifecycle tracker is unavailable: lifecycle topic missing");
+
+        DistributionLifecycleReadiness.Snapshot snapshot = this.readiness.snapshot();
+
+        assertFalse(snapshot.ready());
+        assertEquals(DistributionLifecycleReadiness.State.FAILED, snapshot.state());
+        assertTrue(snapshot.reason().contains("unavailable"));
+    }
+
+    @Test
+    void snapshot_whenTrackerReadyAndStateAvailable_isReady() throws IOException {
+        Path stateFile = Files.createTempFile("scg-readiness-", ".json");
+        writeLifecycleStateFile(stateFile);
+        this.readiness.configure(true, true, new DistributionLifecycleStateFile(stateFile, null), () -> true);
+        this.readiness.markReady();
+
+        DistributionLifecycleReadiness.Snapshot snapshot = this.readiness.snapshot();
+
+        assertTrue(snapshot.ready());
+        assertEquals(DistributionLifecycleReadiness.State.READY, snapshot.state());
+    }
+
+    private static void writeLifecycleStateFile(Path stateFile) throws IOException {
+        Files.writeString(stateFile, """
+                {
+                  "application": "scg-test",
+                  "distributions": {
+                    "urn:distribution:one": "Active"
+                  }
+                }
+                """, StandardCharsets.UTF_8);
+    }
+}

--- a/scg-system/src/test/java/io/telicent/core/TestDistributionLifecycleReadinessServlet.java
+++ b/scg-system/src/test/java/io/telicent/core/TestDistributionLifecycleReadinessServlet.java
@@ -1,5 +1,6 @@
 package io.telicent.core;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.telicent.LibTestsSCG;
 import io.telicent.distribution.DistributionLifecycleStateFile;
 import io.telicent.smart.cache.configuration.Configurator;
@@ -20,6 +21,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
 
+import static io.telicent.backup.utils.JsonFileUtils.OBJECT_MAPPER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -42,10 +44,12 @@ class TestDistributionLifecycleReadinessServlet {
         startServer(new Properties());
 
         HttpResponse<String> response = getReady();
+        JsonNode body = OBJECT_MAPPER.readTree(response.body());
 
         assertEquals(200, response.statusCode());
-        assertTrue(response.body().contains("\"ready\" : true"));
-        assertTrue(response.body().contains("\"state\" : \"DISABLED\""));
+        assertTrue(body.get("healthy").booleanValue());
+        assertEquals("DISABLED", body.path("config").path("state").textValue());
+        assertEquals("Distribution lifecycle filtering is disabled.", body.path("reasons").get(0).textValue());
     }
 
     @Test
@@ -57,10 +61,11 @@ class TestDistributionLifecycleReadinessServlet {
         startServer(properties);
 
         HttpResponse<String> response = getReady();
+        JsonNode body = OBJECT_MAPPER.readTree(response.body());
 
         assertEquals(503, response.statusCode());
-        assertTrue(response.body().contains("\"state\" : \"EXTERNAL_ONLY\""));
-        assertTrue(response.body().contains("still unavailable"));
+        assertEquals("EXTERNAL_ONLY", body.path("config").path("state").textValue());
+        assertTrue(body.path("reasons").get(0).textValue().contains("still unavailable"));
     }
 
     @Test
@@ -81,10 +86,12 @@ class TestDistributionLifecycleReadinessServlet {
         startServer(properties);
 
         HttpResponse<String> response = getReady();
+        JsonNode body = OBJECT_MAPPER.readTree(response.body());
 
         assertEquals(200, response.statusCode());
-        assertTrue(response.body().contains("\"ready\" : true"));
-        assertTrue(response.body().contains("\"state\" : \"READY\""));
+        assertTrue(body.get("healthy").booleanValue());
+        assertEquals("READY", body.path("config").path("state").textValue());
+        assertEquals("Distribution lifecycle state is usable.", body.path("reasons").get(0).textValue());
     }
 
     private void startServer(Properties properties) throws IOException {

--- a/scg-system/src/test/java/io/telicent/core/TestDistributionLifecycleReadinessServlet.java
+++ b/scg-system/src/test/java/io/telicent/core/TestDistributionLifecycleReadinessServlet.java
@@ -1,0 +1,108 @@
+package io.telicent.core;
+
+import io.telicent.LibTestsSCG;
+import io.telicent.distribution.DistributionLifecycleStateFile;
+import io.telicent.smart.cache.configuration.Configurator;
+import io.telicent.smart.cache.configuration.sources.PropertiesSource;
+import io.telicent.smart.caches.configuration.auth.AuthConstants;
+import org.apache.jena.fuseki.main.FusekiServer;
+import org.apache.jena.http.HttpEnv;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TestDistributionLifecycleReadinessServlet {
+
+    private static final String DATASET_NAME = "/ds";
+    private FusekiServer server;
+
+    @AfterEach
+    void cleanup() {
+        DistributionLifecycleReadiness.getInstance().reset();
+        Configurator.reset();
+        if (server != null) {
+            server.stop();
+        }
+    }
+
+    @Test
+    void readinessEndpoint_whenFilteringDisabled_returns200() throws IOException, InterruptedException {
+        startServer(new Properties());
+
+        HttpResponse<String> response = getReady();
+
+        assertEquals(200, response.statusCode());
+        assertTrue(response.body().contains("\"ready\" : true"));
+        assertTrue(response.body().contains("\"state\" : \"DISABLED\""));
+    }
+
+    @Test
+    void readinessEndpoint_whenLifecycleStateUnavailable_returns503() throws IOException, InterruptedException {
+        Properties properties = new Properties();
+        properties.setProperty(FMod_DistributionLifecycle.ROUTE_TO_NAMED_GRAPHS, "true");
+        properties.setProperty(FMod_DistributionLifecycle.DISTRIBUTION_LIFECYCLE_STATE_FILE,
+                               "target/missing-readiness-state.json");
+        startServer(properties);
+
+        HttpResponse<String> response = getReady();
+
+        assertEquals(503, response.statusCode());
+        assertTrue(response.body().contains("\"state\" : \"EXTERNAL_ONLY\""));
+        assertTrue(response.body().contains("still unavailable"));
+    }
+
+    @Test
+    void readinessEndpoint_whenLifecycleStateAvailable_returns200() throws IOException, InterruptedException {
+        Path stateFile = Files.createTempFile("scg-readiness-servlet-", ".json");
+        Files.writeString(stateFile, """
+                {
+                  "application": "scg-test",
+                  "distributions": {
+                    "urn:distribution:one": "Active"
+                  }
+                }
+                """, StandardCharsets.UTF_8);
+
+        Properties properties = new Properties();
+        properties.setProperty(FMod_DistributionLifecycle.ROUTE_TO_NAMED_GRAPHS, "true");
+        properties.setProperty(FMod_DistributionLifecycle.DISTRIBUTION_LIFECYCLE_STATE_FILE, stateFile.toString());
+        startServer(properties);
+
+        HttpResponse<String> response = getReady();
+
+        assertEquals(200, response.statusCode());
+        assertTrue(response.body().contains("\"ready\" : true"));
+        assertTrue(response.body().contains("\"state\" : \"READY\""));
+    }
+
+    private void startServer(Properties properties) throws IOException {
+        properties.put(AuthConstants.ENV_JWKS_URL, AuthConstants.AUTH_DISABLED);
+        Configurator.setSingleSource(new PropertiesSource(properties));
+        LibTestsSCG.disableInitialCompaction();
+        server = SmartCacheGraph.serverBuilder()
+                                .port(0)
+                                .add(DATASET_NAME, DatasetGraphFactory.createTxnMem())
+                                .build()
+                                .start();
+    }
+
+    private HttpResponse<String> getReady() throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder()
+                                         .uri(URI.create(server.serverURL() + "$/ready"))
+                                         .GET()
+                                         .build();
+        return HttpEnv.getDftHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+    }
+}


### PR DESCRIPTION
 Also create specific /ready endpoint. 
 
 Note: I've switched the dev-ops helm readiness probe to using the /ready endpoint (we already use /ping for the  liveness probes). 