### PR TITLE
[CORE-1396] Add /version-info endpoint for liveness probes

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   maven-build:
-    uses: telicent-oss/shared-workflows/.github/workflows/maven.yml@main
+    uses: telicent-oss/shared-workflows/.github/workflows/maven.yml@sonarqube-to-mvn
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   maven-build:
-    uses: telicent-oss/shared-workflows/.github/workflows/maven.yml@sonarqube-to-mvn
+    uses: telicent-oss/shared-workflows/.github/workflows/maven.yml@main
     permissions:
       contents: write
       id-token: write

--- a/charts/graph/templates/statefulset.yaml
+++ b/charts/graph/templates/statefulset.yaml
@@ -157,7 +157,7 @@ spec:
           successThreshold: {{ .Values.readinessProbe.successThreshold }}
         livenessProbe:
           httpGet:
-            path: /$/ping
+            path: /version-info
             port: 3030
             scheme: HTTP
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
     <plugin.clean>3.3.2</plugin.clean>
     <plugin.compiler>3.15.0</plugin.compiler>
     <plugin.cyclonedx>2.9.3</plugin.cyclonedx>
+    <plugin.buildnumber>3.3.0</plugin.buildnumber>
     <plugin.dependency>3.11.0</plugin.dependency>
     <plugin.deploy>3.1.4</plugin.deploy>
     <plugin.enforcer>3.4.1</plugin.enforcer>
@@ -526,6 +527,32 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>buildnumber-maven-plugin</artifactId>
+          <version>${plugin.buildnumber}</version>
+          <executions>
+            <execution>
+              <phase>generate-resources</phase>
+              <goals>
+                <goal>create-metadata</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <doCheck>true</doCheck>
+            <doUpdate>true</doUpdate>
+            <outputName>${project.artifactId}.version</outputName>
+            <addOutputDirectoryToResources>true</addOutputDirectoryToResources>
+            <timestampFormat>yyyy-MM-dd HH:mm:ss</timestampFormat>
+            <properties>
+              <artifactId>${project.artifactId}</artifactId>
+              <groupId>${project.groupId}</groupId>
+              <buildEnv>${os.name} ${os.version} (${os.arch})</buildEnv>
+            </properties>
+          </configuration>
+        </plugin>
+
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${plugin.compiler}</version>
@@ -673,6 +700,12 @@
     </pluginManagement>
 
     <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>buildnumber-maven-plugin</artifactId>
+        <version>${plugin.buildnumber}</version>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -83,9 +83,13 @@
     <plugin.resources>3.5.0</plugin.resources>
     <plugin.shade>3.4.1</plugin.shade>
     <plugin.site>3.9.1</plugin.site>
+    <plugin.sonar>5.7.0.6970</plugin.sonar>
     <plugin.source>3.4.0</plugin.source>
     <plugin.surefire>3.5.6</plugin.surefire>
     <plugin.versions>2.21.0</plugin.versions>
+
+    <!-- SonarQube analysis, invoked from CI via mvn sonar:sonar -->
+    <sonar.projectKey>telicent-oss_smart-cache-graph</sonar.projectKey>
 
     <!-- Dependency versions -->
     <!-- Internal dependencies -->
@@ -666,6 +670,12 @@
           <configuration>
             <argLine>@{jacocoArgLine} -javaagent:${org.mockito:mockito-core:jar} -XX:+EnableDynamicAgentLoading -Xshare:off</argLine>
           </configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>org.sonarsource.scanner.maven</groupId>
+          <artifactId>sonar-maven-plugin</artifactId>
+          <version>${plugin.sonar}</version>
         </plugin>
 
         <plugin>

--- a/scg-benchmark/pom.xml
+++ b/scg-benchmark/pom.xml
@@ -14,6 +14,8 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        
+        <sonar.skip>true</sonar.skip>
     </properties>
 
     <dependencies>

--- a/scg-deletion-worker/pom.xml
+++ b/scg-deletion-worker/pom.xml
@@ -220,6 +220,13 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <skipPublishing>true</skipPublishing>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/scg-system/pom.xml
+++ b/scg-system/pom.xml
@@ -121,6 +121,11 @@
         </dependency>
         <dependency>
             <groupId>io.telicent.smart-caches</groupId>
+            <artifactId>observability-core</artifactId>
+            <version>${dependency.smart-caches-core}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.telicent.smart-caches</groupId>
             <artifactId>jwt-auth-common</artifactId>
         </dependency>
         <dependency>

--- a/scg-system/src/main/java/io/telicent/core/FMod_VersionInfo.java
+++ b/scg-system/src/main/java/io/telicent/core/FMod_VersionInfo.java
@@ -79,7 +79,7 @@ public class FMod_VersionInfo implements FusekiModule {
             }
 
             TreeSet<String> extras = new TreeSet<>(properties.stringPropertyNames());
-            extras.removeAll(STANDARD_FIELDS);
+            STANDARD_FIELDS.forEach(extras::remove);
             for (String key : extras) {
                 json.put(key, properties.getProperty(key));
             }

--- a/scg-system/src/main/java/io/telicent/core/FMod_VersionInfo.java
+++ b/scg-system/src/main/java/io/telicent/core/FMod_VersionInfo.java
@@ -1,0 +1,97 @@
+package io.telicent.core;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.telicent.smart.cache.observability.LibraryVersion;
+import io.telicent.utils.ServletUtils;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.jena.atlas.lib.Version;
+import org.apache.jena.atlas.logging.FmtLog;
+import org.apache.jena.fuseki.Fuseki;
+import org.apache.jena.fuseki.main.FusekiServer;
+import org.apache.jena.fuseki.main.sys.FusekiModule;
+import org.apache.jena.rdf.model.Model;
+
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static io.telicent.backup.utils.JsonFileUtils.OBJECT_MAPPER;
+
+public class FMod_VersionInfo implements FusekiModule {
+
+    private static final String VERSION = Version.versionForClass(FMod_VersionInfo.class).orElse("<development>");
+    private static final List<String> VERSION_LIBRARIES = List.of(
+            "scg-system",
+            "configurator",
+            "distribution-lifecycle",
+            "jwt-auth-common",
+            "event-source-file",
+            "event-source-kafka",
+            "event-sources-core",
+            "observability-core",
+            "projector-driver",
+            "projectors-core",
+            "data-security-core",
+            "common",
+            "rocksdb",
+            "label-store-rocksdb"
+    );
+
+    @Override
+    public String name() {
+        return "Version Info";
+    }
+
+    @Override
+    public void prepare(FusekiServer.Builder serverBuilder, Set<String> datasetNames, Model configModel) {
+        FmtLog.info(Fuseki.configLog, "Telicent Version Info Module (%s)", VERSION);
+        serverBuilder.addServlet("/version-info", new VersionInfoServlet());
+    }
+
+    static final class VersionInfoServlet extends HttpServlet {
+
+        private static final List<String> STANDARD_FIELDS =
+                List.of("buildEnv", "groupId", "name", "artifactId", "version", "revision", "timestamp");
+
+        @Override
+        protected void doGet(HttpServletRequest request, HttpServletResponse response) {
+            ObjectNode json = OBJECT_MAPPER.createObjectNode();
+            for (String library : VERSION_LIBRARIES) {
+                Properties properties = LibraryVersion.getProperties(library);
+                if (properties.isEmpty()) {
+                    continue;
+                }
+                json.set(library, toJson(properties));
+            }
+
+            response.setStatus(HttpServletResponse.SC_OK);
+            ServletUtils.processResponse(response, json);
+        }
+
+        private static ObjectNode toJson(Properties properties) {
+            ObjectNode json = OBJECT_MAPPER.createObjectNode();
+
+            for (String key : STANDARD_FIELDS) {
+                putIfPresent(json, properties, key);
+            }
+
+            TreeSet<String> extras = new TreeSet<>(properties.stringPropertyNames());
+            extras.removeAll(STANDARD_FIELDS);
+            for (String key : extras) {
+                json.put(key, properties.getProperty(key));
+            }
+
+            return json;
+        }
+
+        private static void putIfPresent(ObjectNode json, Properties properties, String key) {
+            String value = properties.getProperty(key);
+            if (value != null) {
+                json.put(key, value);
+            }
+        }
+    }
+}

--- a/scg-system/src/main/java/io/telicent/core/SmartCacheGraph.java
+++ b/scg-system/src/main/java/io/telicent/core/SmartCacheGraph.java
@@ -128,6 +128,7 @@ public class SmartCacheGraph {
                 new FMod_JwtServletAuth()
                 , new FMod_OpenTelemetry()
                 , new FMod_MemoryInfo()
+                , new FMod_VersionInfo()
                 , new FMod_TelicentGraphQL()
                 , new FMod_RequestIDFilter()
                 , new FMod_DatasetAvailabilityFilter()

--- a/scg-system/src/main/java/io/telicent/core/auth/FMod_JwtServletAuth.java
+++ b/scg-system/src/main/java/io/telicent/core/auth/FMod_JwtServletAuth.java
@@ -64,7 +64,7 @@ public class FMod_JwtServletAuth implements FusekiModule {
         // should we enable these features in future
         serverBuilder.setServletAttribute(JwtServletConstants.ATTRIBUTE_PATH_EXCLUSIONS,
                                           PathExclusion.parsePathPatterns(
-                                                  "/$/ping,/$/ready,/$/metrics,/$/stats/*"));
+                                                  "/$/ping,/$/ready,/version-info,/$/metrics,/$/stats/*"));
 
         // Register the filter
         serverBuilder.addFilter("/*", new FusekiJwtAuthFilter());

--- a/scg-system/src/test/java/io/telicent/TestJwtServletAuth.java
+++ b/scg-system/src/test/java/io/telicent/TestJwtServletAuth.java
@@ -3,6 +3,7 @@ package io.telicent;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.telicent.core.FMod_InitialCompaction;
+import io.telicent.core.FMod_VersionInfo;
 import io.telicent.core.auth.FMod_JwtServletAuth;
 import io.telicent.core.SmartCacheGraph;
 import io.telicent.jena.abac.core.Attributes;
@@ -99,6 +100,7 @@ public class TestJwtServletAuth {
         List<PathExclusion> expectedList = List.of(
                 new PathExclusion("/$/ping"),
                 new PathExclusion("/$/ready"),
+                new PathExclusion("/version-info"),
                 new PathExclusion("/$/metrics"),
                 new PathExclusion("/$/stats/*")
         );
@@ -118,8 +120,9 @@ public class TestJwtServletAuth {
     public void test_exclusionLogic() {
         FMod_JwtServletAuth jwtServletAuth = new FMod_JwtServletAuth();
         FMod_InitialCompaction initialCompaction = new FMod_InitialCompaction ();
+        FMod_VersionInfo versionInfo = new FMod_VersionInfo();
         Attributes.buildStore(emptyGraph);
-        FusekiServer server = FusekiMain.builder(FusekiModules.create(jwtServletAuth, initialCompaction), "--port=0", "--empty")
+        FusekiServer server = FusekiMain.builder(FusekiModules.create(jwtServletAuth, initialCompaction, versionInfo), "--port=0", "--empty")
                 .setServletAttribute(ATTRIBUTE_JWT_VERIFIER, new TestJwtVerifier())
                 .enablePing(true)
                 .enableMetrics(true)
@@ -133,6 +136,10 @@ public class TestJwtServletAuth {
         // Correct path
         HttpResponse<InputStream> metricsResponse = makePOSTCallWithPath(server, "$/metrics");
         assertEquals(200, metricsResponse.statusCode());
+
+        // Correct path
+        HttpResponse<InputStream> versionInfoResponse = makeGETCallWithPath(server, "version-info");
+        assertEquals(200, versionInfoResponse.statusCode());
 
         // Fails - due to missing path but NOT due to Auth.
         HttpResponse<InputStream> statsResponse = makePOSTCallWithPath(server, "$/stats/unrecognised");
@@ -176,6 +183,15 @@ public class TestJwtServletAuth {
                         .method(METHOD_POST, HttpRequest.BodyPublishers.noBody());
         return execute(HttpEnv.getDftHttpClient(), builder.build());
     }
+
+    public static HttpResponse<InputStream> makeGETCallWithPath(FusekiServer server, String path) {
+        HttpRequest.Builder builder =
+                HttpLib.requestBuilderFor(server.serverURL())
+                        .uri(toRequestURI(server.serverURL() + path))
+                        .GET();
+        return execute(HttpEnv.getDftHttpClient(), builder.build());
+    }
+
     public static HttpResponse<InputStream> makeAuthPOSTCallWithPath(FusekiServer server, String path, String user) {
         return makeAuthCallWithPathForMethod(server, path, user, METHOD_POST);
     }

--- a/scg-system/src/test/java/io/telicent/core/TestVersionInfoServlet.java
+++ b/scg-system/src/test/java/io/telicent/core/TestVersionInfoServlet.java
@@ -55,7 +55,7 @@ class TestVersionInfoServlet {
         assertFalse(scgSystem.path("buildEnv").textValue().isBlank());
     }
 
-    private void startServer() throws IOException {
+    private void startServer() {
         Properties properties = new Properties();
         properties.put(AuthConstants.ENV_JWKS_URL, AuthConstants.AUTH_DISABLED);
         Configurator.setSingleSource(new PropertiesSource(properties));

--- a/scg-system/src/test/java/io/telicent/core/TestVersionInfoServlet.java
+++ b/scg-system/src/test/java/io/telicent/core/TestVersionInfoServlet.java
@@ -1,0 +1,77 @@
+package io.telicent.core;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.telicent.LibTestsSCG;
+import io.telicent.smart.cache.configuration.Configurator;
+import io.telicent.smart.cache.configuration.sources.PropertiesSource;
+import io.telicent.smart.caches.configuration.auth.AuthConstants;
+import org.apache.jena.fuseki.main.FusekiServer;
+import org.apache.jena.http.HttpEnv;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Properties;
+
+import static io.telicent.backup.utils.JsonFileUtils.OBJECT_MAPPER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TestVersionInfoServlet {
+
+    private static final String DATASET_NAME = "/ds";
+    private FusekiServer server;
+
+    @AfterEach
+    void cleanup() {
+        Configurator.reset();
+        if (server != null) {
+            server.stop();
+        }
+    }
+
+    @Test
+    void versionInfoEndpoint_whenServerRunning_returnsVersionInformation() throws IOException, InterruptedException {
+        startServer();
+
+        HttpResponse<String> response = getVersionInfo();
+        JsonNode body = OBJECT_MAPPER.readTree(response.body());
+        JsonNode scgSystem = body.path("scg-system");
+
+        assertEquals(200, response.statusCode());
+        assertTrue(body.has("scg-system"));
+        assertFalse(body.has("scg-server"));
+        assertEquals("scg-system", scgSystem.path("artifactId").textValue());
+        assertEquals("io.telicent.smart-caches.graph", scgSystem.path("groupId").textValue());
+        assertEquals("Telicent Smart Cache Graph - System", scgSystem.path("name").textValue());
+        assertFalse(scgSystem.path("version").textValue().isBlank());
+        assertFalse(scgSystem.path("revision").textValue().isBlank());
+        assertFalse(scgSystem.path("timestamp").textValue().isBlank());
+        assertFalse(scgSystem.path("buildEnv").textValue().isBlank());
+    }
+
+    private void startServer() throws IOException {
+        Properties properties = new Properties();
+        properties.put(AuthConstants.ENV_JWKS_URL, AuthConstants.AUTH_DISABLED);
+        Configurator.setSingleSource(new PropertiesSource(properties));
+        LibTestsSCG.disableInitialCompaction();
+        server = SmartCacheGraph.serverBuilder()
+                                .port(0)
+                                .add(DATASET_NAME, DatasetGraphFactory.createTxnMem())
+                                .build()
+                                .start();
+    }
+
+    private HttpResponse<String> getVersionInfo() throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder()
+                                         .uri(URI.create(server.serverURL() + "version-info"))
+                                         .GET()
+                                         .build();
+        return HttpEnv.getDftHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+    }
+}

--- a/scg-system/src/test/java/io/telicent/core/auth/TestServletAuthorizationEngine.java
+++ b/scg-system/src/test/java/io/telicent/core/auth/TestServletAuthorizationEngine.java
@@ -113,9 +113,10 @@ public class TestServletAuthorizationEngine {
     private static Stream<Arguments> otherPaths() {
         //@formatter:off
         return Stream.of(
-                // The /$/ping endpoint has no policy, this is because in normal use it's excluded from Authentication
+                // Health/version endpoints have no policy because in normal use they're excluded from Authentication
                 // so AuthZ would never apply anyway
                 Arguments.of("/$/ping", null),
+                Arguments.of("/version-info", null),
                 // Some random unrecognised paths
                 Arguments.of(null, "/no-such-path"),
                 Arguments.of(null, "/deeply/nested/path/to/nothing.txt"),


### PR DESCRIPTION
**Notes**
1. It's not /$/version-info ..... which means it doesn't fall into line with the other Fuseki endpoints.... but does follow the pattern of SC Search & SC Docs by being /version-info 
2. We no longer need /$/ping but couldn't bring myself to just rip it out. A ticket for the future = )