### PR TITLE
CORE-1461: fix for encrypted backups not being counted

### DIFF
--- a/scg-system/src/main/java/io/telicent/backup/services/DatasetBackupService.java
+++ b/scg-system/src/main/java/io/telicent/backup/services/DatasetBackupService.java
@@ -691,13 +691,17 @@ public class DatasetBackupService {
         response.put("delete-id", deleteID);
         response.put("date", DateTimeUtils.nowAsString(DATE_FORMAT));
         response.put("deletePath", deletePath);
-        if (!checkPathExistsAndIsDir(deletePath) && !checkPathExistsAndIsFile(deletePath + JSON_INFO_SUFFIX) && !checkPathExistsAndIsFile(deletePath + ZIP_SUFFIX)) {
+        if (!checkPathExistsAndIsDir(deletePath) &&
+                !checkPathExistsAndIsFile(deletePath + JSON_INFO_SUFFIX) &&
+                !checkPathExistsAndIsFile(deletePath + ZIP_SUFFIX) &&
+                !checkPathExistsAndIsFile(deletePath + ZIP_SUFFIX + ENCRYPTION_SUFFIX)) {
             response.put("reason", "Backup path unsuitable: " + deletePath);
             response.put("success", false);
         } else {
             executeDeleteBackup(deletePath);
             executeDeleteBackup(deletePath + JSON_INFO_SUFFIX);
             executeDeleteBackup(deletePath + ZIP_SUFFIX);
+            executeDeleteBackup(deletePath + ZIP_SUFFIX + ENCRYPTION_SUFFIX);
             deleteFilesRegEx(getBackUpDir(), deleteID + WILDCARD_REPORT_SUFFIX);
             response.put("success", true);
         }

--- a/scg-system/src/main/java/io/telicent/backup/utils/BackupUtils.java
+++ b/scg-system/src/main/java/io/telicent/backup/utils/BackupUtils.java
@@ -52,7 +52,7 @@ public class BackupUtils extends ServletUtils {
 
     public static final Logger LOG = LoggerFactory.getLogger(BackupUtils.class);
 
-    private static final Pattern NUMBERED_ITEM_PATTERN = Pattern.compile("^(\\d+)(\\.zip)?$");
+    private static final Pattern NUMBERED_ITEM_PATTERN = Pattern.compile("^(\\d+)(\\.zip(\\.enc)?)?$");
 
     /**
      * Configuration parameter for determining location of backups (if unset defaults to PWD/backups)

--- a/scg-system/src/test/java/io/telicent/backup/services/TestDatasetBackupService.java
+++ b/scg-system/src/test/java/io/telicent/backup/services/TestDatasetBackupService.java
@@ -123,9 +123,50 @@ public class TestDatasetBackupService {
         ObjectNode result = cut.deleteBackup(existingID);
 
         // then
-        assertEquals(3, DatasetBackupService_Test.getCallCount(DELETE_BACKUP_DIR));
+        assertEquals(4, DatasetBackupService_Test.getCallCount(DELETE_BACKUP_DIR));
         assertTrue(result.has("success"));
         assertTrue(result.get("success").asBoolean());
+    }
+
+    @Test
+    @DisplayName("Delete backup recognises and removes an encryption-only (.zip.enc) backup")
+    public void test_delete_encryptedOnlyBackup() throws IOException {
+        // given - a completed encrypted backup can survive as nothing but <id>.zip.enc
+        final DataSecurityPlugin mockPlugin = mock(DataSecurityPlugin.class);
+        final DatasetBackupService realService = new DatasetBackupService(mockRegistry, mockPlugin);
+        final String id = "31";
+        final Path encFile = baseDir.resolve(id + ".zip.enc");
+        Files.createFile(encFile);
+
+        // when
+        final ObjectNode result = realService.deleteBackup(id);
+
+        // then - it must be treated as a valid backup and the encrypted file physically removed
+        assertTrue(result.has("success"));
+        assertTrue(result.get("success").asBoolean());
+        assertFalse(Files.exists(encFile), "Encrypted backup file should have been deleted");
+    }
+
+    @Test
+    @DisplayName("Delete backup removes the encrypted artifact of a full encrypted backup")
+    public void test_delete_fullEncryptedBackup_removesEncFile() throws IOException {
+        // given - a full encrypted backup on disk: <id>.zip.enc plus its metadata <id>_info.json
+        final DataSecurityPlugin mockPlugin = mock(DataSecurityPlugin.class);
+        final DatasetBackupService realService = new DatasetBackupService(mockRegistry, mockPlugin);
+        final String id = "31";
+        final Path encFile = baseDir.resolve(id + ".zip.enc");
+        final Path infoFile = baseDir.resolve(id + "_info.json");
+        Files.createFile(encFile);
+        Files.createFile(infoFile);
+
+        // when
+        final ObjectNode result = realService.deleteBackup(id);
+
+        // then - the encrypted artifact must not be left behind (previously it was leaked)
+        assertTrue(result.has("success"));
+        assertTrue(result.get("success").asBoolean());
+        assertFalse(Files.exists(encFile), "Encrypted backup file should have been deleted");
+        assertFalse(Files.exists(infoFile), "Backup metadata file should have been deleted");
     }
 
     /*

--- a/scg-system/src/test/java/io/telicent/backup/utils/TestBackupUtils.java
+++ b/scg-system/src/test/java/io/telicent/backup/utils/TestBackupUtils.java
@@ -445,6 +445,36 @@ public class TestBackupUtils {
     }
 
     @Test
+    @DisplayName("getHighestDirectoryNumber counts encrypted (.zip.enc) backup artifacts")
+    public void test_getHighestDirectoryNumber_countsEncryptedArtifact() throws IOException {
+        // given - a completed encrypted backup leaves only <id>.zip.enc (+ <id>_info.json) behind:
+        // the source directory and the intermediate .zip are both deleted during encryption.
+        final Path parentDir = Files.createDirectory(tempDir.resolve("highest_encrypted"));
+        Files.createFile(parentDir.resolve("31.zip.enc"));
+        Files.createFile(parentDir.resolve("31_info.json"));
+        // when
+        final int highest = getHighestDirectoryNumber(parentDir.toAbsolutePath().toString());
+        // then - the encrypted artifact must be recognised so it is not overwritten
+        assertEquals(31, highest);
+    }
+
+    @Test
+    @DisplayName("getNextDirectoryNumberAndCreate does not reuse an ID whose backup exists only as .zip.enc")
+    public void test_getNextDirectoryNumberAndCreate_doesNotReuseEncryptedId() throws IOException {
+        // given - reproduces the backup-id 31 collision: the previous encrypted backup survives
+        // only as 31.zip.enc, which the numbering logic previously failed to see.
+        final Path parentDir = Files.createDirectory(tempDir.resolve("next_encrypted"));
+        Files.createFile(parentDir.resolve("31.zip.enc"));
+        Files.createFile(parentDir.resolve("31_info.json"));
+        // when
+        final int nextNum = getNextDirectoryNumberAndCreate(parentDir.toAbsolutePath().toString());
+        // then - the next backup gets a fresh ID rather than clobbering 31.zip.enc
+        assertEquals(32, nextNum);
+        assertTrue(Files.isDirectory(parentDir.resolve("32")));
+        assertTrue(Files.exists(parentDir.resolve("31.zip.enc")));
+    }
+
+    @Test
     @DisplayName("Tests getNextDirectoryNumberAndCreate with a null path")
     public void test_getNextDirectoryNumberAndCreate_nullPath() {
         // given


### PR DESCRIPTION
Fix for duplicate backup ID issue reported by @EmilyJKohler.

When encryption is enabled a backup survives on disk only as `<id>.zip.enc`, which the numbering and delete logic didn't recognise. As a result the next backup reused the same ID and overwrote the previous encrypted file, and `deleteBackup` left `.zip.enc` files behind.

- Match `.zip.enc` in the backup-ID numbering.
- Recognise and delete `.zip.enc` in `deleteBackup`.
- Add regression tests for create (no ID reuse) and delete (encrypted file removed).